### PR TITLE
refactor(tui): implement configuration-driven TaskTableRowBuilder

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/widgets/task_table_row_builder.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/task_table_row_builder.py
@@ -1,5 +1,9 @@
 """Task table row builder for constructing table row data."""
 
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal
+
 from rich.text import Text
 
 from taskdog.builders.table_cell_builder import TableCellBuilder
@@ -10,6 +14,21 @@ from taskdog.formatters.date_time_formatter import DateTimeFormatter
 from taskdog.formatters.duration_formatter import DurationFormatter
 from taskdog.tui.constants.ui_settings import TAGS_MAX_DISPLAY_LENGTH
 from taskdog.view_models.task_view_model import TaskRowViewModel
+
+
+@dataclass(frozen=True)
+class ColumnConfig:
+    """Configuration for a single table column.
+
+    Attributes:
+        formatter: Function to extract/format value from TaskRowViewModel
+        justification: Text alignment (left/center/right)
+        style_func: Optional function to determine cell style based on TaskRowViewModel
+    """
+
+    formatter: Callable[[TaskRowViewModel], str]
+    justification: Literal["left", "center", "right"] = "center"
+    style_func: Callable[[TaskRowViewModel], str | None] | None = None
 
 
 class TaskTableRowBuilder:
@@ -25,6 +44,79 @@ class TaskTableRowBuilder:
         self.date_formatter = DateTimeFormatter()
         self.duration_formatter = DurationFormatter()
         self.cell_builder = TableCellBuilder()
+        self._columns = self._initialize_column_config()
+
+    def _initialize_column_config(self) -> list[ColumnConfig]:
+        """Initialize column configuration for table building.
+
+        Returns:
+            List of ColumnConfig defining each table column's formatting
+        """
+        return [
+            # ID column
+            ColumnConfig(formatter=lambda vm: str(vm.id)),
+            # Name column (left-aligned, strikethrough for finished)
+            ColumnConfig(
+                formatter=lambda vm: self._format_name(vm.name),
+                justification="left",
+                style_func=lambda vm: "strike" if vm.is_finished else None,
+            ),
+            # Status column (color-coded)
+            ColumnConfig(
+                formatter=lambda vm: vm.status.value,
+                style_func=lambda vm: STATUS_STYLES.get(vm.status.value, "white"),
+            ),
+            # Priority column
+            ColumnConfig(formatter=lambda vm: str(vm.priority)),
+            # Flags column (fixed indicator + note indicator)
+            ColumnConfig(formatter=lambda vm: self._format_flags(vm)),
+            # Estimated duration column
+            ColumnConfig(
+                formatter=lambda vm: self.duration_formatter.format_estimated_duration(
+                    vm
+                )
+            ),
+            # Actual duration column
+            ColumnConfig(
+                formatter=lambda vm: self.duration_formatter.format_actual_duration(vm)
+            ),
+            # Deadline column
+            ColumnConfig(
+                formatter=lambda vm: self.date_formatter.format_deadline(vm.deadline)
+            ),
+            # Planned start column
+            ColumnConfig(
+                formatter=lambda vm: self.date_formatter.format_planned_start(
+                    vm.planned_start
+                )
+            ),
+            # Planned end column
+            ColumnConfig(
+                formatter=lambda vm: self.date_formatter.format_planned_end(
+                    vm.planned_end
+                )
+            ),
+            # Actual start column
+            ColumnConfig(
+                formatter=lambda vm: self.date_formatter.format_actual_start(
+                    vm.actual_start
+                )
+            ),
+            # Actual end column
+            ColumnConfig(
+                formatter=lambda vm: self.date_formatter.format_actual_end(
+                    vm.actual_end
+                )
+            ),
+            # Elapsed time column
+            ColumnConfig(
+                formatter=lambda vm: self.duration_formatter.format_elapsed_time(vm)
+            ),
+            # Dependencies column
+            ColumnConfig(formatter=lambda vm: self._format_dependencies(vm.depends_on)),
+            # Tags column
+            ColumnConfig(formatter=lambda vm: self._format_tags(vm.tags)),
+        ]
 
     def build_row(self, task_vm: TaskRowViewModel) -> tuple[Text, ...]:
         """Build a table row from a task view model.
@@ -35,213 +127,41 @@ class TaskTableRowBuilder:
         Returns:
             Tuple of Text objects representing the table row columns
         """
