### PR TITLE
refactor(tui): remove redundant validator wrapper classes

### DIFF
--- a/src/presentation/tui/formatters/task_table_formatter.py
+++ b/src/presentation/tui/formatters/task_table_formatter.py
@@ -48,6 +48,26 @@ class TaskTableFormatter:
         return ",".join(str(dep_id) for dep_id in task.depends_on)
 
     @staticmethod
+    def _format_datetime(dt: datetime | None) -> str:
+        """Format datetime for display with year-aware formatting.
+
+        Shows MM-DD HH:MM for current year, 'YY MM-DD HH:MM otherwise.
+
+        Args:
+            dt: Datetime to format, or None
+
+        Returns:
+            Formatted string, or "-" if dt is None
+        """
+        if not dt:
+            return "-"
+
+        current_year = datetime.now().year
+        if dt.year == current_year:
+            return dt.strftime("%m-%d %H:%M")
+        return dt.strftime("'%y %m-%d %H:%M")
+
+    @staticmethod
     def format_deadline(deadline: datetime | None) -> str:
         """Format deadline for display.
 
@@ -57,17 +77,7 @@ class TaskTableFormatter:
         Returns:
             Formatted deadline string
         """
-        if not deadline:
-            return "-"
-
-        # Show year only if different from current year
-        current_year = datetime.now().year
-        if deadline.year == current_year:
-            # Current year: MM-DD HH:MM
-            return deadline.strftime("%m-%d %H:%M")
-        else:
-            # Different year: 'YY MM-DD HH:MM
-            return deadline.strftime("'%y %m-%d %H:%M")
+        return TaskTableFormatter._format_datetime(deadline)
 
     @staticmethod
     def format_estimated_duration(task: Task) -> str:
@@ -107,17 +117,7 @@ class TaskTableFormatter:
         Returns:
             Formatted planned start string
         """
-        if not planned_start:
-            return "-"
-
-        # Show year only if different from current year
-        current_year = datetime.now().year
-        if planned_start.year == current_year:
-            # Current year: MM-DD HH:MM
-            return planned_start.strftime("%m-%d %H:%M")
-        else:
-            # Different year: 'YY MM-DD HH:MM
-            return planned_start.strftime("'%y %m-%d %H:%M")
+        return TaskTableFormatter._format_datetime(planned_start)
 
     @staticmethod
     def format_planned_end(planned_end: datetime | None) -> str:
@@ -129,17 +129,7 @@ class TaskTableFormatter:
         Returns:
             Formatted planned end string
         """
-        if not planned_end:
-            return "-"
-
-        # Show year only if different from current year
-        current_year = datetime.now().year
-        if planned_end.year == current_year:
-            # Current year: MM-DD HH:MM
-            return planned_end.strftime("%m-%d %H:%M")
-        else:
-            # Different year: 'YY MM-DD HH:MM
-            return planned_end.strftime("'%y %m-%d %H:%M")
+        return TaskTableFormatter._format_datetime(planned_end)
 
     @staticmethod
     def format_actual_start(actual_start: datetime | None) -> str:
@@ -151,17 +141,7 @@ class TaskTableFormatter:
         Returns:
             Formatted actual start string
         """
-        if not actual_start:
-            return "-"
-
-        # Show year only if different from current year
-        current_year = datetime.now().year
-        if actual_start.year == current_year:
-            # Current year: MM-DD HH:MM
-            return actual_start.strftime("%m-%d %H:%M")
-        else:
-            # Different year: 'YY MM-DD HH:MM
-            return actual_start.strftime("'%y %m-%d %H:%M")
+        return TaskTableFormatter._format_datetime(actual_start)
 
     @staticmethod
     def format_actual_end(actual_end: datetime | None) -> str:
@@ -173,17 +153,7 @@ class TaskTableFormatter:
         Returns:
             Formatted actual end string
         """
-        if not actual_end:
-            return "-"
-
-        # Show year only if different from current year
-        current_year = datetime.now().year
-        if actual_end.year == current_year:
-            # Current year: MM-DD HH:MM
-            return actual_end.strftime("%m-%d %H:%M")
-        else:
-            # Different year: 'YY MM-DD HH:MM
-            return actual_end.strftime("'%y %m-%d %H:%M")
+        return TaskTableFormatter._format_datetime(actual_end)
 
     @staticmethod
     def format_elapsed_time(task: Task) -> str:

