### PR TITLE
refactor(tui): introduce EventDispatcher pattern in WebSocketHandler (#380)

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/services/event_handler_registry.py
+++ b/packages/taskdog-ui/src/taskdog/tui/services/event_handler_registry.py
@@ -1,0 +1,190 @@
+"""Event handler registry for WebSocket messages.
+
+This module provides a registry pattern for dispatching WebSocket events
+to their appropriate handlers, replacing if-elif chains with a lookup table.
+"""
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from taskdog.tui.app import TaskdogTUI
+
+
+class EventHandlerRegistry:
+    """Registry for WebSocket event handlers.
+
+    This class maps event types to handler methods, providing a clean
+    dispatch mechanism for incoming WebSocket messages.
+    """
+
+    def __init__(self, app: "TaskdogTUI"):
+        """Initialize the event handler registry.
+
+        Args:
+            app: The TaskdogTUI application instance
+        """
+        self.app = app
+        self._handlers: dict[str, Callable[[dict[str, Any]], None]] = {}
+        self._register_handlers()
+
+    def _register_handlers(self) -> None:
+        """Register all event handlers."""
+        self._handlers["connected"] = self._handle_connected
+        self._handlers["task_created"] = self._handle_task_created
+        self._handlers["task_updated"] = self._handle_task_updated
+        self._handlers["task_deleted"] = self._handle_task_deleted
+        self._handlers["task_status_changed"] = self._handle_task_status_changed
+        self._handlers["schedule_optimized"] = self._handle_schedule_optimized
+
+    def dispatch(self, message: dict[str, Any]) -> None:
+        """Dispatch event to registered handler.
+
+        Args:
+            message: WebSocket message dictionary with type and data fields
+        """
+        event_type = message.get("type")
+        if isinstance(event_type, str) and (handler := self._handlers.get(event_type)):
+            handler(message)
+
+    def _handle_connected(self, message: dict[str, Any]) -> None:
+        """Handle WebSocket connection message.
+
+        Sets the client ID in the API client for message attribution.
+
+        Args:
+            message: Connection message with client_id
+        """
+        client_id = message.get("client_id")
+        if client_id:
+            self.app.api_client.set_client_id(client_id)
+
+    def _handle_task_created(self, message: dict[str, Any]) -> None:
+        """Handle task created event."""
+        self._reload_tasks()
+        task_name = message.get("task_name", "Unknown")
+        task_id = message.get("task_id")
+        display_source = self._get_display_source(message)
+        msg = self._build_task_message(
+            "added", task_name, task_id=task_id, source_client_id=display_source
+        )
+        self.app.notify(msg, severity="information")
+
+    def _handle_task_updated(self, message: dict[str, Any]) -> None:
+        """Handle task updated event."""
+        self._reload_tasks()
+        task_name = message.get("task_name", "Unknown")
+        task_id = message.get("task_id")
+        display_source = self._get_display_source(message)
+        fields = message.get("updated_fields", [])
+        details = ", ".join(fields)
+        msg = self._build_task_message(
+            "updated",
+            task_name,
+            task_id=task_id,
+            details=details,
+            source_client_id=display_source,
+        )
+        self.app.notify(msg, severity="information")
+
+    def _handle_task_deleted(self, message: dict[str, Any]) -> None:
+        """Handle task deleted event."""
+        self._reload_tasks()
+        task_name = message.get("task_name", "Unknown")
+        task_id = message.get("task_id")
+        display_source = self._get_display_source(message)
+        msg = self._build_task_message(
+            "deleted", task_name, task_id=task_id, source_client_id=display_source
+        )
+        self.app.notify(msg, severity="warning")
+
+    def _handle_task_status_changed(self, message: dict[str, Any]) -> None:
+        """Handle task status changed event."""
+        self._reload_tasks()
+        task_name = message.get("task_name", "Unknown")
+        task_id = message.get("task_id")
+        display_source = self._get_display_source(message)
+        old_status = message.get("old_status", "")
+        new_status = message.get("new_status", "")
+        details = f"{old_status} → {new_status}"
+        msg = self._build_task_message(
+            "status changed",
+            task_name,
+            task_id=task_id,
+            details=details,
+            source_client_id=display_source,
+        )
+        self.app.notify(msg, severity="information")
+
+    def _handle_schedule_optimized(self, message: dict[str, Any]) -> None:
+        """Handle schedule optimization WebSocket event.
+
+        Reloads tasks and shows optimization result notification.
+
+        Args:
+            message: Schedule optimization message with counts and algorithm
+        """
+        from taskdog.tui.messages import TUIMessageBuilder
+
+        self._reload_tasks()
+        scheduled_count = message.get("scheduled_count", 0)
+        failed_count = message.get("failed_count", 0)
+        algorithm = message.get("algorithm", "unknown")
+        msg = TUIMessageBuilder.schedule_optimized(
+            algorithm, scheduled_count, failed_count
+        )
+        self.app.notify(msg, severity="information")
+
+    def _reload_tasks(self) -> None:
+        """Reload tasks via TaskUIManager."""
+        if self.app.task_ui_manager:
+            self.app.call_later(
+                self.app.task_ui_manager.load_tasks, keep_scroll_position=True
+            )
+
+    def _get_display_source(self, message: dict[str, Any]) -> str | None:
+        """Get display source client ID if different from this client.
+
+        Args:
+            message: Message containing source_client_id
+
+        Returns:
+            Source client ID if different from this client, None otherwise
+        """
+        source_client_id = message.get("source_client_id")
+        if (
+            isinstance(source_client_id, str)
+            and source_client_id != self.app.api_client.client_id
+        ):
+            return source_client_id
+        return None
+
+    def _build_task_message(
+        self,
+        action: str,
+        task_name: str,
+        task_id: int | None = None,
+        details: str | None = None,
+        source_client_id: str | None = None,
+    ) -> str:
+        """Build task event notification message.
+
+        Args:
+            action: Action performed (added, updated, deleted, status changed)
+            task_name: Name of the task
+            task_id: Optional task ID
+            details: Optional additional details
+            source_client_id: Optional source client ID
+
+        Returns:
+            Formatted notification message
+        """
+        from taskdog.tui.messages import TUIMessageBuilder
+
+        return TUIMessageBuilder.websocket_event(
+            action,
+            task_name,
+            task_id=task_id,
+            details=details or "",
+            source_client_id=source_client_id,
+        )

--- a/packages/taskdog-ui/src/taskdog/tui/services/websocket_handler.py
+++ b/packages/taskdog-ui/src/taskdog/tui/services/websocket_handler.py
@@ -6,6 +6,8 @@ the main app class for better separation of concerns.
 
 from typing import TYPE_CHECKING, Any
 
+from taskdog.tui.services.event_handler_registry import EventHandlerRegistry
+
 if TYPE_CHECKING:
     from taskdog.tui.app import TaskdogTUI
 
@@ -13,8 +15,8 @@ if TYPE_CHECKING:
 class WebSocketHandler:
     """Handles incoming WebSocket messages for the TUI.
 
-    This class encapsulates all WebSocket message processing logic,
-    delegating UI updates and notifications to the app instance.
+    This class receives WebSocket messages and delegates processing
+    to the EventHandlerRegistry for dispatch.
     """
 
     def __init__(self, app: "TaskdogTUI"):
@@ -24,6 +26,7 @@ class WebSocketHandler:
             app: The TaskdogTUI application instance
         """
         self.app = app
+        self.registry = EventHandlerRegistry(app)
 
     def handle_message(self, message: dict[str, Any]) -> None:
         """Handle incoming WebSocket messages.
@@ -31,119 +34,4 @@ class WebSocketHandler:
         Args:
             message: WebSocket message dictionary with type and data fields
         """
-
-        msg_type = message.get("type")
-
-        # Handle connection message - set client ID in API client
-        if msg_type == "connected":
-            self._handle_connected(message)
-            return
-
-        # Handle task-related events
-        if msg_type in (
-            "task_created",
-            "task_updated",
-            "task_deleted",
-            "task_status_changed",
-        ):
-            self._handle_task_event(message, msg_type)
-        elif msg_type == "schedule_optimized":
-            self._handle_schedule_optimized(message)
-
-    def _handle_connected(self, message: dict[str, Any]) -> None:
-        """Handle WebSocket connection message.
-
-        Sets the client ID in the API client for message attribution.
-
-        Args:
-            message: Connection message with client_id
-        """
-        client_id = message.get("client_id")
-        if client_id:
-            self.app.api_client.set_client_id(client_id)
-
-    def _handle_task_event(self, message: dict[str, Any], msg_type: str) -> None:
-        """Handle task-related WebSocket events.
-
-        Reloads tasks and shows appropriate notifications based on event type.
-
-        Args:
-            message: Task event message
-            msg_type: Type of task event (created, updated, deleted, status_changed)
-        """
-        from taskdog.tui.messages import TUIMessageBuilder
-
-        # Reload tasks on any task change via TaskUIManager
-        if self.app.task_ui_manager:
-            self.app.call_later(
-                self.app.task_ui_manager.load_tasks, keep_scroll_position=True
-            )
-
-        # Show notification with source client ID if available
-        task_name = message.get("task_name", "Unknown")
-        task_id = message.get("task_id")
-        source_client_id = message.get("source_client_id")
-
-        # Only show "by {client_id}" if the source is different from this client
-        display_source = None
-        if source_client_id and source_client_id != self.app.api_client.client_id:
-            display_source = source_client_id
-
-        if msg_type == "task_created":
-            msg = TUIMessageBuilder.websocket_event(
-                "added", task_name, task_id=task_id, source_client_id=display_source
-            )
-            self.app.notify(msg, severity="information")
-        elif msg_type == "task_updated":
-            fields = message.get("updated_fields", [])
-            details = ", ".join(fields)
-            msg = TUIMessageBuilder.websocket_event(
-                "updated",
-                task_name,
-                task_id=task_id,
-                details=details,
-                source_client_id=display_source,
-            )
-            self.app.notify(msg, severity="information")
-        elif msg_type == "task_deleted":
-            msg = TUIMessageBuilder.websocket_event(
-                "deleted", task_name, task_id=task_id, source_client_id=display_source
-            )
-            self.app.notify(msg, severity="warning")
-        elif msg_type == "task_status_changed":
-            old_status = message.get("old_status", "")
-            new_status = message.get("new_status", "")
-            details = f"{old_status} → {new_status}"
-            msg = TUIMessageBuilder.websocket_event(
-                "status changed",
-                task_name,
-                task_id=task_id,
-                details=details,
-                source_client_id=display_source,
-            )
-            self.app.notify(msg, severity="information")
-
-    def _handle_schedule_optimized(self, message: dict[str, Any]) -> None:
-        """Handle schedule optimization WebSocket event.
-
-        Reloads tasks and shows optimization result notification.
-
-        Args:
-            message: Schedule optimization message with counts and algorithm
-        """
-        from taskdog.tui.messages import TUIMessageBuilder
-
-        # Reload tasks on schedule optimization via TaskUIManager
-        if self.app.task_ui_manager:
-            self.app.call_later(
-                self.app.task_ui_manager.load_tasks, keep_scroll_position=True
-            )
-
-        # Show notification
-        scheduled_count = message.get("scheduled_count", 0)
-        failed_count = message.get("failed_count", 0)
-        algorithm = message.get("algorithm", "unknown")
-        msg = TUIMessageBuilder.schedule_optimized(
-            algorithm, scheduled_count, failed_count
-        )
-        self.app.notify(msg, severity="information")
+        self.registry.dispatch(message)

--- a/packages/taskdog-ui/tests/tui/services/test_event_handler_registry.py
+++ b/packages/taskdog-ui/tests/tui/services/test_event_handler_registry.py
@@ -1,0 +1,187 @@
+"""Tests for EventHandlerRegistry."""
+
+import unittest
+from unittest.mock import MagicMock
+
+
+class TestEventHandlerRegistry(unittest.TestCase):
+    """Test cases for EventHandlerRegistry."""
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        self.mock_app = MagicMock()
+        self.mock_app.api_client = MagicMock()
+        self.mock_app.api_client.client_id = "test-client-id"
+        self.mock_app.task_ui_manager = MagicMock()
+        self.mock_app.call_later = MagicMock()
+        self.mock_app.notify = MagicMock()
+
+        # Import here to avoid circular import issues
+        from taskdog.tui.services.event_handler_registry import EventHandlerRegistry
+
+        self.registry = EventHandlerRegistry(self.mock_app)
+
+    def test_handlers_registered(self) -> None:
+        """Test that all expected handlers are registered."""
+        expected_handlers = [
+            "connected",
+            "task_created",
+            "task_updated",
+            "task_deleted",
+            "task_status_changed",
+            "schedule_optimized",
+        ]
+        for event_type in expected_handlers:
+            self.assertIn(event_type, self.registry._handlers)
+
+    def test_dispatch_connected_sets_client_id(self) -> None:
+        """Test that connected event sets client ID in API client."""
+        message = {"type": "connected", "client_id": "new-client-id"}
+        self.registry.dispatch(message)
+        self.mock_app.api_client.set_client_id.assert_called_once_with("new-client-id")
+
+    def test_dispatch_connected_without_client_id(self) -> None:
+        """Test that connected event without client_id doesn't fail."""
+        message = {"type": "connected"}
+        self.registry.dispatch(message)
+        self.mock_app.api_client.set_client_id.assert_not_called()
+
+    def test_dispatch_task_created_reloads_tasks(self) -> None:
+        """Test that task_created event triggers task reload."""
+        message = {
+            "type": "task_created",
+            "task_id": 1,
+            "task_name": "New Task",
+        }
+        self.registry.dispatch(message)
+        self.mock_app.call_later.assert_called_once()
+        self.mock_app.notify.assert_called_once()
+
+    def test_dispatch_task_updated_shows_fields(self) -> None:
+        """Test that task_updated event shows updated fields."""
+        message = {
+            "type": "task_updated",
+            "task_id": 1,
+            "task_name": "Updated Task",
+            "updated_fields": ["priority", "deadline"],
+        }
+        self.registry.dispatch(message)
+        self.mock_app.call_later.assert_called_once()
+        self.mock_app.notify.assert_called_once()
+
+    def test_dispatch_task_deleted_shows_warning(self) -> None:
+        """Test that task_deleted event shows warning notification."""
+        message = {
+            "type": "task_deleted",
+            "task_id": 1,
+            "task_name": "Deleted Task",
+        }
+        self.registry.dispatch(message)
+        self.mock_app.call_later.assert_called_once()
+        self.mock_app.notify.assert_called_once()
+        # Verify warning severity
+        call_args = self.mock_app.notify.call_args
+        self.assertEqual(call_args.kwargs.get("severity"), "warning")
+
+    def test_dispatch_task_status_changed_shows_transition(self) -> None:
+        """Test that task_status_changed event shows status transition."""
+        message = {
+            "type": "task_status_changed",
+            "task_id": 1,
+            "task_name": "Task",
+            "old_status": "PENDING",
+            "new_status": "IN_PROGRESS",
+        }
+        self.registry.dispatch(message)
+        self.mock_app.call_later.assert_called_once()
+        self.mock_app.notify.assert_called_once()
+
+    def test_dispatch_schedule_optimized(self) -> None:
+        """Test that schedule_optimized event shows optimization result."""
+        message = {
+            "type": "schedule_optimized",
+            "scheduled_count": 5,
+            "failed_count": 1,
+            "algorithm": "greedy",
+        }
+        self.registry.dispatch(message)
+        self.mock_app.call_later.assert_called_once()
+        self.mock_app.notify.assert_called_once()
+
+    def test_dispatch_unknown_event_type_ignored(self) -> None:
+        """Test that unknown event types are silently ignored."""
+        message = {"type": "unknown_event_type"}
+        # Should not raise
+        self.registry.dispatch(message)
+        self.mock_app.notify.assert_not_called()
+
+    def test_dispatch_without_type_ignored(self) -> None:
+        """Test that messages without type are silently ignored."""
+        message = {"data": "something"}
+        # Should not raise
+        self.registry.dispatch(message)
+        self.mock_app.notify.assert_not_called()
+
+    def test_source_client_id_hidden_when_same(self) -> None:
+        """Test that source client ID is not shown when same as this client."""
+        message = {
+            "type": "task_created",
+            "task_id": 1,
+            "task_name": "Task",
+            "source_client_id": "test-client-id",  # Same as mock_app.api_client.client_id
+        }
+        self.registry.dispatch(message)
+        # The source should not be displayed in the notification
+        result = self.registry._get_display_source(message)
+        self.assertIsNone(result)
+
+    def test_source_client_id_shown_when_different(self) -> None:
+        """Test that source client ID is shown when different from this client."""
+        message = {
+            "type": "task_created",
+            "task_id": 1,
+            "task_name": "Task",
+            "source_client_id": "other-client-id",
+        }
+        result = self.registry._get_display_source(message)
+        self.assertEqual(result, "other-client-id")
+
+    def test_no_task_ui_manager_does_not_fail(self) -> None:
+        """Test that events don't fail when task_ui_manager is None."""
+        self.mock_app.task_ui_manager = None
+        message = {
+            "type": "task_created",
+            "task_id": 1,
+            "task_name": "Task",
+        }
+        # Should not raise
+        self.registry.dispatch(message)
+        self.mock_app.notify.assert_called_once()
+
+
+class TestWebSocketHandler(unittest.TestCase):
+    """Test cases for WebSocketHandler delegation."""
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        self.mock_app = MagicMock()
+        self.mock_app.api_client = MagicMock()
+        self.mock_app.api_client.client_id = "test-client-id"
+        self.mock_app.task_ui_manager = MagicMock()
+        self.mock_app.call_later = MagicMock()
+        self.mock_app.notify = MagicMock()
+
+    def test_handle_message_delegates_to_registry(self) -> None:
+        """Test that WebSocketHandler delegates to EventHandlerRegistry."""
+        from taskdog.tui.services.websocket_handler import WebSocketHandler
+
+        handler = WebSocketHandler(self.mock_app)
+        message = {"type": "connected", "client_id": "new-client"}
+
+        handler.handle_message(message)
+
+        self.mock_app.api_client.set_client_id.assert_called_once_with("new-client")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replace if-elif chain in `WebSocketHandler.handle_message()` with `EventHandlerRegistry` pattern
- Add comprehensive tests for the new registry
- Improve extensibility: adding new events now requires only adding an entry to `_register_handlers()` and the corresponding handler method

Closes #380

## Test plan
- [x] All existing tests pass (`make test-ui`)
- [x] Type check passes (`make typecheck`)
- [x] New tests cover EventHandlerRegistry dispatch logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)