-        return (
-            self._build_id_cell(task_vm),
-            self._build_name_cell(task_vm),
-            self._build_status_cell(task_vm),
-            self._build_priority_cell(task_vm),
-            self._build_flags_cell(task_vm),
-            self._build_estimated_duration_cell(task_vm),
-            self._build_actual_duration_cell(task_vm),
-            self._build_deadline_cell(task_vm),
-            self._build_planned_start_cell(task_vm),
-            self._build_planned_end_cell(task_vm),
-            self._build_actual_start_cell(task_vm),
-            self._build_actual_end_cell(task_vm),
-            self._build_elapsed_cell(task_vm),
-            self._build_dependencies_cell(task_vm),
-            self._build_tags_cell(task_vm),
-        )
+        return tuple(self._build_cell(task_vm, col) for col in self._columns)
 
-    def _build_id_cell(self, task_vm: TaskRowViewModel) -> Text:
-        """Build ID cell.
+    def _build_cell(self, task_vm: TaskRowViewModel, col: ColumnConfig) -> Text:
+        """Build a single cell based on column configuration.
 
         Args:
-            task_vm: TaskRowViewModel to extract ID from
+            task_vm: TaskRowViewModel to extract data from
+            col: ColumnConfig defining cell formatting
 
         Returns:
-            Text object for ID column
+            Text object for the cell
         """
-        return self.cell_builder.build_centered_cell(task_vm.id)
+        value = col.formatter(task_vm)
+        style = col.style_func(task_vm) if col.style_func else None
 
-    def _build_name_cell(self, task_vm: TaskRowViewModel) -> Text:
-        """Build name cell with truncation and strikethrough for completed, canceled, and archived tasks.
+        if col.justification == "left":
+            return self.cell_builder.build_left_aligned_cell(value, style=style)
+        else:
+            return self.cell_builder.build_styled_cell(
+                value, style=style, justify=col.justification
+            )
 
-        Args:
-            task_vm: TaskRowViewModel to extract name from
-
-        Returns:
-            Text object for name column
-        """
-        name_text = self._format_name(task_vm.name)
-        name_style = "strike" if task_vm.is_finished else None
-        return self.cell_builder.build_left_aligned_cell(name_text, style=name_style)
-
-    def _build_priority_cell(self, task_vm: TaskRowViewModel) -> Text:
-        """Build priority cell.
+    @staticmethod
+    def _format_flags(task_vm: TaskRowViewModel) -> str:
+        """Format task flags (fixed indicator + note indicator).
 
         Args:
-            task_vm: TaskRowViewModel to extract priority from
+            task_vm: TaskRowViewModel to extract flags from
 
         Returns:
-            Text object for priority column
-        """
-        return self.cell_builder.build_centered_cell(task_vm.priority)
-
-    def _build_status_cell(self, task_vm: TaskRowViewModel) -> Text:
-        """Build status cell with color coding.
-
-        Args:
-            task_vm: TaskRowViewModel to extract status from
-
-        Returns:
-            Text object for status column
-        """
-        status_text = task_vm.status.value
-        status_color = STATUS_STYLES.get(task_vm.status.value, "white")
-        return Text(status_text, style=status_color, justify="center")
-
-    def _build_elapsed_cell(self, task_vm: TaskRowViewModel) -> Text:
-        """Build elapsed time cell.
-
-        Args:
-            task_vm: TaskRowViewModel to calculate elapsed time for
-
-        Returns:
-            Text object for elapsed time column
-        """
-        return self.cell_builder.build_cell_from_formatter(
-            self.duration_formatter.format_elapsed_time, task_vm
-        )
-
-    def _build_planned_start_cell(self, task_vm: TaskRowViewModel) -> Text:
-        """Build planned start cell.
-
-        Args:
-            task_vm: TaskRowViewModel to extract planned start from
-
-        Returns:
-            Text object for planned start column
-        """
-        return self.cell_builder.build_cell_from_formatter(
-            self.date_formatter.format_planned_start, task_vm.planned_start
-        )
-
-    def _build_planned_end_cell(self, task_vm: TaskRowViewModel) -> Text:
-        """Build planned end cell.
-
-        Args:
-            task_vm: TaskRowViewModel to extract planned end from
-
-        Returns:
-            Text object for planned end column
-        """
-        return self.cell_builder.build_cell_from_formatter(
-            self.date_formatter.format_planned_end, task_vm.planned_end
-        )
-
-    def _build_actual_start_cell(self, task_vm: TaskRowViewModel) -> Text:
-        """Build actual start cell.
-
-        Args:
-            task_vm: TaskRowViewModel to extract actual start from
-
-        Returns:
-            Text object for actual start column
-        """
-        return self.cell_builder.build_cell_from_formatter(
-            self.date_formatter.format_actual_start, task_vm.actual_start
-        )
-
-    def _build_actual_end_cell(self, task_vm: TaskRowViewModel) -> Text:
-        """Build actual end cell.
-
-        Args:
-            task_vm: TaskRowViewModel to extract actual end from
-
-        Returns:
-            Text object for actual end column
-        """
-        return self.cell_builder.build_cell_from_formatter(
-            self.date_formatter.format_actual_end, task_vm.actual_end
-        )
-
-    def _build_estimated_duration_cell(self, task_vm: TaskRowViewModel) -> Text:
-        """Build estimated duration cell.
-
-        Args:
-            task_vm: TaskRowViewModel to extract estimated duration from
-
-        Returns:
-            Text object for estimated duration column
-        """
-        return self.cell_builder.build_cell_from_formatter(
-            self.duration_formatter.format_estimated_duration, task_vm
-        )
-
-    def _build_actual_duration_cell(self, task_vm: TaskRowViewModel) -> Text:
-        """Build actual duration cell.
-
-        Args:
-            task_vm: TaskRowViewModel to extract actual duration from
-
-        Returns:
-            Text object for actual duration column
-        """
-        return self.cell_builder.build_cell_from_formatter(
-            self.duration_formatter.format_actual_duration, task_vm
-        )
-
-    def _build_deadline_cell(self, task_vm: TaskRowViewModel) -> Text:
-        """Build deadline cell.
-
-        Args:
-            task_vm: TaskRowViewModel to extract deadline from
-
-        Returns:
-            Text object for deadline column
-        """
-        return self.cell_builder.build_cell_from_formatter(
-            self.date_formatter.format_deadline, task_vm.deadline
-        )
-
-    def _build_dependencies_cell(self, task_vm: TaskRowViewModel) -> Text:
-        """Build dependencies cell.
-
-        Args:
-            task_vm: TaskRowViewModel to extract dependencies from
-
-        Returns:
-            Text object for dependencies column
-        """
-        deps_text = self._format_dependencies(task_vm.depends_on)
-        return self.cell_builder.build_centered_cell(deps_text)
-
-    def _build_tags_cell(self, task_vm: TaskRowViewModel) -> Text:
-        """Build tags cell with truncation.
-
-        Args:
-            task_vm: TaskRowViewModel to extract tags from
-
-        Returns:
-            Text object for tags column
-        """
-        tags_text = self._format_tags(task_vm.tags)
-        return self.cell_builder.build_centered_cell(tags_text)
-
-    def _build_flags_cell(self, task_vm: TaskRowViewModel) -> Text:
-        """Build flags cell (fixed indicator + note indicator).
-
-        Args:
-            task_vm: TaskRowViewModel to build flags for
-
-        Returns:
-            Text object for flags column
+            Formatted flags string
         """
         fixed_indicator = "📌" if task_vm.is_fixed else ""
         note_indicator = EMOJI_NOTE if task_vm.has_notes else ""
