### PR TITLE
refactor: consolidate DTO type alias files into single module (#326)

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/dto/__init__.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/__init__.py
@@ -6,6 +6,16 @@ from taskdog_core.application.dto.query_inputs import (
     ListTasksInput,
     TimeRange,
 )
+from taskdog_core.application.dto.single_task_inputs import (
+    ArchiveTaskInput,
+    CancelTaskInput,
+    CompleteTaskInput,
+    PauseTaskInput,
+    RemoveTaskInput,
+    ReopenTaskInput,
+    RestoreTaskInput,
+    StartTaskInput,
+)
 from taskdog_core.application.dto.statistics_output import (
     CalculateStatisticsInput,
     DeadlineComplianceStatistics,
@@ -19,14 +29,22 @@ from taskdog_core.application.dto.statistics_output import (
 from taskdog_core.application.dto.task_detail_output import TaskDetailOutput
 
 __all__ = [
+    "ArchiveTaskInput",
     "CalculateStatisticsInput",
+    "CancelTaskInput",
+    "CompleteTaskInput",
     "DeadlineComplianceStatistics",
     "EstimationAccuracyStatistics",
     "GanttDateRange",
     "GanttOutput",
     "GetGanttDataInput",
     "ListTasksInput",
+    "PauseTaskInput",
     "PriorityDistributionStatistics",
+    "RemoveTaskInput",
+    "ReopenTaskInput",
+    "RestoreTaskInput",
+    "StartTaskInput",
     "StatisticsOutput",
     "TaskDetailOutput",
     "TaskStatistics",

--- a/packages/taskdog-core/src/taskdog_core/application/dto/archive_task_input.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/archive_task_input.py
@@ -1,6 +1,0 @@
-"""DTO for archiving a task."""
-
-from taskdog_core.application.dto.base import SingleTaskInput
-
-# Type alias for semantic clarity
-ArchiveTaskInput = SingleTaskInput

--- a/packages/taskdog-core/src/taskdog_core/application/dto/cancel_task_input.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/cancel_task_input.py
@@ -1,6 +1,0 @@
-"""DTO for canceling a task."""
-
-from taskdog_core.application.dto.base import SingleTaskInput
-
-# Type alias for semantic clarity
-CancelTaskInput = SingleTaskInput

--- a/packages/taskdog-core/src/taskdog_core/application/dto/complete_task_input.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/complete_task_input.py
@@ -1,6 +1,0 @@
-"""DTO for completing a task."""
-
-from taskdog_core.application.dto.base import SingleTaskInput
-
-# Type alias for semantic clarity
-CompleteTaskInput = SingleTaskInput

--- a/packages/taskdog-core/src/taskdog_core/application/dto/pause_task_input.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/pause_task_input.py
@@ -1,6 +1,0 @@
-"""DTO for pausing a task."""
-
-from taskdog_core.application.dto.base import SingleTaskInput
-
-# Type alias for semantic clarity
-PauseTaskInput = SingleTaskInput

--- a/packages/taskdog-core/src/taskdog_core/application/dto/remove_task_input.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/remove_task_input.py
@@ -1,6 +1,0 @@
-"""DTO for removing a task."""
-
-from taskdog_core.application.dto.base import SingleTaskInput
-
-# Type alias for semantic clarity
-RemoveTaskInput = SingleTaskInput

--- a/packages/taskdog-core/src/taskdog_core/application/dto/reopen_task_input.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/reopen_task_input.py
@@ -1,6 +1,0 @@
-"""DTO for reopening a task."""
-
-from taskdog_core.application.dto.base import SingleTaskInput
-
-# Type alias for clarity
-ReopenTaskInput = SingleTaskInput

--- a/packages/taskdog-core/src/taskdog_core/application/dto/restore_task_input.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/restore_task_input.py
@@ -1,6 +1,0 @@
-"""DTO for restoring a task."""
-
-from taskdog_core.application.dto.base import SingleTaskInput
-
-# Type alias for semantic clarity
-RestoreTaskInput = SingleTaskInput

--- a/packages/taskdog-core/src/taskdog_core/application/dto/single_task_inputs.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/single_task_inputs.py
@@ -1,0 +1,16 @@
+"""Type aliases for single-task operation DTOs.
+
+These type aliases provide semantic clarity while sharing the same
+underlying SingleTaskInput structure.
+"""
+
+from taskdog_core.application.dto.base import SingleTaskInput
+
+ArchiveTaskInput = SingleTaskInput
+CancelTaskInput = SingleTaskInput
+CompleteTaskInput = SingleTaskInput
+PauseTaskInput = SingleTaskInput
+RemoveTaskInput = SingleTaskInput
+ReopenTaskInput = SingleTaskInput
+RestoreTaskInput = SingleTaskInput
+StartTaskInput = SingleTaskInput

--- a/packages/taskdog-core/src/taskdog_core/application/dto/start_task_input.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/start_task_input.py
@@ -1,6 +1,0 @@
-"""DTO for starting a task."""
-
-from taskdog_core.application.dto.base import SingleTaskInput
-
-# Type alias for semantic clarity
-StartTaskInput = SingleTaskInput

--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/archive_task.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/archive_task.py
@@ -1,6 +1,6 @@
 """Use case for archiving a task."""
 
-from taskdog_core.application.dto.archive_task_input import ArchiveTaskInput
+from taskdog_core.application.dto.single_task_inputs import ArchiveTaskInput
 from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 from taskdog_core.application.use_cases.base import UseCase
 from taskdog_core.domain.repositories.task_repository import TaskRepository

--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/cancel_task.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/cancel_task.py
@@ -1,6 +1,6 @@
 """Use case for canceling a task."""
 
-from taskdog_core.application.dto.cancel_task_input import CancelTaskInput
+from taskdog_core.application.dto.single_task_inputs import CancelTaskInput
 from taskdog_core.application.use_cases.status_change_use_case import (
     StatusChangeUseCase,
 )

--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/complete_task.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/complete_task.py
@@ -1,6 +1,6 @@
 """Use case for completing a task."""
 
-from taskdog_core.application.dto.complete_task_input import CompleteTaskInput
+from taskdog_core.application.dto.single_task_inputs import CompleteTaskInput
 from taskdog_core.application.use_cases.status_change_use_case import (
     StatusChangeUseCase,
 )

--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/pause_task.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/pause_task.py
@@ -1,6 +1,6 @@
 """Use case for pausing a task."""
 
-from taskdog_core.application.dto.pause_task_input import PauseTaskInput
+from taskdog_core.application.dto.single_task_inputs import PauseTaskInput
 from taskdog_core.application.use_cases.status_change_use_case import (
     StatusChangeUseCase,
 )

--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/remove_task.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/remove_task.py
@@ -1,6 +1,6 @@
 """Use case for removing a task."""
 
-from taskdog_core.application.dto.remove_task_input import RemoveTaskInput
+from taskdog_core.application.dto.single_task_inputs import RemoveTaskInput
 from taskdog_core.application.use_cases.base import UseCase
 from taskdog_core.domain.repositories.notes_repository import NotesRepository
 from taskdog_core.domain.repositories.task_repository import TaskRepository

--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/reopen_task.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/reopen_task.py
@@ -1,6 +1,6 @@
 """Use case for reopening a completed or canceled task."""
 
-from taskdog_core.application.dto.reopen_task_input import ReopenTaskInput
+from taskdog_core.application.dto.single_task_inputs import ReopenTaskInput
 from taskdog_core.application.use_cases.status_change_use_case import (
     StatusChangeUseCase,
 )

--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/restore_task.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/restore_task.py
@@ -1,6 +1,6 @@
 """Use case for restoring an archived task."""
 
-from taskdog_core.application.dto.restore_task_input import RestoreTaskInput
+from taskdog_core.application.dto.single_task_inputs import RestoreTaskInput
 from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 from taskdog_core.application.use_cases.base import UseCase
 from taskdog_core.domain.exceptions.task_exceptions import TaskValidationError

--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/start_task.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/start_task.py
@@ -1,6 +1,6 @@
 """Use case for starting a task."""
 
-from taskdog_core.application.dto.start_task_input import StartTaskInput
+from taskdog_core.application.dto.single_task_inputs import StartTaskInput
 from taskdog_core.application.use_cases.status_change_use_case import (
     StatusChangeUseCase,
 )

--- a/packages/taskdog-core/src/taskdog_core/controllers/task_crud_controller.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/task_crud_controller.py
@@ -10,10 +10,12 @@ This controller handles standard CRUD operations:
 
 from datetime import datetime
 
-from taskdog_core.application.dto.archive_task_input import ArchiveTaskInput
 from taskdog_core.application.dto.create_task_input import CreateTaskInput
-from taskdog_core.application.dto.remove_task_input import RemoveTaskInput
-from taskdog_core.application.dto.restore_task_input import RestoreTaskInput
+from taskdog_core.application.dto.single_task_inputs import (
+    ArchiveTaskInput,
+    RemoveTaskInput,
+    RestoreTaskInput,
+)
 from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 from taskdog_core.application.dto.update_task_input import UpdateTaskInput
 from taskdog_core.application.dto.update_task_output import TaskUpdateOutput

--- a/packages/taskdog-core/src/taskdog_core/controllers/task_lifecycle_controller.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/task_lifecycle_controller.py
@@ -8,11 +8,13 @@ This controller handles all task lifecycle operations (status changes with time 
 - reopen_task: Reset finished task to PENDING, clear timestamps
 """
 
-from taskdog_core.application.dto.cancel_task_input import CancelTaskInput
-from taskdog_core.application.dto.complete_task_input import CompleteTaskInput
-from taskdog_core.application.dto.pause_task_input import PauseTaskInput
-from taskdog_core.application.dto.reopen_task_input import ReopenTaskInput
-from taskdog_core.application.dto.start_task_input import StartTaskInput
+from taskdog_core.application.dto.single_task_inputs import (
+    CancelTaskInput,
+    CompleteTaskInput,
+    PauseTaskInput,
+    ReopenTaskInput,
+    StartTaskInput,
+)
 from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 from taskdog_core.application.use_cases.cancel_task import CancelTaskUseCase
 from taskdog_core.application.use_cases.complete_task import CompleteTaskUseCase

--- a/packages/taskdog-core/tests/application/dto/test_single_task_input.py
+++ b/packages/taskdog-core/tests/application/dto/test_single_task_input.py
@@ -4,12 +4,14 @@ import unittest
 
 from parameterized import parameterized
 
-from taskdog_core.application.dto.archive_task_input import ArchiveTaskInput
 from taskdog_core.application.dto.base import SingleTaskInput
-from taskdog_core.application.dto.complete_task_input import CompleteTaskInput
-from taskdog_core.application.dto.pause_task_input import PauseTaskInput
-from taskdog_core.application.dto.remove_task_input import RemoveTaskInput
-from taskdog_core.application.dto.start_task_input import StartTaskInput
+from taskdog_core.application.dto.single_task_inputs import (
+    ArchiveTaskInput,
+    CompleteTaskInput,
+    PauseTaskInput,
+    RemoveTaskInput,
+    StartTaskInput,
+)
 
 
 class TestSingleTaskInput(unittest.TestCase):

--- a/packages/taskdog-core/tests/application/dto/test_status_change_inputs.py
+++ b/packages/taskdog-core/tests/application/dto/test_status_change_inputs.py
@@ -4,11 +4,13 @@ import unittest
 
 from parameterized import parameterized
 
-from taskdog_core.application.dto.cancel_task_input import CancelTaskInput
-from taskdog_core.application.dto.complete_task_input import CompleteTaskInput
-from taskdog_core.application.dto.pause_task_input import PauseTaskInput
-from taskdog_core.application.dto.reopen_task_input import ReopenTaskInput
-from taskdog_core.application.dto.start_task_input import StartTaskInput
+from taskdog_core.application.dto.single_task_inputs import (
+    CancelTaskInput,
+    CompleteTaskInput,
+    PauseTaskInput,
+    ReopenTaskInput,
+    StartTaskInput,
+)
 
 
 class TestStatusChangeInputs(unittest.TestCase):

--- a/packages/taskdog-core/tests/application/dto/test_task_management_inputs.py
+++ b/packages/taskdog-core/tests/application/dto/test_task_management_inputs.py
@@ -5,14 +5,16 @@ from datetime import datetime
 
 from parameterized import parameterized
 
-from taskdog_core.application.dto.archive_task_input import ArchiveTaskInput
 from taskdog_core.application.dto.log_hours_input import LogHoursInput
 from taskdog_core.application.dto.manage_dependencies_input import (
     AddDependencyInput,
     RemoveDependencyInput,
 )
-from taskdog_core.application.dto.restore_task_input import RestoreTaskInput
 from taskdog_core.application.dto.set_task_tags_input import SetTaskTagsInput
+from taskdog_core.application.dto.single_task_inputs import (
+    ArchiveTaskInput,
+    RestoreTaskInput,
+)
 
 
 class TestSimpleTaskManagementInputs(unittest.TestCase):

--- a/packages/taskdog-core/tests/application/use_cases/test_archive_task_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_archive_task_use_case.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from taskdog_core.application.dto.archive_task_input import ArchiveTaskInput
+from taskdog_core.application.dto.single_task_inputs import ArchiveTaskInput
 from taskdog_core.application.use_cases.archive_task import ArchiveTaskUseCase
 from taskdog_core.domain.entities.task import TaskStatus
 from taskdog_core.domain.exceptions.task_exceptions import TaskNotFoundException

--- a/packages/taskdog-core/tests/application/use_cases/test_cancel_task_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_cancel_task_use_case.py
@@ -3,7 +3,7 @@
 import unittest
 from datetime import datetime
 
-from taskdog_core.application.dto.cancel_task_input import CancelTaskInput
+from taskdog_core.application.dto.single_task_inputs import CancelTaskInput
 from taskdog_core.application.use_cases.cancel_task import CancelTaskUseCase
 from taskdog_core.domain.entities.task import Task, TaskStatus
 from tests.application.use_cases.status_change_test_base import (

--- a/packages/taskdog-core/tests/application/use_cases/test_complete_task_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_complete_task_use_case.py
@@ -3,7 +3,7 @@
 import unittest
 from datetime import datetime
 
-from taskdog_core.application.dto.complete_task_input import CompleteTaskInput
+from taskdog_core.application.dto.single_task_inputs import CompleteTaskInput
 from taskdog_core.application.use_cases.complete_task import CompleteTaskUseCase
 from taskdog_core.domain.entities.task import Task, TaskStatus
 from taskdog_core.domain.exceptions.task_exceptions import TaskNotStartedError

--- a/packages/taskdog-core/tests/application/use_cases/test_pause_task_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_pause_task_use_case.py
@@ -3,7 +3,7 @@
 import unittest
 from datetime import datetime
 
-from taskdog_core.application.dto.pause_task_input import PauseTaskInput
+from taskdog_core.application.dto.single_task_inputs import PauseTaskInput
 from taskdog_core.application.use_cases.pause_task import PauseTaskUseCase
 from taskdog_core.domain.entities.task import Task, TaskStatus
 from tests.application.use_cases.status_change_test_base import (

--- a/packages/taskdog-core/tests/application/use_cases/test_remove_task_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_remove_task_use_case.py
@@ -3,7 +3,7 @@
 import unittest
 from unittest.mock import MagicMock
 
-from taskdog_core.application.dto.remove_task_input import RemoveTaskInput
+from taskdog_core.application.dto.single_task_inputs import RemoveTaskInput
 from taskdog_core.application.use_cases.remove_task import RemoveTaskUseCase
 from taskdog_core.domain.exceptions.task_exceptions import TaskNotFoundException
 from tests.test_fixtures import InMemoryDatabaseTestCase

--- a/packages/taskdog-core/tests/application/use_cases/test_reopen_task_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_reopen_task_use_case.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from parameterized import parameterized
 
-from taskdog_core.application.dto.reopen_task_input import ReopenTaskInput
+from taskdog_core.application.dto.single_task_inputs import ReopenTaskInput
 from taskdog_core.application.use_cases.reopen_task import ReopenTaskUseCase
 from taskdog_core.domain.entities.task import TaskStatus
 from taskdog_core.domain.exceptions.task_exceptions import (

--- a/packages/taskdog-core/tests/application/use_cases/test_restore_task_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_restore_task_use_case.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from taskdog_core.application.dto.restore_task_input import RestoreTaskInput
+from taskdog_core.application.dto.single_task_inputs import RestoreTaskInput
 from taskdog_core.application.use_cases.restore_task import RestoreTaskUseCase
 from taskdog_core.domain.entities.task import TaskStatus
 from taskdog_core.domain.exceptions.task_exceptions import (

--- a/packages/taskdog-core/tests/application/use_cases/test_start_task_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_start_task_use_case.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from taskdog_core.application.dto.start_task_input import StartTaskInput
+from taskdog_core.application.dto.single_task_inputs import StartTaskInput
 from taskdog_core.application.use_cases.start_task import StartTaskUseCase
 from taskdog_core.domain.entities.task import Task, TaskStatus
 from tests.application.use_cases.status_change_test_base import (


### PR DESCRIPTION
## Summary

- 8つの単一行type aliasファイルを`single_task_inputs.py`に統合
- ファイル増殖を削減し、メンテナンス性を向上

## Changes

- `single_task_inputs.py`を新規作成（8つのtype aliasを統合）
- `__init__.py`を更新してエクスポートを追加
- use cases、controllers、testsのインポートを更新
- 8つの個別type aliasファイルを削除

## Test plan

- [x] `make test-core` - 929 tests passed
- [x] `make typecheck` - Success (354 source files)

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)