--- a/src/presentation/tui/forms/validators.py
+++ b/src/presentation/tui/forms/validators.py
@@ -161,57 +161,6 @@ class DateTimeValidatorTUI(BaseValidator):
             )
 
 
-class DeadlineValidator(BaseValidator):
-    """Validator for task deadlines."""
-
-    @staticmethod
-    def validate(value: str, default_hour: int) -> ValidationResult:
-        """Validate a task deadline.
-
-        Args:
-            value: Deadline string to validate (can be empty for no deadline)
-            default_hour: Default hour to use when only date is provided (from config)
-
-        Returns:
-            ValidationResult with validation status, error message, and formatted deadline
-        """
-        return DateTimeValidatorTUI.validate(value, "deadline", default_hour=default_hour)
-
-
-class PlannedStartValidator(BaseValidator):
-    """Validator for planned start date."""
-
-    @staticmethod
-    def validate(value: str, default_hour: int) -> ValidationResult:
-        """Validate a planned start date.
-
-        Args:
-            value: Planned start string to validate (can be empty)
-            default_hour: Default hour to use when only date is provided (from config)
-
-        Returns:
-            ValidationResult with validation status, error message, and formatted date
-        """
-        return DateTimeValidatorTUI.validate(value, "planned start", default_hour=default_hour)
-
-
-class PlannedEndValidator(BaseValidator):
-    """Validator for planned end date."""
-
-    @staticmethod
-    def validate(value: str, default_hour: int) -> ValidationResult:
-        """Validate a planned end date.
-
-        Args:
-            value: Planned end string to validate (can be empty)
-            default_hour: Default hour to use when only date is provided (from config)
-
-        Returns:
-            ValidationResult with validation status, error message, and formatted date
-        """
-        return DateTimeValidatorTUI.validate(value, "planned end", default_hour=default_hour)
-
-
 class DurationValidator(BaseValidator):
     """Validator for estimated duration."""
 