-        flags = fixed_indicator + note_indicator
-        return Text(flags, justify="center")
+        return fixed_indicator + note_indicator
 
     @staticmethod
     def _format_name(name: str) -> str:


### PR DESCRIPTION
## Summary

Replace 15 repetitive `_build_*_cell()` methods with a single configuration-driven approach using `ColumnConfig` dataclass.

This is part of **Phase 3B Priority 5**: TaskTableRowBuilder builder pattern implementation.

## Changes

### Added
- `ColumnConfig` frozen dataclass with:
  - `formatter`: Function to extract/format value from TaskRowViewModel
  - `justification`: Text alignment (left/center/right)
  - `style_func`: Optional function to determine cell style
- `_initialize_column_config()` method: Centralizes all 15 column definitions
- `_build_cell()` method: Generic cell builder based on ColumnConfig
- `_format_flags()` helper: Converts old `_build_flags_cell()` to string formatter

### Removed
- 15 `_build_*_cell()` methods (228 lines total):
  - `_build_id_cell()`, `_build_name_cell()`, `_build_status_cell()`, etc.
  - 75 lines of repetitive docstrings eliminated

### Modified
- `build_row()`: Now uses list comprehension over `_columns` configuration

### Preserved
- Complex logic helpers: `_format_name()`, `_format_tags()`, `_format_dependencies()`
- All formatting logic and behavior unchanged

## Benefits

- **Code reduction**: 291 lines → 209 lines (82 line reduction, 28%)
- **Eliminated duplication**: 80% of methods followed identical patterns
- **Improved maintainability**: Column definitions now centralized in one place
- **Easier column reordering**: Column order explicit in configuration list
- **Type safety**: Using `Literal["left", "center", "right"]` for justification
- **No behavior changes**: All existing tests pass

## Testing

```bash
make test-ui  # 232 tests passed, 4 skipped
make typecheck  # All packages pass mypy
```

## Related

- Part of Phase 3 code reduction effort
- Previous Phase 3B work: PR #220 (FilterableTaskTable delegation, +18 lines saved)
- Phase 3 total savings so far: ~153 lines (71 from Phase 3A + 82 from this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)