### PR TITLE
feat(notes): add custom note template support

### DIFF
--- a/examples/cli.toml
+++ b/examples/cli.toml
@@ -50,6 +50,30 @@ theme = "textual-dark"
 # - Gruvbox: theme = "gruvbox"
 
 # =============================================================================
+# Notes Settings
+# =============================================================================
+#
+# Configure note template for new task notes.
+
+[notes]
+# Custom note template file path (default: none, uses system default)
+# Supports ~ expansion for home directory.
+# If the file doesn't exist, falls back to system default template.
+#
+# Template variables (use {{variable}} syntax):
+#   - {{task_id}}           - Task ID
+#   - {{task_name}}         - Task name
+#   - {{priority}}          - Priority value
+#   - {{status}}            - Task status (PENDING, IN_PROGRESS, etc.)
+#   - {{deadline}}          - Deadline date (empty if not set)
+#   - {{estimated_duration}} - Estimated hours (empty if not set)
+#   - {{tags}}              - Comma-separated tags (empty if none)
+#   - {{created_at}}        - Current datetime
+#
+# Example: template = "~/.config/taskdog/note_template.md"
+# template = "~/.config/taskdog/note_template.md"
+
+# =============================================================================
 # Keybindings (Future Feature)
 # =============================================================================
 #

--- a/examples/note_template.md
+++ b/examples/note_template.md
@@ -1,0 +1,24 @@
+# {{task_name}}
+
+## Task Info
+- **ID**: {{task_id}}
+- **Priority**: {{priority}}
+- **Status**: {{status}}
+- **Deadline**: {{deadline}}
+- **Estimated**: {{estimated_duration}} hours
+- **Tags**: {{tags}}
+
+## Overview
+[Task overview here]
+
+## Details
+- [ ] Subtask 1
+- [ ] Subtask 2
+- [ ] Subtask 3
+
+## Technical Notes
+[Technical details, references, links, etc.]
+
+## Progress Log
+### {{created_at}}
+[Work started]

--- a/packages/taskdog-ui/src/taskdog/cli/commands/note.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/note.py
@@ -12,8 +12,9 @@ from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_task_errors
 from taskdog.console.console_writer import ConsoleWriter
 from taskdog.infrastructure.api_client import TaskdogApiClient
+from taskdog.infrastructure.cli_config import CliConfig
 from taskdog.utils.editor import get_editor
-from taskdog.utils.notes_template import generate_notes_template
+from taskdog.utils.notes_template import get_note_template
 from taskdog_core.application.dto.task_dto import TaskDetailDto
 from taskdog_core.domain.exceptions.task_exceptions import TaskNotFoundException
 
