### PR TITLE
refactor(server): reduce code duplication in broadcaster.py using EventBroadcaster class

### DIFF
--- a/packages/taskdog-server/src/taskdog_server/websocket/broadcaster.py
+++ b/packages/taskdog-server/src/taskdog_server/websocket/broadcaster.py
@@ -38,9 +38,10 @@ class EventBroadcaster:
             payload: Event-specific data to broadcast
             exclude_client_id: Optional client ID to exclude from broadcast
         """
-        payload["type"] = event_type
-        payload["source_client_id"] = exclude_client_id
-        await self._manager.broadcast(payload, exclude_client_id)
+        broadcast_payload = payload.copy()
+        broadcast_payload["type"] = event_type
+        broadcast_payload["source_client_id"] = exclude_client_id
+        await self._manager.broadcast(broadcast_payload, exclude_client_id)
 
 
 async def broadcast_task_created(


### PR DESCRIPTION
## Summary
- Introduce `EventBroadcaster` class to centralize common broadcast logic
- Refactor all 6 `broadcast_*` functions to use `EventBroadcaster.broadcast_event()`
- Reduce code duplication (~70 lines of repeated patterns)

## Changes
- Add `EventBroadcaster` class with `broadcast_event()` method
- Common logic centralized: `type` and `source_client_id` field assignment, `manager.broadcast()` call
- Backward compatibility maintained (function signatures unchanged)

## Test plan
- [x] All server tests pass (243 tests)
- [x] Type check passes
- [x] Lint passes

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)