### PR TITLE
fix: change TUI pause keybinding from 'p' to 'P'

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Taskdog includes a full-screen terminal user interface (TUI) for managing tasks 
 **Keyboard Shortcuts:**
 - `a` - Add new task
 - `s` - Start selected task
-- `p` - Pause selected task
+- `P` - Pause selected task
 - `d` - Complete (done) selected task
 - `c` - Cancel selected task
 - `R` - Reopen task

--- a/src/presentation/tui/app.py
+++ b/src/presentation/tui/app.py
@@ -61,7 +61,7 @@ class TaskdogTUI(App):
         ("q", "quit", "Quit"),
         ("a", "add_task", "Add"),
         ("s", "start_task", "Start"),
-        ("p", "pause_task", "Pause"),
+        ("P", "pause_task", "Pause"),
         ("d", "done_task", "Done"),
         ("c", "cancel_task", "Cancel"),
         ("R", "reopen_task", "Reopen"),


### PR DESCRIPTION
## Summary
- Changed TUI pause keybinding from lowercase `p` to uppercase `P` (Shift+p)
- Updated README.md documentation to reflect the change

## Motivation
Accidentally pressing `p` instead of Ctrl+p was causing unintended task pauses in the TUI (issue #165). By changing to uppercase `P`, this requires a deliberate Shift+p keystroke, preventing accidental pauses.

## Changes
- `src/presentation/tui/app.py`: Changed keybinding from `("p", "pause_task", "Pause")` to `("P", "pause_task", "Pause")`
- `README.md`: Updated keyboard shortcuts documentation

## Pattern Consistency
This follows the existing pattern in the codebase where important/destructive actions use uppercase keys:
- `R` - Reopen task
- `X` - Hard delete task

## Test plan
- [x] Start TUI with `taskdog tui`
- [x] Verify lowercase `p` no longer pauses tasks
- [x] Verify uppercase `P` (Shift+p) pauses tasks correctly
- [x] Verify footer displays updated keybinding
- [x] All pre-commit hooks pass (ruff, mypy, tests)

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)