### PR TITLE
refactor(tui): Phase 3A - Validation messages consolidation

### DIFF
--- a/packages/taskdog-ui/src/taskdog/constants/validation_messages.py
+++ b/packages/taskdog-ui/src/taskdog/constants/validation_messages.py
@@ -1,0 +1,64 @@
+"""Validation error message constants for TUI forms.
+
+Centralizes all validation error messages for:
+- Consistency across validators
+- Easy maintenance and updates
+- Future internationalization support
+"""
+
+
+class ValidationMessages:
+    """Validation error messages used across form validators."""
+
+    # Task name validation
+    TASK_NAME_REQUIRED = "Task name is required"
+
+    # Priority validation
+    PRIORITY_MUST_BE_NUMBER = "Priority must be a number"
+    PRIORITY_MUST_BE_POSITIVE = "Priority must be greater than 0"
+
+    # Duration validation
+    DURATION_MUST_BE_NUMBER = "Duration must be a number"
+    DURATION_MUST_BE_POSITIVE = "Duration must be greater than 0"
+    DURATION_MAX_EXCEEDED = "Duration must be 999 hours or less"
+
+    # Tag validation
+    TAG_CANNOT_BE_EMPTY = "Tag cannot be empty"
+    TAGS_MUST_BE_UNIQUE = "Tags must be unique"
+
+    @staticmethod
+    def invalid_date_format(field_name: str, examples: str) -> str:
+        """Generate invalid date format error message.
+
+        Args:
+            field_name: Name of the date field (e.g., "deadline", "planned start")
+            examples: Examples of valid formats
+
+        Returns:
+            Formatted error message
+        """
+        return f"Invalid {field_name} format. Examples: {examples}"
+
+    @staticmethod
+    def invalid_task_id(value: str) -> str:
+        """Generate invalid task ID error message.
+
+        Args:
+            value: The invalid task ID value
+
+        Returns:
+            Formatted error message
+        """
+        return f"Invalid task ID: '{value}'. Must be a number."
+
+    @staticmethod
+    def task_not_found(task_id: int) -> str:
+        """Generate task not found error message.
+
+        Args:
+            task_id: The task ID that was not found
+
+        Returns:
+            Formatted error message
+        """
+        return f"Task #{task_id} not found"

--- a/packages/taskdog-ui/tests/presentation/tui/forms/test_dependencies_validator.py
+++ b/packages/taskdog-ui/tests/presentation/tui/forms/test_dependencies_validator.py
@@ -68,14 +68,14 @@ class TestDependenciesValidator(unittest.TestCase):
         """Test validation fails with negative ID."""
         result = DependenciesValidator.validate("1,-2,3")
         self.assertFalse(result.is_valid)
-        self.assertIn("Task ID must be positive", result.error_message)
+        self.assertIn("Invalid task ID", result.error_message)
         self.assertIsNone(result.value)
 
     def test_validate_with_zero_id_returns_error(self):
         """Test validation fails with zero ID."""
         result = DependenciesValidator.validate("1,0,3")
         self.assertFalse(result.is_valid)
-        self.assertIn("Task ID must be positive", result.error_message)
+        self.assertIn("Invalid task ID", result.error_message)
         self.assertIsNone(result.value)
 
     def test_validate_with_float_returns_error(self):


### PR DESCRIPTION
## Summary
Completes Phase 3A quick wins by centralizing validation error messages into a dedicated constants module.

## Changes

### Centralize Validation Error Messages (a832cbe)
- **Problem**: 15+ validation error messages hardcoded across validators, making updates difficult and preventing future i18n
- **Solution**: Created `ValidationMessages` class in `constants/validation_messages.py`
  - String constants for common errors (task name, priority, duration, tags)
  - Helper methods for parameterized messages (`invalid_date_format()`, `invalid_task_id()`, `task_not_found()`)
- **Updated all validators**:
  - TaskNameValidator → `TASK_NAME_REQUIRED`
  - PriorityValidator → `PRIORITY_MUST_BE_NUMBER`, `PRIORITY_MUST_BE_POSITIVE`
  - DurationValidator → `DURATION_MUST_BE_NUMBER`, `DURATION_MUST_BE_POSITIVE`, `DURATION_MAX_EXCEEDED`
  - DateTimeValidator → `invalid_date_format()` method
  - DependenciesValidator → `invalid_task_id()` method
  - TagsValidator → `TAG_CANNOT_BE_EMPTY`, `TAGS_MUST_BE_UNIQUE`
- **Updated tests**: Adjusted assertions to match new error message format

## Benefits
- **Code Reduction**: ~15 lines of hardcoded strings eliminated
- **Single Source of Truth**: All validation messages in one place
- **Easier Maintenance**: Update messages in one location instead of across multiple validators
- **i18n Foundation**: Ready for future internationalization
- **Consistency**: Uniform error message style across all validators

## Testing
- ✅ All code quality checks pass (ruff lint + mypy)
- ✅ All existing unit tests pass (including updated tests)
- ✅ Manual testing of form validation

## Phase 3 Progress
- ✅ Phase 3A - Quick Wins (PR #216): Message display + formatter optimization
- ✅ Phase 3A - Validation messages (this PR): Error message consolidation
- 🔜 Phase 3A - Remaining: Date formatting + field checking
- 🔜 Phase 3B - Medium Effort: Delegate methods + builder pattern

Related: PR #216, PR #215 (Phase 2), PR #214 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)