### PR TITLE
refactor: centralize nested date-dict parsing utilities (#365)

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/shared/utils/datetime_parser.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/utils/datetime_parser.py
@@ -10,6 +10,7 @@ Error Handling:
 - Raises ValueError for malformed input (consumers handle translation)
 """
 
+from collections.abc import Iterable
 from datetime import date, datetime
 
 
@@ -75,3 +76,43 @@ def format_iso_date(d: date | None) -> str | None:
     if d is None:
         return None
     return d.isoformat()
+
+
+def parse_date_keyed_dict[T](str_dict: dict[str, T]) -> dict[date, T]:
+    """Parse dict with ISO date string keys to date object keys.
+
+    Args:
+        str_dict: Dictionary with ISO date string keys
+
+    Returns:
+        Dictionary with date object keys and original values
+
+    Raises:
+        ValueError: If any date key is malformed or empty
+    """
+    result: dict[date, T] = {}
+    for date_str, value in str_dict.items():
+        if not date_str:
+            raise ValueError("Empty date key")
+        result[datetime.fromisoformat(date_str).date()] = value
+    return result
+
+
+def parse_date_set(date_strings: Iterable[str]) -> set[date]:
+    """Parse iterable of ISO date strings to set of date objects.
+
+    Args:
+        date_strings: Iterable of ISO date strings
+
+    Returns:
+        Set of date objects
+
+    Raises:
+        ValueError: If any date string is malformed or empty
+    """
+    result: set[date] = set()
+    for date_str in date_strings:
+        if not date_str:
+            raise ValueError("Empty date string")
+        result.add(datetime.fromisoformat(date_str).date())
+    return result

--- a/packages/taskdog-ui/src/taskdog/infrastructure/api/converters/datetime_utils.py
+++ b/packages/taskdog-ui/src/taskdog/infrastructure/api/converters/datetime_utils.py
@@ -5,6 +5,9 @@ from datetime import datetime
 from typing import Any
 
 from taskdog_core.shared.utils.datetime_parser import (
+    parse_date_set as _core_parse_date_set,
+)
+from taskdog_core.shared.utils.datetime_parser import (
     parse_iso_date as _core_parse_date,
 )
 from taskdog_core.shared.utils.datetime_parser import (
@@ -157,4 +160,31 @@ def _parse_date_dict(data: dict[str, Any], field: str) -> dict[date_type, float]
             f"Failed to parse date dictionary field '{field}': {value_dict}",
             field=field,
             value=value_dict,
+        ) from e
+
+
+def _parse_date_set(data: dict[str, Any], field: str) -> set[date_type]:
+    """Parse list of ISO date strings to set of date objects.
+
+    Args:
+        data: Dictionary containing date list field
+        field: Field name to extract
+
+    Returns:
+        Set of date objects
+
+    Raises:
+        ConversionError: If any date string is malformed
+    """
+    value_list = data.get(field, [])
+    if not value_list:
+        return set()
+
+    try:
+        return _core_parse_date_set(value_list)
+    except (ValueError, TypeError) as e:
+        raise ConversionError(
+            f"Failed to parse date set field '{field}': {value_list}",
+            field=field,
+            value=value_list,
         ) from e


### PR DESCRIPTION
## Summary
- `datetime_parser.py` に `parse_date_keyed_dict()` と `parse_date_set()` を追加
- `datetime_utils.py` に `_parse_date_set()` ラッパーを追加
- `gantt_converters.py` を共通ユーティリティを使うようリファクタリング
- 重複した try-except パターンを削減 (約35行削減)

## Test plan
- [x] `make test-core` - 949 tests passed
- [x] `make test-ui` - 443 tests passed
- [x] `make typecheck` - no issues
- [x] `make lint` - all checks passed

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)