--- a/src/presentation/tui/screens/task_form_dialog.py
+++ b/src/presentation/tui/screens/task_form_dialog.py
@@ -10,11 +10,9 @@ from textual.widgets import Checkbox, Input, Label, Static
 from domain.entities.task import Task
 from presentation.tui.forms.task_form_fields import TaskFormData, TaskFormFields
 from presentation.tui.forms.validators import (
-    DeadlineValidator,
+    DateTimeValidatorTUI,
     DependenciesValidator,
     DurationValidator,
-    PlannedEndValidator,
-    PlannedStartValidator,
     PriorityValidator,
     TagsValidator,
     TaskNameValidator,
@@ -111,10 +109,20 @@ class TaskFormDialog(BaseModalDialog[TaskFormData | None]):
         validations: list[tuple[str, Input, Any, list[Any]]] = [
             ("task_name", inputs["task_name"], TaskNameValidator, []),
             ("priority", inputs["priority"], PriorityValidator, [default_priority]),
-            ("deadline", inputs["deadline"], DeadlineValidator, [default_end_hour]),
+            ("deadline", inputs["deadline"], DateTimeValidatorTUI, ["deadline", default_end_hour]),
             ("duration", inputs["duration"], DurationValidator, []),
-            ("planned_start", inputs["planned_start"], PlannedStartValidator, [default_start_hour]),
-            ("planned_end", inputs["planned_end"], PlannedEndValidator, [default_end_hour]),
+            (
+                "planned_start",
+                inputs["planned_start"],
+                DateTimeValidatorTUI,
+                ["planned start", default_start_hour],
+            ),
+            (
+                "planned_end",
+                inputs["planned_end"],
+                DateTimeValidatorTUI,
+                ["planned end", default_end_hour],
+            ),
             ("dependencies", inputs["dependencies"], DependenciesValidator, []),
             ("tags", inputs["tags"], TagsValidator, []),
         ]

--- a/tests/presentation/tui/forms/test_datetime_validator.py
+++ b/tests/presentation/tui/forms/test_datetime_validator.py
@@ -1,13 +1,8 @@
-"""Tests for DateTimeValidatorTUI and related validators."""
+"""Tests for DateTimeValidatorTUI."""
 
 import unittest
 
-from presentation.tui.forms.validators import (
-    DateTimeValidatorTUI,
-    DeadlineValidator,
-    PlannedEndValidator,
-    PlannedStartValidator,
-)
+from presentation.tui.forms.validators import DateTimeValidatorTUI
 
 
 class TestDateTimeValidatorTUI(unittest.TestCase):
@@ -82,72 +77,6 @@ class TestDateTimeValidatorTUI(unittest.TestCase):
         self.assertTrue(result.is_valid)
         # Should preserve 00:00 because ":" was present
         self.assertIn("00:00:00", result.value)
-
-
-class TestDeadlineValidator(unittest.TestCase):
-    """Test cases for DeadlineValidator."""
-
-    def test_validate_date_only_uses_default_end_hour(self):
-        """Test that deadline without time uses default end hour (18)."""
-        result = DeadlineValidator.validate("10/22", 18)
-        self.assertTrue(result.is_valid)
-        self.assertIn("18:00:00", result.value)
-
-    def test_validate_with_custom_default_hour(self):
-        """Test that custom default hour is applied."""
-        result = DeadlineValidator.validate("10/22", 20)
-        self.assertTrue(result.is_valid)
-        self.assertIn("20:00:00", result.value)
-
-    def test_validate_with_time_preserves_time(self):
-        """Test that deadline with time preserves it."""
-        result = DeadlineValidator.validate("10/22 14:00", 18)
-        self.assertTrue(result.is_valid)
-        self.assertIn("14:00:00", result.value)
-
-
-class TestPlannedStartValidator(unittest.TestCase):
-    """Test cases for PlannedStartValidator."""
-
-    def test_validate_date_only_uses_default_start_hour(self):
-        """Test that planned start without time uses default start hour (9)."""
-        result = PlannedStartValidator.validate("10/22", 9)
-        self.assertTrue(result.is_valid)
-        self.assertIn("09:00:00", result.value)
-
-    def test_validate_with_custom_default_hour(self):
-        """Test that custom default hour is applied."""
-        result = PlannedStartValidator.validate("10/22", 8)
-        self.assertTrue(result.is_valid)
-        self.assertIn("08:00:00", result.value)
-
-    def test_validate_with_time_preserves_time(self):
-        """Test that planned start with time preserves it."""
-        result = PlannedStartValidator.validate("10/22 10:00", 9)
-        self.assertTrue(result.is_valid)
-        self.assertIn("10:00:00", result.value)
-
-
-class TestPlannedEndValidator(unittest.TestCase):
-    """Test cases for PlannedEndValidator."""
-
-    def test_validate_date_only_uses_default_end_hour(self):
-        """Test that planned end without time uses default end hour (18)."""
-        result = PlannedEndValidator.validate("10/22", 18)
-        self.assertTrue(result.is_valid)
-        self.assertIn("18:00:00", result.value)
-
-    def test_validate_with_custom_default_hour(self):
-        """Test that custom default hour is applied."""
-        result = PlannedEndValidator.validate("10/22", 17)
-        self.assertTrue(result.is_valid)
-        self.assertIn("17:00:00", result.value)
-
-    def test_validate_with_time_preserves_time(self):
-        """Test that planned end with time preserves it."""
-        result = PlannedEndValidator.validate("10/22 16:00", 18)
-        self.assertTrue(result.is_valid)
-        self.assertIn("16:00:00", result.value)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Removes three redundant validator wrapper classes (`DeadlineValidator`, `PlannedStartValidator`, `PlannedEndValidator`) that only delegated to `DateTimeValidatorTUI` without adding any value.

## Changes

- **validators.py**: Removed 3 wrapper classes (~50 lines)
- **task_form_dialog.py**: Updated to use `DateTimeValidatorTUI` directly
- **test_datetime_validator.py**: Removed tests for deleted wrapper classes

## Benefits

- Reduced code by ~50 lines
- Eliminated unnecessary indirection
- Maintained existing validation loop structure
- All tests passing (606 tests)

## Test Plan

- [x] Ran validator-specific tests
- [x] Ran full test suite (606 tests pass)
- [x] Type checking passes (mypy)

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)