### PR TITLE
refactor(server): eliminate config double-load on startup (#338)

### DIFF
--- a/packages/taskdog-server/src/taskdog_server/api/dependencies.py
+++ b/packages/taskdog-server/src/taskdog_server/api/dependencies.py
@@ -33,16 +33,20 @@ _api_context: ApiContext | None = None
 _connection_manager: ConnectionManager | None = None
 
 
-def initialize_api_context() -> ApiContext:
+def initialize_api_context(config: Config | None = None) -> ApiContext:
     """Initialize API context with all dependencies.
 
     This should be called once during application startup.
 
+    Args:
+        config: Optional pre-loaded configuration. If None, loads from file.
+
     Returns:
         ApiContext: Initialized context with all controllers
     """
-    # Load configuration
-    config = ConfigManager.load()
+    # Load configuration if not provided
+    if config is None:
+        config = ConfigManager.load()
     notes_repository = FileNotesRepository()
 
     # Initialize HolidayChecker if country is configured


### PR DESCRIPTION
## Summary
- Move `lifespan` into `create_app()` as a closure to share config via closure scope
- Add optional `config` parameter to `initialize_api_context()` for pre-loaded config
- Eliminate duplicate `ConfigManager.load()` calls on server startup

Closes #338

## Test plan
- [x] `make test-server` passes (241 tests)
- [x] `make typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)