### PR TITLE
refactor(server): replace global state with FastAPI app.state (#349)

### DIFF
--- a/packages/taskdog-server/tests/test_base.py
+++ b/packages/taskdog-server/tests/test_base.py
@@ -26,7 +26,7 @@ from taskdog_core.infrastructure.persistence.file_notes_repository import (
     FileNotesRepository,
 )
 from taskdog_server.api.context import ApiContext
-from taskdog_server.api.dependencies import set_api_context
+from taskdog_server.websocket.connection_manager import ConnectionManager
 
 
 class BaseApiRouterTest(unittest.TestCase):
@@ -98,7 +98,6 @@ class BaseApiRouterTest(unittest.TestCase):
             crud_controller=crud_controller,
             holiday_checker=None,
         )
-        set_api_context(api_context)
 
         # Create FastAPI app once with all routers
         app = FastAPI(
@@ -106,6 +105,10 @@ class BaseApiRouterTest(unittest.TestCase):
             description="Test instance",
             version="1.0.0",
         )
+
+        # Set context on app.state BEFORE creating TestClient
+        app.state.api_context = api_context
+        app.state.connection_manager = ConnectionManager()
 
         # Import and register all routers
         from taskdog_server.api.routers import (


### PR DESCRIPTION
## Summary

- Replace module-level global variables (`_api_context`, `_connection_manager`) with FastAPI's built-in `app.state`
- Add `Request` parameter to `get_api_context()` and `get_connection_manager()` for accessing `app.state`
- Update `set_api_context()` signature to accept FastAPI app instance
- Add `reset_app_state()` helper function for testing
- Update all test fixtures to use `app.state` pattern

## Benefits

- Proper dependency injection (no global mutable state)
- Easier to mock in tests (isolated `app.state` per test)
- Thread-safe by design
- Clear lifecycle management
- FastAPI idiomatic approach

## Test plan

- [x] `make test-server` passes (243 tests)
- [x] `make typecheck` passes
- [x] `make lint` passes
- [x] Pre-commit hooks pass

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)