@@ -88,6 +89,7 @@ def _edit_with_editor(
     task: TaskDetailDto,
     api_client: TaskdogApiClient,
     console_writer: ConsoleWriter,
+    config: CliConfig | None = None,
 ) -> None:
     """Edit note using $EDITOR.
 
@@ -96,10 +98,11 @@ def _edit_with_editor(
         task: Task detail DTO
         api_client: API client
         console_writer: Console writer
+        config: CLI configuration for custom template (optional)
     """
     existing_content, _ = api_client.get_task_notes(task_id)
     editor_content = (
-        existing_content if existing_content else generate_notes_template(task)
+        existing_content if existing_content else get_note_template(task, config)
     )
 
     with tempfile.NamedTemporaryFile(
@@ -199,4 +202,4 @@ def note_command(
         _save_content_directly(task_id, new_content, append, api_client, console_writer)
     else:
         # No input source, use editor mode
-        _edit_with_editor(task_id, task, api_client, console_writer)
+        _edit_with_editor(task_id, task, api_client, console_writer, ctx_obj.config)

--- a/packages/taskdog-ui/src/taskdog/infrastructure/cli_config.py
+++ b/packages/taskdog-ui/src/taskdog/infrastructure/cli_config.py
@@ -37,6 +37,19 @@ class UiConfig:
 
 
 @dataclass(frozen=True)
+class NotesConfig:
+    """Notes-related configuration.
+
+    Attributes:
+        template: Path to custom note template file.
+                  Supports ~ expansion. If None or file doesn't exist,
+                  system default template is used.
+    """
+
+    template: str | None = None
+
+
+@dataclass(frozen=True)
 class CliConfig:
     """CLI/TUI configuration.
 
@@ -46,11 +59,13 @@ class CliConfig:
     Attributes:
         api: API connection settings
         ui: UI appearance settings (theme, etc.)
+        notes: Notes settings (template path, etc.)
         keybindings: Future: Custom keybindings for TUI (not yet implemented)
     """
 
     api: CliApiConfig = field(default_factory=CliApiConfig)
     ui: UiConfig = field(default_factory=UiConfig)
+    notes: NotesConfig = field(default_factory=NotesConfig)
     keybindings: dict[str, str] = field(default_factory=dict)
 
 
@@ -88,6 +103,7 @@ def load_cli_config() -> CliConfig:
     api_host = "127.0.0.1"
     api_port = 8000
     theme = "textual-dark"
+    notes_template: str | None = None
     keybindings: dict[str, str] = {}
 
     # Load from cli.toml if exists
@@ -107,6 +123,11 @@ def load_cli_config() -> CliConfig:
             if "ui" in data:
                 ui_section = data["ui"]
                 theme = ui_section.get("theme", theme)
+
+            # Parse [notes] section
+            if "notes" in data:
+                notes_section = data["notes"]
+                notes_template = notes_section.get("template", notes_template)
 
             # Parse [keybindings] section (future feature)
             if "keybindings" in data:
@@ -129,4 +150,7 @@ def load_cli_config() -> CliConfig:
     # Build config object
     api_config = CliApiConfig(host=api_host, port=api_port)
     ui_config = UiConfig(theme=theme)
-    return CliConfig(api=api_config, ui=ui_config, keybindings=keybindings)
+    notes_config = NotesConfig(template=notes_template)
+    return CliConfig(
+        api=api_config, ui=ui_config, notes=notes_config, keybindings=keybindings
+    )

--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -209,8 +209,8 @@ class TaskdogTUI(App):
                 pass
 
         self.api_client = api_client
-        _cli_config = cli_config or CliConfig()
-        self._theme = _cli_config.ui.theme
+        self._cli_config = cli_config or CliConfig()
+        self._theme = self._cli_config.ui.theme
         self.main_screen: MainScreen | None = None
 
         # Initialize TUI state (Single Source of Truth for all app state)
@@ -221,10 +221,11 @@ class TaskdogTUI(App):
         # - _all_tasks, _gantt_view_model → state (Step 4)
         # - viewmodels → state (Step 5)
 
-        # Initialize TUIContext with API client and state
+        # Initialize TUIContext with API client, state, and config
         self.context = TUIContext(
             api_client=self.api_client,
             state=self.state,  # Share same state instance
+            config=self._cli_config,
         )
 
         # Initialize presenters for view models (will be updated to not use notes_repository)

--- a/packages/taskdog-ui/src/taskdog/tui/commands/note.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/note.py
@@ -36,4 +36,5 @@ class NoteCommand(TUICommandBase):
             app=self.app,
             on_success=lambda name, id_: self._on_note_saved(name, id_),
             on_error=self.notify_error,
+            config=self.context.config,
         )

--- a/packages/taskdog-ui/src/taskdog/tui/context.py
+++ b/packages/taskdog-ui/src/taskdog/tui/context.py
@@ -7,6 +7,7 @@ from taskdog.tui.state import TUIState
 
 if TYPE_CHECKING:
     from taskdog.infrastructure.api_client import TaskdogApiClient
+    from taskdog.infrastructure.cli_config import CliConfig
 
 
 @dataclass
@@ -22,7 +23,9 @@ class TUIContext:
     Attributes:
         api_client: API client for server communication (required)
         state: TUI application state (shared with app instance)
+        config: CLI configuration (optional, for custom templates etc.)
     """
 
     api_client: "TaskdogApiClient"
     state: TUIState
+    config: "CliConfig | None" = None

--- a/packages/taskdog-ui/src/taskdog/utils/notes_template.py
+++ b/packages/taskdog-ui/src/taskdog/utils/notes_template.py
@@ -1,7 +1,30 @@
 """Template generator for task notes markdown files."""
 
 from taskdog.formatters.date_time_formatter import DateTimeFormatter
+from taskdog.infrastructure.cli_config import CliConfig
+from taskdog.utils.template_loader import load_note_template
 from taskdog_core.application.dto.task_dto import TaskDetailDto
+
+
+def get_note_template(task: TaskDetailDto, config: CliConfig | None = None) -> str:
+    """Get note template with custom template support.
+
+    Tries to load custom template from config, falls back to system default.
+
+    Args:
+        task: Task DTO to generate template for
+        config: CLI configuration containing template path (optional)
+
+    Returns:
+        Template string (custom or system default)
+    """
+    # Try custom template first
+    custom_template = load_note_template(config, task)
+    if custom_template is not None:
+        return custom_template
+
+    # Fall back to system default
+    return generate_notes_template(task)
 
 
 def generate_notes_template(task: TaskDetailDto) -> str:

--- a/packages/taskdog-ui/src/taskdog/utils/template_loader.py
+++ b/packages/taskdog-ui/src/taskdog/utils/template_loader.py
@@ -1,0 +1,86 @@
+"""Template loader for custom note templates."""
+
+import os
+from datetime import datetime
+
+from taskdog.infrastructure.cli_config import CliConfig
+from taskdog_core.application.dto.task_dto import TaskDetailDto
+
+
+def load_note_template(config: CliConfig | None, task: TaskDetailDto) -> str | None:
+    """Load custom note template from file and expand variables.
+
+    Args:
+        config: CLI configuration containing template path
+        task: Task DTO for variable expansion
+
+    Returns:
+        Expanded template string, or None if no custom template configured/found
+    """
+    if config is None or config.notes.template is None:
+        return None
+
+    template_path = os.path.expanduser(config.notes.template)
+
+    if not os.path.isfile(template_path):
+        return None
+
+    try:
+        with open(template_path, encoding="utf-8") as f:
+            template = f.read()
+        return _expand_template_variables(template, task)
+    except (OSError, UnicodeDecodeError):
+        # If file can't be read, fall back to system default
+        return None
+
+
+def _expand_template_variables(template: str, task: TaskDetailDto) -> str:
+    """Expand {{variable}} placeholders in template.
+
+    Supported variables:
+        {{task_id}} - Task ID
+        {{task_name}} - Task name
+        {{priority}} - Priority value
+        {{status}} - Task status
+        {{deadline}} - Deadline (empty string if not set)
+        {{estimated_duration}} - Estimated duration in hours (empty if not set)
+        {{tags}} - Comma-separated tags (empty if none)
+        {{created_at}} - Current datetime
+
+    Args:
+        template: Template string with {{variable}} placeholders
+        task: Task DTO for variable values
+
+    Returns:
+        Template with variables expanded
+    """
+    now = datetime.now().strftime("%Y-%m-%d %H:%M")
+
+    # Format optional fields
+    deadline_str = ""
+    if task.deadline:
+        deadline_str = task.deadline.strftime("%Y-%m-%d")
+
+    estimated_str = ""
+    if task.estimated_duration is not None:
+        estimated_str = str(task.estimated_duration)
+
+    tags_str = ", ".join(task.tags) if task.tags else ""
+
+    # Variable mapping
+    variables = {
+        "{{task_id}}": str(task.id),
+        "{{task_name}}": task.name,
+        "{{priority}}": str(task.priority),
+        "{{status}}": task.status.value,
+        "{{deadline}}": deadline_str,
+        "{{estimated_duration}}": estimated_str,
+        "{{tags}}": tags_str,
+        "{{created_at}}": now,
+    }
+
+    result = template
+    for placeholder, value in variables.items():
+        result = result.replace(placeholder, value)
+
+    return result


### PR DESCRIPTION
## Summary

- Add ability to configure custom markdown templates for new task notes
- Templates support variable expansion (`{{task_name}}`, `{{task_id}}`, etc.)
- Falls back to system default template if custom template is not configured or file doesn't exist

## Changes

- Add `NotesConfig` to `CliConfig` with `template` path setting
- Add `template_loader.py` for loading and expanding custom templates
- Update `notes_template.py` with `get_note_template()` fallback logic
- Pass config through CLI and TUI note commands
- Add example template (`examples/note_template.md`) and `cli.toml` documentation

## Usage

```toml
# ~/.config/taskdog/cli.toml
[notes]
template = "~/.config/taskdog/note_template.md"
```

## Template Variables

| Variable | Description |
|----------|-------------|
| `{{task_id}}` | Task ID |
| `{{task_name}}` | Task name |
| `{{priority}}` | Priority value |
| `{{status}}` | Task status |
| `{{deadline}}` | Deadline (empty if not set) |
| `{{estimated_duration}}` | Estimated hours (empty if not set) |
| `{{tags}}` | Comma-separated tags |
| `{{created_at}}` | Current datetime |

## Test plan

- [x] Lint passes (`make lint`)
- [x] Type check passes (`make typecheck`)
- [x] All tests pass (`make test-ui`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)