### PR TITLE
fix: clear daily_allocations when manually scheduling tasks (#171)

### DIFF
--- a/src/application/use_cases/update_task.py
+++ b/src/application/use_cases/update_task.py
@@ -78,6 +78,14 @@ class UpdateTaskUseCase(UseCase[UpdateTaskRequest, tuple[Task, list[str]]]):
                 setattr(task, field_name, value)
                 updated_fields.append(field_name)
 
+        # Clear daily_allocations when manually setting planned schedule
+        # This ensures manual scheduling takes precedence over optimizer-generated allocations
+        if (
+            "planned_start" in updated_fields or "planned_end" in updated_fields
+        ) and task.daily_allocations:
+            task.daily_allocations = {}
+            updated_fields.append("daily_allocations")
+
     def execute(self, input_dto: UpdateTaskRequest) -> tuple[Task, list[str]]:
         """Execute task update.
 


### PR DESCRIPTION
## Summary

Fixes #171

When a task is optimized (daily_allocations set) and then manually scheduled via `schedule` or `update` command, daily_allocations are now automatically cleared. This ensures manual scheduling takes precedence over optimizer-generated allocations and resolves inconsistency in gantt chart display.

## Changes

- **Modified `UpdateTaskUseCase._update_standard_fields()`** to automatically clear `daily_allocations` when `planned_start` or `planned_end` are updated
- **Added 4 comprehensive test cases** to verify the clearing behavior:
  - Test clearing when updating `planned_start`
  - Test clearing when updating `planned_end`
  - Test clearing when updating both dates simultaneously
  - Test that empty `daily_allocations` doesn't trigger unnecessary updates

## Test Plan

✅ All existing tests pass (615 tests)
✅ New test cases verify the fix works correctly
✅ Manual testing confirmed:
1. Created task with deadline and estimate
2. Ran `optimize` to generate daily_allocations
3. Ran `schedule` to manually set planned_start/end
4. Verified daily_allocations are cleared
5. Verified gantt chart displays correctly with manual schedule

## Root Cause

`WorkloadCalculator.get_task_daily_hours()` prioritizes `daily_allocations` over `planned_start/end` range. When both exist, it uses `daily_allocations`, causing the gantt chart to display optimizer-generated schedule instead of the manually set schedule.

This fix ensures that manual scheduling always clears optimizer-generated allocations, maintaining consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)