### PR TITLE
refactor(ui): unify datetime formatting across the codebase

### DIFF
--- a/packages/taskdog-ui/src/taskdog/cli/commands/log_hours.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/log_hours.py
@@ -3,6 +3,7 @@
 import click
 
 from taskdog.cli.context import CliContext
+from taskdog.formatters.date_time_formatter import DateTimeFormatter
 from taskdog_core.domain.exceptions.task_exceptions import (
     TaskNotFoundException,
     TaskValidationError,
@@ -40,7 +41,7 @@ def log_hours_command(ctx, task_id, hours, date):
     if date is None:
         from datetime import datetime
 
-        date = datetime.now().strftime("%Y-%m-%d")
+        date = DateTimeFormatter.format_date_only(datetime.now())
 
     try:
         # Log hours via API client

--- a/packages/taskdog-ui/src/taskdog/cli/commands/report.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/report.py
@@ -13,6 +13,7 @@ from taskdog.cli.commands.common_options import (
 from taskdog.cli.commands.filter_helpers import build_task_filter
 from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_command_errors
+from taskdog.formatters.date_time_formatter import DateTimeFormatter
 from taskdog_core.application.queries.workload_calculator import WorkloadCalculator
 from taskdog_core.domain.entities.task import Task
 
@@ -154,7 +155,7 @@ def _generate_markdown_report(
 
     for task_date, task_hours_list in grouped_tasks.items():
         # Date header in Japanese format (YYYY/MM/DD)
-        lines.append(f"{task_date.strftime('%Y/%m/%d')}")
+        lines.append(f"{DateTimeFormatter.format_date_japanese(task_date)}")
 
         # Table header
         lines.append("|タスク|想定工数[h]|")

--- a/packages/taskdog-ui/src/taskdog/exporters/markdown_table_exporter.py
+++ b/packages/taskdog-ui/src/taskdog/exporters/markdown_table_exporter.py
@@ -4,6 +4,7 @@ from datetime import date, datetime
 from typing import Any
 
 from taskdog.exporters.task_exporter import TaskExporter
+from taskdog.formatters.date_time_formatter import DateTimeFormatter
 from taskdog_core.application.dto.task_dto import TaskRowDto
 
 # Default fields for Markdown table export when no specific fields are requested
@@ -82,11 +83,11 @@ class MarkdownTableExporter(TaskExporter):
 
         # Handle datetime objects
         if isinstance(value, datetime):
-            return value.strftime("%Y-%m-%d %H:%M:%S")
+            return DateTimeFormatter.format_datetime_for_export(value)
 
         # Handle date objects
         if isinstance(value, date):
-            return value.strftime("%Y-%m-%d")
+            return DateTimeFormatter.format_date_only(value)
 
         # Handle boolean (check before dict/list since bool is a subclass of int)
         if isinstance(value, bool):

--- a/packages/taskdog-ui/src/taskdog/formatters/date_time_formatter.py
+++ b/packages/taskdog-ui/src/taskdog/formatters/date_time_formatter.py
@@ -1,6 +1,8 @@
 """Date and time formatting utilities."""
 
-from datetime import datetime
+from datetime import date, datetime
+
+from taskdog_core.shared.constants.formats import DATETIME_FORMAT
 
 
 class DateTimeFormatter:
@@ -105,3 +107,113 @@ class DateTimeFormatter:
             True if year should be shown, False otherwise
         """
         return dt.year != datetime.now().year
+
+    @staticmethod
+    def format_created(created_at: datetime) -> str:
+        """Format created timestamp (always shows full datetime).
+
+        Args:
+            created_at: Created timestamp
+
+        Returns:
+            Formatted timestamp string (YYYY-MM-DD HH:MM:SS)
+        """
+        return created_at.strftime(DATETIME_FORMAT)
+
+    @staticmethod
+    def format_updated(updated_at: datetime) -> str:
+        """Format updated timestamp (always shows full datetime).
+
+        Args:
+            updated_at: Updated timestamp
+
+        Returns:
+            Formatted timestamp string (YYYY-MM-DD HH:MM:SS)
+        """
+        return updated_at.strftime(DATETIME_FORMAT)
+
+    @staticmethod
+    def format_current_timestamp() -> str:
+        """Format current timestamp for logging/notes.
+
+        Returns:
+            Current timestamp formatted as YYYY-MM-DD HH:MM:SS
+        """
+        return datetime.now().strftime(DATETIME_FORMAT)
+
+    @staticmethod
+    def format_date_only(dt: datetime | date | None) -> str:
+        """Format as date only (YYYY-MM-DD).
+
+        Args:
+            dt: Datetime or date to format, or None
+
+        Returns:
+            Formatted date string, or "-" if dt is None
+        """
+        if not dt:
+            return "-"
+        return dt.strftime("%Y-%m-%d")
+
+    @staticmethod
+    def format_date_for_filename() -> str:
+        """Format current date for filename (YYYYMMDD).
+
+        Returns:
+            Current date formatted as YYYYMMDD
+        """
+        return datetime.now().strftime("%Y%m%d")
+
+    @staticmethod
+    def format_date_japanese(dt: datetime | date) -> str:
+        """Format date in Japanese style (YYYY/MM/DD).
+
+        Args:
+            dt: Datetime or date to format
+
+        Returns:
+            Formatted date string
+        """
+        return dt.strftime("%Y/%m/%d")
+
+    @staticmethod
+    def format_datetime_for_export(dt: datetime | None) -> str:
+        """Format datetime for export (CSV/Markdown).
+
+        Args:
+            dt: Datetime to format, or None
+
+        Returns:
+            Formatted datetime string, or "-" if dt is None
+        """
+        if not dt:
+            return "-"
+        return dt.strftime(DATETIME_FORMAT)
+
+    @staticmethod
+    def format_datetime_compact(dt: datetime | None) -> str:
+        """Format datetime without seconds (YYYY-MM-DD HH:MM).
+
+        Args:
+            dt: Datetime to format, or None
+
+        Returns:
+            Formatted datetime string, or "-" if dt is None
+        """
+        if not dt:
+            return "-"
+        return dt.strftime("%Y-%m-%d %H:%M")
+
+    @staticmethod
+    def format_datetime_full(dt: datetime | None) -> str:
+        """Format datetime with full format (YYYY-MM-DD HH:MM:SS).
+
+        Alias for format_datetime_for_export for consistency.
+
+        Args:
+            dt: Datetime to format, or None
+
+        Returns:
+            Formatted datetime string, or "-" if dt is None
+        """
+        return DateTimeFormatter.format_datetime_for_export(dt)

--- a/packages/taskdog-ui/src/taskdog/renderers/rich_detail_renderer.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/rich_detail_renderer.py
@@ -13,9 +13,9 @@ from taskdog.constants.table_styles import (
     TABLE_PADDING,
     format_table_title,
 )
+from taskdog.formatters.date_time_formatter import DateTimeFormatter
 from taskdog_core.application.dto.task_detail_output import GetTaskDetailOutput
 from taskdog_core.application.dto.task_dto import TaskDetailDto
-from taskdog_core.shared.constants.formats import DATETIME_FORMAT
 
 
 class RichDetailRenderer:
@@ -53,19 +53,31 @@ class RichDetailRenderer:
 
     def _add_time_fields(self, table: Table, task: TaskDetailDto) -> None:
         """Add time-related fields to table."""
-        table.add_row("Created", task.created_at.strftime(DATETIME_FORMAT))
-        table.add_row("Updated", task.updated_at.strftime(DATETIME_FORMAT))
+        table.add_row("Created", DateTimeFormatter.format_created(task.created_at))
+        table.add_row("Updated", DateTimeFormatter.format_updated(task.updated_at))
 
         if task.planned_start:
-            table.add_row("Planned Start", task.planned_start.strftime(DATETIME_FORMAT))
+            table.add_row(
+                "Planned Start",
+                DateTimeFormatter.format_datetime_full(task.planned_start),
+            )
         if task.planned_end:
-            table.add_row("Planned End", task.planned_end.strftime(DATETIME_FORMAT))
+            table.add_row(
+                "Planned End", DateTimeFormatter.format_datetime_full(task.planned_end)
+            )
         if task.deadline:
-            table.add_row("Deadline", task.deadline.strftime(DATETIME_FORMAT))
+            table.add_row(
+                "Deadline", DateTimeFormatter.format_datetime_full(task.deadline)
+            )
         if task.actual_start:
-            table.add_row("Actual Start", task.actual_start.strftime(DATETIME_FORMAT))
+            table.add_row(
+                "Actual Start",
+                DateTimeFormatter.format_datetime_full(task.actual_start),
+            )
         if task.actual_end:
-            table.add_row("Actual End", task.actual_end.strftime(DATETIME_FORMAT))
+            table.add_row(
+                "Actual End", DateTimeFormatter.format_datetime_full(task.actual_end)
+            )
         if task.estimated_duration:
             table.add_row("Estimated Duration", f"{task.estimated_duration}h")
         if task.actual_duration_hours:

--- a/packages/taskdog-ui/src/taskdog/renderers/rich_table_renderer.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/rich_table_renderer.py
@@ -18,6 +18,7 @@ from taskdog.constants.table_styles import (
     TABLE_PADDING,
     format_table_title,
 )
+from taskdog.formatters.date_time_formatter import DateTimeFormatter
 from taskdog.renderers.rich_renderer_base import RichRendererBase
 from taskdog.view_models.task_view_model import TaskRowViewModel
 
@@ -292,7 +293,7 @@ class RichTableRenderer(RichRendererBase):
 
         if isinstance(dt, datetime):
             # Show only date and time (YYYY-MM-DD HH:MM)
-            return dt.strftime("%Y-%m-%d %H:%M")
+            return DateTimeFormatter.format_datetime_compact(dt)
         return str(dt)
 
     def _format_dependencies(self, task: TaskRowViewModel) -> str:

--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -10,6 +10,7 @@ from textual.command import CommandPalette
 if TYPE_CHECKING:
     from taskdog.infrastructure.api_client import TaskdogApiClient
 
+from taskdog.formatters.date_time_formatter import DateTimeFormatter
 from taskdog.presenters.gantt_presenter import GanttPresenter
 from taskdog.presenters.table_presenter import TablePresenter
 from taskdog.services.task_data_loader import TaskDataLoader
@@ -351,7 +352,6 @@ class TaskdogTUI(App):
         Args:
             format_key: Export format (json, csv, markdown)
         """
-        from datetime import datetime
         from pathlib import Path
 
         from taskdog.exporters import (
@@ -384,7 +384,7 @@ class TaskdogTUI(App):
             extension = format_config["extension"]
 
             # Generate filename with current date
-            today = datetime.now().strftime("%Y%m%d")
+            today = DateTimeFormatter.format_date_for_filename()
             filename = f"Taskdog_export_{today}.{extension}"
 
             # Use ~/Downloads directory

--- a/packages/taskdog-ui/src/taskdog/tui/forms/task_form_fields.py
+++ b/packages/taskdog-ui/src/taskdog/tui/forms/task_form_fields.py
@@ -7,6 +7,7 @@ from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.widgets import Checkbox, Input, Label, Static
 
+from taskdog.formatters.date_time_formatter import DateTimeFormatter
 from taskdog_core.application.dto.task_dto import TaskDetailDto
 from taskdog_core.shared.config_manager import Config
 from taskdog_core.shared.constants.formats import DATETIME_FORMAT
@@ -119,7 +120,7 @@ class TaskFormFields:
             yield Input(
                 placeholder="Optional: 2025-12-31, tomorrow 6pm, next friday",
                 id="deadline-input",
-                value=task.deadline.strftime(DATETIME_FORMAT)
+                value=DateTimeFormatter.format_datetime_for_export(task.deadline)
                 if task and task.deadline
                 else "",
             )
@@ -129,7 +130,7 @@ class TaskFormFields:
             yield Input(
                 placeholder="Optional: 2025-11-01, tomorrow 9am, next monday",
                 id="planned-start-input",
-                value=task.planned_start.strftime(DATETIME_FORMAT)
+                value=DateTimeFormatter.format_datetime_for_export(task.planned_start)
                 if task and task.planned_start
                 else "",
             )
@@ -139,7 +140,7 @@ class TaskFormFields:
             yield Input(
                 placeholder="Optional: 2025-11-15, in 2 weeks, friday 5pm",
                 id="planned-end-input",
-                value=task.planned_end.strftime(DATETIME_FORMAT)
+                value=DateTimeFormatter.format_datetime_for_export(task.planned_end)
                 if task and task.planned_end
                 else "",
             )

--- a/packages/taskdog-ui/src/taskdog/tui/forms/validators.py
+++ b/packages/taskdog-ui/src/taskdog/tui/forms/validators.py
@@ -8,6 +8,7 @@ from dateutil import parser as dateutil_parser
 from dateutil.parser import ParserError
 
 from taskdog.constants.validation_messages import ValidationMessages
+from taskdog_core.shared.constants.formats import DATETIME_FORMAT
 
 
 @dataclass
@@ -157,7 +158,7 @@ class DateTimeValidator(BaseValidator):
                 parsed_date = parsed_date.replace(hour=default_hour, minute=0, second=0)
 
             # Convert to the standard format YYYY-MM-DD HH:MM:SS
-            formatted_datetime = parsed_date.strftime("%Y-%m-%d %H:%M:%S")
+            formatted_datetime = parsed_date.strftime(DATETIME_FORMAT)
             return DateTimeValidator._success(formatted_datetime)
         except (ValueError, TypeError, OverflowError, ParserError):
             return DateTimeValidator._error(

--- a/packages/taskdog-ui/src/taskdog/tui/screens/algorithm_selection_screen.py
+++ b/packages/taskdog-ui/src/taskdog/tui/screens/algorithm_selection_screen.py
@@ -11,6 +11,7 @@ from textual.containers import Container, Vertical
 from textual.widgets import Input, Label, OptionList, Static
 from textual.widgets.option_list import Option
 
+from taskdog.formatters.date_time_formatter import DateTimeFormatter
 from taskdog.tui.screens.base_dialog import BaseModalDialog
 from taskdog_core.shared.config_manager import Config
 
@@ -134,11 +135,11 @@ class AlgorithmSelectionScreen(BaseModalDialog[tuple[str, float, datetime] | Non
         today = datetime.now()
         # If today is a weekday, use today; otherwise use next Monday
         if today.weekday() < 5:  # Monday=0, Friday=4
-            return today.strftime("%Y-%m-%d")
+            return DateTimeFormatter.format_date_only(today)
         # Move to next Monday
         days_until_monday = 7 - today.weekday()
         next_monday = today + timedelta(days=days_until_monday)
-        return next_monday.strftime("%Y-%m-%d")
+        return DateTimeFormatter.format_date_only(next_monday)
 
     def action_focus_next(self) -> None:
         """Move focus to the next field (Ctrl+J)."""

--- a/packages/taskdog-ui/src/taskdog/tui/screens/task_detail_screen.py
+++ b/packages/taskdog-ui/src/taskdog/tui/screens/task_detail_screen.py
@@ -7,6 +7,7 @@ from textual.containers import Container, VerticalScroll
 from textual.widgets import Label, Markdown, Static
 
 from taskdog.constants.colors import STATUS_COLORS_BOLD
+from taskdog.formatters.date_time_formatter import DateTimeFormatter
 from taskdog.tui.screens.base_dialog import BaseModalDialog
 from taskdog_core.application.dto.task_detail_output import GetTaskDetailOutput
 from taskdog_core.application.dto.task_dto import TaskDetailDto
@@ -85,10 +86,10 @@ class TaskDetailScreen(BaseModalDialog[tuple[str, int] | None]):
             classes="detail-row",
         )
         yield self._create_detail_row(
-            "Created", self.task_data.created_at.strftime(DATETIME_FORMAT)
+            "Created", DateTimeFormatter.format_created(self.task_data.created_at)
         )
         yield self._create_detail_row(
-            "Updated", self.task_data.updated_at.strftime(DATETIME_FORMAT)
+            "Updated", DateTimeFormatter.format_updated(self.task_data.updated_at)
         )
 
         # Dependencies

--- a/packages/taskdog-ui/src/taskdog/utils/notes_template.py
+++ b/packages/taskdog-ui/src/taskdog/utils/notes_template.py
@@ -1,9 +1,7 @@
 """Template generator for task notes markdown files."""
 
-from datetime import datetime
-
+from taskdog.formatters.date_time_formatter import DateTimeFormatter
 from taskdog_core.application.dto.task_dto import TaskDetailDto
-from taskdog_core.shared.constants.formats import DATETIME_FORMAT
 
 
 def generate_notes_template(task: TaskDetailDto) -> str:
@@ -15,7 +13,7 @@ def generate_notes_template(task: TaskDetailDto) -> str:
     Returns:
         Markdown template string with task information
     """
-    now = datetime.now().strftime(DATETIME_FORMAT)
+    now = DateTimeFormatter.format_current_timestamp()
 
     template = f"""# Task #{task.id}: {task.name}
 


### PR DESCRIPTION
## Summary

Centralize all datetime formatting logic in `DateTimeFormatter` to eliminate hardcoded format strings and improve maintainability.

## Changes

### New DateTimeFormatter Methods

Added 8 new formatting methods:
- `format_created()` / `format_updated()`: Timestamp formatting
- `format_current_timestamp()`: Current time for logging/notes  
- `format_date_only()`: Date-only format (YYYY-MM-DD)
- `format_date_for_filename()`: Compact date for filenames (YYYYMMDD)
- `format_date_japanese()`: Japanese date format (YYYY/MM/DD)
- `format_datetime_for_export()`: Full datetime for export
- `format_datetime_compact()`: Datetime without seconds
- `format_datetime_full()`: Alias for consistency

### Replaced Hardcoded Format Strings (9 occurrences)

| File | Before | After |
|------|--------|-------|
| `markdown_table_exporter.py` | `strftime("%Y-%m-%d %H:%M:%S")` | `format_datetime_for_export()` |
| `markdown_table_exporter.py` | `strftime("%Y-%m-%d")` | `format_date_only()` |
| `rich_table_renderer.py` | `strftime("%Y-%m-%d %H:%M")` | `format_datetime_compact()` |
| `log_hours.py` | `strftime("%Y-%m-%d")` | `format_date_only()` |
| `algorithm_selection_screen.py` | `strftime("%Y-%m-%d")` × 2 | `format_date_only()` |
| `validators.py` | `strftime("%Y-%m-%d %H:%M:%S")` | `DATETIME_FORMAT` constant |
| `app.py` | `strftime("%Y%m%d")` | `format_date_for_filename()` |
| `report.py` | `strftime("%Y/%m/%d")` | `format_date_japanese()` |

### Replaced DATETIME_FORMAT Calls (14 occurrences)

| File | Occurrences | Methods Used |
|------|-------------|--------------|
| `rich_detail_renderer.py` | 7 | `format_created()`, `format_updated()`, `format_datetime_full()` |
| `task_detail_screen.py` | 2 | `format_created()`, `format_updated()` |
| `task_form_fields.py` | 3 | `format_datetime_for_export()` |
| `notes_template.py` | 1 | `format_current_timestamp()` |
| `task_form_fields.py` | 1 | `DATETIME_FORMAT` (kept for parsing) |

## Benefits

- ✅ **Single source of truth** for all datetime formatting
- ✅ **Easy maintenance**: Change format strings in one place
- ✅ **I18n ready**: Foundation for future locale/timezone support
- ✅ **Better readability**: Eliminates magic strings
- ✅ **Type safety**: Clear method signatures with intent

## Testing

- ✅ All tests passing (`make test-ui`)
- ✅ Type checking passing (`make typecheck`)
- ✅ Linting passing (ruff)

## Phase 3A Progress

This completes **Priority 7** of Phase 3A quick wins.

**Phase 3A Status**:
- ✅ Priority 1: Message display consolidation in GanttWidget (PR #216)
- ✅ Priority 2: Field check pattern extraction in task detail screen (PR #218)
- ✅ Priority 4: Validation error message centralization (PR #217)
- ✅ Priority 6: Formatter instance caching optimization (PR #216)
- ✅ Priority 7: Datetime formatting unification (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)