### PR TITLE
feat: add toggle for completed/canceled tasks in TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Taskdog includes a full-screen terminal user interface (TUI) for managing tasks 
 - `i` - Show task details
 - `e` - Edit task
 - `v` - Edit task note
+- `t` - Toggle visibility of completed/canceled tasks
 - `o` - Run optimizer
 - `r` - Refresh task list
 - `S` - Sort selection dialog (deadline/planned_start/priority/estimated_duration/id)

--- a/src/application/queries/filters/incomplete_or_active_filter.py
+++ b/src/application/queries/filters/incomplete_or_active_filter.py
@@ -1,0 +1,25 @@
+"""Filter for incomplete or active tasks."""
+
+from application.queries.filters.task_filter import TaskFilter
+from domain.entities.task import Task, TaskStatus
+
+
+class IncompleteOrActiveFilter(TaskFilter):
+    """Filter tasks that are incomplete or active.
+
+    Returns tasks with status != COMPLETED and status != CANCELED.
+    Excludes finished tasks (completed/canceled) from the result set.
+    """
+
+    def filter(self, tasks: list[Task]) -> list[Task]:
+        """Filter incomplete or active tasks.
+
+        Args:
+            tasks: List of all tasks
+
+        Returns:
+            List of tasks that are not completed or canceled
+        """
+        return [
+            task for task in tasks if task.status not in (TaskStatus.COMPLETED, TaskStatus.CANCELED)
+        ]


### PR DESCRIPTION
## Summary

Implements issue #168 by adding a keyboard shortcut to toggle visibility of completed and canceled tasks in the TUI.

- Press `t` key to hide/show completed and canceled tasks
- Works in both gantt chart and task table views
- Shows notification when toggling ("Completed tasks hidden" / "Completed tasks shown")
- Default behavior: show all tasks

## Changes

- **New filter**: `IncompleteOrActiveFilter` to exclude COMPLETED/CANCELED tasks
- **State management**: Added `_hide_completed` boolean to `TaskdogTUI`
- **Filtering logic**: Modified `_load_tasks()` to apply conditional filtering
- **Action handler**: Added `action_toggle_completed()` method
- **Keybinding**: Bound `t` key to toggle action
- **Documentation**: Updated README with new keybinding

## Test Plan

- [x] Type checking passes (mypy)
- [x] Unit tests pass
- [x] Filter logic tested programmatically (19 PENDING tasks shown when hiding 3 COMPLETED + 1 CANCELED)
- [x] Manual TUI testing:
  - [x] Press `t` to hide completed/canceled tasks
  - [ ] Press `t` again to show all tasks
  - [ ] Verify notification messages appear
  - [ ] Verify both gantt and table update correctly

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)