### PR TITLE
chore: add markdownlint and actionlint to pre-commit hooks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,11 +33,13 @@ Please delete options that are not relevant.
 <!-- Describe the tests you ran to verify your changes -->
 
 ### Test Environment
+
 - OS:
 - Python version:
 - UV version:
 
 ### Tests Performed
+
 - [ ] Unit tests pass (`make test`)
 - [ ] Added new tests for new features
 - [ ] Manual testing completed
@@ -80,12 +82,12 @@ Please check all that apply:
 
 <!-- If applicable, add screenshots or command output to demonstrate your changes -->
 
-```
+```text
 Before:
 
 ```
 
-```
+```text
 After:
 
 ```
@@ -107,6 +109,7 @@ After:
 ---
 
 **For Maintainers:**
+
 - [ ] Reviewed for security implications
 - [ ] Verified test coverage
 - [ ] Checked for breaking changes

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,38 @@
+# Markdownlint configuration
+# See: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+
+# Line length - disabled (code blocks, tables often exceed)
+MD013: false
+
+# Inline HTML - disabled (badges, details/summary tags)
+MD033: false
+
+# First line should be top-level heading - disabled (CLAUDE.md, etc.)
+MD041: false
+
+# Emphasis as heading - disabled (stylistic choice in docs)
+MD036: false
+
+# Trailing punctuation in heading - allow Japanese punctuation
+MD026:
+  punctuation: ".,;:!"
+
+# Code block style
+MD046:
+  style: fenced
+
+# Fenced code should have a language specified
+MD040: true
+
+# Unordered list style - consistent dashes
+MD004:
+  style: dash
+
+# Ordered list item prefix - disabled (1. 2. 3. style is intentional)
+MD029: false
+
+# No bare URLs - disabled (often useful in docs)
+MD034: false
+
+# Link fragments - disabled (some generated anchors differ)
+MD051: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,20 @@ repos:
         args: [--config-file=pyproject.toml, packages/taskdog-core/src/, packages/taskdog-server/src/, packages/taskdog-ui/src/]
         pass_filenames: false
 
+  # Markdown linter
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.17.2
+    hooks:
+      - id: markdownlint-cli2
+        args: [--fix]
+        exclude: ^\.venv/
+
+  # GitHub Actions linter
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint
+
   # Standard pre-commit hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,12 +11,14 @@ Taskdog is a task management system built with Python. It provides a CLI/TUI int
 The repository uses UV workspace with three packages:
 
 **taskdog-core** (`packages/taskdog-core/`): Core business logic and infrastructure
+
 - Domain entities, use cases, repositories, validators
 - SQLite persistence layer with transactional writes
 - Schedule optimization algorithms (9 strategies)
 - No UI dependencies - pure business logic
 
 **taskdog-server** (`packages/taskdog-server/`): FastAPI REST API server
+
 - Depends on: taskdog-core
 - FastAPI application with automatic OpenAPI docs
 - API routers: tasks, lifecycle, relationships, analytics
@@ -24,6 +26,7 @@ The repository uses UV workspace with three packages:
 - Health check and comprehensive error handling
 
 **taskdog-ui** (`packages/taskdog-ui/`): CLI and TUI interfaces
+
 - Depends on: taskdog-core
 - Click-based CLI commands with Rich output
 - Textual-based full-screen TUI
@@ -35,6 +38,7 @@ The repository uses UV workspace with three packages:
 **Tasks**: Stored in SQLite database `tasks.db` at `$XDG_DATA_HOME/taskdog/tasks.db` (fallback: `~/.local/share/taskdog/tasks.db`)
 
 **Config**: Optional TOML at `$XDG_CONFIG_HOME/taskdog/config.toml` (fallback: `~/.config/taskdog/config.toml`)
+
 - Sections: `[api]`, `[optimization]`, `[task]`, `[time]`, `[region]`, `[storage]`
 - Settings:
   - API: cors_origins (for future Web UI)
@@ -115,11 +119,13 @@ journalctl --user -u taskdog-server -f   # View logs in real-time
 ## Working with the Monorepo
 
 **Package Navigation:**
+
 - Core business logic changes: `packages/taskdog-core/src/taskdog_core/`
 - API server changes: `packages/taskdog-server/src/taskdog_server/`
 - CLI/TUI changes: `packages/taskdog-ui/src/taskdog/`
 
 **Adding Features:**
+
 1. Add domain entities/use cases in `taskdog-core`
 2. Expose via controllers (TaskController/QueryController) in `taskdog-core`
 3. Add API endpoints in `taskdog-server` (if needed)
@@ -127,17 +133,20 @@ journalctl --user -u taskdog-server -f   # View logs in real-time
 5. Add TUI commands in `taskdog-ui` (if needed)
 
 **Testing Workflow:**
+
 - Test core changes: `make test-core`
 - Test server changes: `make test-server`
 - Test UI changes: `make test-ui`
 - Test everything: `make test`
 
 **Type Checking:**
+
 - Mypy configured with progressive type checking (Phase 4)
 - Some modules temporarily ignored (see pyproject.toml `[[tool.mypy.overrides]]`)
 - Run `make typecheck` before committing
 
 **Import Conventions:**
+
 - Core package: `from taskdog_core.domain.entities.task import Task`
 - Server package: `from taskdog_server.api.models.requests import CreateTaskRequest`
 - UI package: `from taskdog.cli.commands.add import add_command`
@@ -152,11 +161,13 @@ Clean Architecture with 5 layers across three packages: **Domain** ← **Applica
 **taskdog-core** contains Domain, Application, Infrastructure (persistence), and Shared layers:
 
 **Domain** (`packages/taskdog-core/src/taskdog_core/domain/`): Core business logic, no external dependencies
+
 - `entities/`: Task, TaskStatus
 - `services/`: TimeTracker (records timestamps)
 - `exceptions/`: TaskNotFoundException, TaskValidationError, TaskAlreadyFinishedError, TaskNotStartedError
 
 **Application** (`packages/taskdog-core/src/taskdog_core/application/`): Business logic orchestration
+
 - `use_cases/`: Each business operation is a separate use case with `execute(input_dto)` method
   - Base classes: `UseCase[TInput, TOutput]`, `StatusChangeUseCase` (Template Method pattern)
   - Examples: CreateTaskUseCase, StartTaskUseCase, OptimizeScheduleUseCase
@@ -170,12 +181,14 @@ Clean Architecture with 5 layers across three packages: **Domain** ← **Applica
 - `dto/`: Input/Output DTOs (CreateTaskRequest, OptimizationResult, SchedulingFailure, etc.)
 
 **Infrastructure** (`packages/taskdog-core/src/taskdog_core/infrastructure/`): External concerns
+
 - `persistence/database/`: SqliteTaskRepository (transactional writes, indexed queries, efficient lookups)
 - `persistence/file/`: FileNotesRepository (markdown note storage)
 - `persistence/mappers/`: TaskDbMapper for entity-to-database mapping
 - `config/`: ConfigManager (loads TOML config with fallback to defaults)
 
 **Controllers** (`packages/taskdog-core/src/taskdog_core/controllers/`): Unified interface for task operations
+
 - `BaseTaskController`: Abstract base class for all task controllers
 - `TaskCrudController`: Orchestrates CRUD operations (create, read, update, delete)
   - Methods: create_task, update_task, delete_task, hard_delete_task
@@ -195,11 +208,13 @@ Clean Architecture with 5 layers across three packages: **Domain** ← **Applica
 - All controllers used by: API server directly; CLI/TUI via HTTP API
 
 **Shared** (`packages/taskdog-core/src/taskdog_core/shared/`): Cross-cutting utilities
+
 - `utils/xdg_utils.py`: XDG paths (get_tasks_file, get_config_file)
 
 **taskdog-server** contains FastAPI-specific presentation layer:
 
 **API** (`packages/taskdog-server/src/taskdog_server/api/`):
+
 - `app.py`: FastAPI application setup with CORS, exception handlers
 - `routers/`: API route handlers
   - `tasks.py`: Task CRUD operations
@@ -213,20 +228,24 @@ Clean Architecture with 5 layers across three packages: **Domain** ← **Applica
 **taskdog-ui** contains CLI/TUI-specific presentation layer:
 
 **CLI** (`packages/taskdog-ui/src/taskdog/cli/`):
+
 - `cli_main.py`: Click application entry point
 - `commands/`: Click command implementations (add, start, done, table, gantt, etc.)
 - `context.py`: CliContext (DI container for console_writer, api_client, config, holiday_checker)
 - Error handlers: `@handle_task_errors`, `@handle_command_errors` decorators
 
 **Console** (`packages/taskdog-ui/src/taskdog/console/`):
+
 - `ConsoleWriter` abstraction for all CLI output
 - `RichConsoleWriter` implementation (Rich-based formatting)
 
 **Renderers** (`packages/taskdog-ui/src/taskdog/renderers/`):
+
 - `RichTableRenderer`: Task table with all fields, strikethrough for finished tasks
 - `RichGanttRenderer`: Timeline with daily hours, status symbols (◆), weekend coloring, workload summary
 
 **TUI** (`packages/taskdog-ui/src/taskdog/tui/`):
+
 - `app.py`: Textual application main screen
 - `commands/`: Command Pattern (CommandRegistry, CommandFactory, TUICommandBase)
 - `screens/`, `widgets/`, `forms/`: UI components
@@ -234,9 +253,11 @@ Clean Architecture with 5 layers across three packages: **Domain** ← **Applica
 - `styles/`: TCSS stylesheets (included via package_data)
 
 **Infrastructure** (`packages/taskdog-ui/src/taskdog/infrastructure/`):
+
 - `api_client.py`: HTTP client for communicating with taskdog-server (optional remote mode)
 
 **Shared** (`packages/taskdog-ui/src/taskdog/shared/`):
+
 - `click_types/`: Custom Click parameter types (DateTimeWithDefault adds 18:00:00 when only date provided)
 
 ### Dependency Injection
@@ -249,6 +270,7 @@ Clean Architecture with 5 layers across three packages: **Domain** ← **Applica
 ### Key Components
 
 **Task Entity** (`packages/taskdog-core/src/taskdog_core/domain/entities/task.py`)
+
 - Fields: id, name, priority, status, planned_start/end, deadline, actual_start/end, estimated_duration, daily_allocations, is_fixed, depends_on, actual_daily_hours, tags, is_archived
 - Statuses: PENDING, IN_PROGRESS, COMPLETED, CANCELED
 - Always-Valid Entity: validates invariants in `__post_init__` (name non-empty, priority > 0, estimated_duration > 0 if set, tags non-empty and unique)
@@ -256,25 +278,30 @@ Clean Architecture with 5 layers across three packages: **Domain** ← **Applica
 - Archive Design: is_archived is a boolean flag (not a status) to preserve original task state when soft-deleted
 
 **Repository** (`packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_task_repository.py`)
+
 - `SqliteTaskRepository`: Transactional writes with automatic rollback on errors
 - Indexed queries for efficient lookups and filtering
 - Connection pooling and proper resource management
 - Used by API server only (CLI/TUI access via HTTP API, not directly)
 
 **TimeTracker** (`packages/taskdog-core/src/taskdog_core/domain/services/time_tracker.py`):
+
 - Records actual_start (→IN_PROGRESS), actual_end (→COMPLETED/CANCELED), clears both (→PENDING)
 
 **Renderers** (`packages/taskdog-ui/src/taskdog/renderers/`)
+
 - `RichTableRenderer`: Task table with all fields, strikethrough for finished tasks (uses task.is_finished)
 - `RichGanttRenderer`: Timeline with daily hours, status symbols (◆), weekend coloring, workload summary, strikethrough for finished tasks
 - Strikethrough applied only to COMPLETED/CANCELED tasks (task.is_finished), not archived tasks
 
 **CLI Patterns** (`packages/taskdog-ui/src/taskdog/cli/`)
+
 - `update_helpers.py`: Shared helper for single-field updates (deadline, priority, estimate, rename)
 - `error_handler.py`: `@handle_task_errors`, `@handle_command_errors` decorators
 - Batch operations: Loop + per-task error handling (start, done, pause, rm, archive)
 
 **Controllers** (`packages/taskdog-core/src/taskdog_core/controllers/`)
+
 - `TaskCrudController`: Orchestrates CRUD operations (create, update, delete)
 - `TaskLifecycleController`: Orchestrates lifecycle operations (start, complete, pause, cancel, reopen)
 - `TaskRelationshipController`: Orchestrates relationship operations (dependencies, tags, log hours)
@@ -285,6 +312,7 @@ Clean Architecture with 5 layers across three packages: **Domain** ← **Applica
 - Used by: API server directly; CLI/TUI via HTTP API client
 
 **TUI Command Pattern** (`packages/taskdog-ui/src/taskdog/tui/commands/`)
+
 - `@command_registry.register("name")` for automatic registration
 - `TUICommandBase`: Abstract base with helpers (get_selected_task, reload_tasks, notify_*)
 - `StatusChangeCommandBase`: Template Method for status changes
@@ -292,6 +320,7 @@ Clean Architecture with 5 layers across three packages: **Domain** ← **Applica
 - `TaskService`: Facade wrapping TaskController + QueryController for TUI
 
 **API Patterns** (`packages/taskdog-server/src/taskdog_server/api/`)
+
 - FastAPI routers: tasks, lifecycle, relationships, analytics, notes, websocket
 - Pydantic models for automatic request/response validation
 - Dependency injection via `dependencies.py`:
@@ -317,6 +346,7 @@ Clean Architecture with 5 layers across three packages: **Domain** ← **Applica
 Commands in `src/presentation/cli/commands/`, registered in `cli.py`:
 
 **Creation & Viewing**
+
 - `add "Task name" [--priority N] [--fixed] [--depends-on ID] [--tag TAG]`: Create task (multiple -d/-t allowed)
 - `table [--sort FIELD] [--reverse] [--all] [--fields LIST] [--status STATUS] [--tag TAG] [--start-date] [--end-date]`: Table view with filtering
 - `today [--sort FIELD] [--reverse]`: Today's tasks (deadline today, planned includes today, or IN_PROGRESS)
@@ -324,6 +354,7 @@ Commands in `src/presentation/cli/commands/`, registered in `cli.py`:
 - `show ID [--raw]`: Task details + notes (markdown rendered or raw)
 
 **Status Management** (support multiple IDs)
+
 - `start ID...`: Start tasks
 - `done ID...`: Complete tasks
 - `pause ID...`: Reset to PENDING, clear timestamps
@@ -331,10 +362,12 @@ Commands in `src/presentation/cli/commands/`, registered in `cli.py`:
 - `reopen ID...`: Reset to PENDING (no dependency validation)
 
 **Updates** (single-field commands use `update_helpers.py`)
+
 - `deadline ID DATE`, `priority ID N`, `rename ID NAME`, `estimate ID HOURS`, `schedule ID START [END]`
 - `update ID [--priority] [--status] [...]`: Multi-field update
 
 **Management**
+
 - `rm ID... [--hard]`: Soft delete (default, sets is_archived=true) or hard delete (permanent removal)
 - `restore ID...`: Restore soft-deleted tasks (sets is_archived=false)
 - `add-dependency TASK_ID DEPENDS_ON_ID`: Add dependency (DFS cycle detection)
@@ -342,10 +375,12 @@ Commands in `src/presentation/cli/commands/`, registered in `cli.py`:
 - `tags [ID] [TAG...]`: List all tags, show task tags, or set task tags
 
 **Time & Optimization**
+
 - `log-hours ID HOURS [--date DATE]`: Log actual hours
 - `optimize [--start-date] [--max-hours-per-day] [--algorithm] [--force]`: Auto-schedule (9 strategies available)
 
 **Visualization**
+
 - `gantt [--sort] [--reverse] [--all] [--status] [--tag] [--start-date] [--end-date]`: Gantt chart with workload summary (default sort: deadline, shows non-archived tasks by default)
 - `table [--sort] [--reverse] [--all] [--fields] [--status] [--tag] [--start-date] [--end-date]`: Task table with filtering (shows non-archived tasks by default)
 - `today`: Today's tasks (deadline today, planned includes today, or IN_PROGRESS)
@@ -355,6 +390,7 @@ Commands in `src/presentation/cli/commands/`, registered in `cli.py`:
 - `stats [--period all|7d|30d] [--focus all|basic|time|estimation|deadline|priority|trends]`: Analytics
 
 **Interactive**
+
 - `note ID`: Edit markdown notes ($EDITOR)
 - `tui`: Full-screen TUI (Textual) with keyboard shortcuts
   - `a`: Add task, `s`: Start, `P`: Pause, `d`: Done, `c`: Cancel, `R`: Reopen
@@ -370,11 +406,13 @@ Commands in `src/presentation/cli/commands/`, registered in `cli.py`:
 **Core Philosophy**: Taskdog is designed for **individual task management** following GTD principles. See [DESIGN_PHILOSOPHY.md](DESIGN_PHILOSOPHY.md) for detailed rationale.
 
 **Key Design Decisions**:
+
 - **No parent-child relationships**: Use dependencies + tags + notes instead (keeps data model simple, optimizer predictable)
 - **Individual over team**: No collaboration features, no cloud sync (privacy-first, local-first)
 - **Transparent algorithms**: 9 scheduling strategies you can understand (no black-box AI)
 
 **When adding new features, ask**:
+
 1. Does this benefit individual users? (Not teams)
 2. Does this maintain simplicity? (Every feature has a cost)
 3. Is this transparent? (No black boxes)
@@ -412,6 +450,7 @@ Commands in `src/presentation/cli/commands/`, registered in `cli.py`:
 The FastAPI server (`taskdog-server`) provides a REST API with automatic OpenAPI documentation at `/docs`:
 
 **Task Management** (`/api/v1/tasks/`)
+
 - `GET /api/v1/tasks/` - List tasks with filtering (status, tags, date ranges, archived)
 - `POST /api/v1/tasks/` - Create new task
 - `GET /api/v1/tasks/{task_id}` - Get task details
@@ -419,6 +458,7 @@ The FastAPI server (`taskdog-server`) provides a REST API with automatic OpenAPI
 - `DELETE /api/v1/tasks/{task_id}?hard=false` - Delete task (soft by default)
 
 **Lifecycle Operations** (`/api/v1/tasks/{task_id}/`)
+
 - `POST /api/v1/tasks/{task_id}/start` - Start task
 - `POST /api/v1/tasks/{task_id}/complete` - Complete task
 - `POST /api/v1/tasks/{task_id}/pause` - Pause task (reset to PENDING)
@@ -429,30 +469,36 @@ The FastAPI server (`taskdog-server`) provides a REST API with automatic OpenAPI
 - `POST /api/v1/tasks/{task_id}/restore` - Restore archived task
 
 **Relationships** (`/api/v1/tasks/{task_id}/`)
+
 - `POST /api/v1/tasks/{task_id}/dependencies` - Add dependency
 - `DELETE /api/v1/tasks/{task_id}/dependencies/{dep_id}` - Remove dependency
 - `PUT /api/v1/tasks/{task_id}/tags` - Set task tags (replaces existing; tags also returned in task details)
 
 **Notes** (`/api/v1/tasks/{task_id}/notes/`)
+
 - `GET /api/v1/tasks/{task_id}/notes` - Get task notes (markdown)
 - `PUT /api/v1/tasks/{task_id}/notes` - Update task notes
 - `DELETE /api/v1/tasks/{task_id}/notes` - Delete task notes
 
 **Analytics** (`/api/v1/`)
+
 - `GET /api/v1/statistics` - Task statistics (period, focus filters)
 - `GET /api/v1/gantt` - Gantt chart data (date ranges, filters)
 - `GET /api/v1/tags/statistics` - Tag statistics
 
 **Optimization** (`/api/v1/`)
+
 - `POST /api/v1/optimize` - Run schedule optimization with algorithm selection
 - `GET /api/v1/algorithms` - List available optimization algorithms
 
 **Real-time Updates**:
+
 - `WebSocket /ws` - Real-time task notifications (task_created, task_updated, task_deleted, task_status_changed)
   - Client ID-based connection management
   - Excludes event broadcaster from receiving their own events via X-Client-ID header
 
 **System**
+
 - `GET /health` - Health check
 - `GET /` - Root redirect to docs
 - `GET /docs` - OpenAPI documentation (Swagger UI)
@@ -465,6 +511,7 @@ All endpoints return JSON with proper HTTP status codes. Error responses include
 All CLI commands use `ConsoleWriter` abstraction (`RichConsoleWriter` implementation). Access via `ctx.obj.console_writer`.
 
 **Methods:**
+
 - `success(action, task)`: Task operations → `✓ Added task: Task name (ID: 123)`
 - `print_success(message)`: Generic success → `✓ {message}`
 - `validation_error(message)`: Input validation → `✗ Error: {message}`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ make install
 
 Taskdog is a **UV workspace monorepo** with three packages:
 
-```
+```text
 taskdog/
 ├── packages/
 │   ├── taskdog-core/      # Core business logic and infrastructure
@@ -97,7 +97,7 @@ taskdog/
 
 ### Communication Flow
 
-```
+```text
 CLI/TUI (taskdog-ui) → HTTP API → FastAPI (taskdog-server) → Controllers/Repository (taskdog-core)
 ```
 
@@ -200,7 +200,7 @@ cd packages/taskdog-core && PYTHONPATH=src uv run python -m unittest tests.test_
 
 This project uses **Conventional Commits** format:
 
-```
+```text
 <type>: <description>
 
 [optional body]

--- a/DESIGN_PHILOSOPHY.md
+++ b/DESIGN_PHILOSOPHY.md
@@ -9,6 +9,7 @@ Taskdog is a **personal task management system** designed for individual users w
 ### The Design Journey
 
 Early versions of Taskdog attempted to support parent-child task hierarchies. However, I discovered that this feature:
+
 - Made schedule optimization algorithms unpredictable and complex
 - Introduced numerous edge cases in business logic (similar to Redmine's challenges)
 - Added implementation complexity without proportional value for individual users
@@ -43,6 +44,7 @@ Taskdog is **NOT** designed for:
 **Decision**: Focus exclusively on personal task management.
 
 **Why**:
+
 - Individual users have different needs than teams
 - Personal tasks don't require approval workflows, role-based permissions, or team synchronization
 - Simpler data models lead to faster performance and easier customization
@@ -53,6 +55,7 @@ Taskdog is **NOT** designed for:
 **Decision**: Use dependencies instead of parent-child relationships (no subtasks).
 
 **Why**:
+
 - Follows GTD philosophy: "Use outlines for planning, plain lists for doing"
 - Individual users can mentally track hierarchies without explicit data structures
 - Dependencies + tags + notes cover 99% of personal task organization needs
@@ -80,6 +83,7 @@ taskdog gantt --tag web  # Visualize dependencies
 ```
 
 **Result**:
+
 - Grouping via tags
 - Ordering via dependencies
 - Context via markdown notes
@@ -90,18 +94,21 @@ taskdog gantt --tag web  # Visualize dependencies
 **Decision**: Implement only features that benefit individual task management.
 
 **Why**:
+
 - Feature bloat increases complexity and maintenance burden
 - Every feature adds cognitive load for users
 - Saying "no" to features is harder but more important than saying "yes"
 - Focus creates better user experience for the target audience
 
 **We prioritize**:
+
 - Core task operations (CRUD, status changes)
 - Powerful scheduling (9 optimization algorithms)
 - Multiple interfaces (CLI, TUI, API)
 - Privacy and offline operation
 
 **We explicitly avoid**:
+
 - Team collaboration features
 - Complex permission systems
 - Cloud synchronization (use git if needed)
@@ -112,12 +119,14 @@ taskdog gantt --tag web  # Visualize dependencies
 **Decision**: Provide 9 different scheduling algorithms users can understand and choose from.
 
 **Why**:
+
 - Users should understand how their schedule is optimized
 - Different situations call for different strategies
 - Algorithm selection is a learning opportunity
 - No vendor lock-in to proprietary AI
 
 **Available algorithms**:
+
 1. `greedy` - Schedule tasks as early as possible
 2. `balanced` - Distribute workload evenly across days
 3. `backward` - Schedule from deadlines backward
@@ -135,6 +144,7 @@ Compare this to Motion/Reclaim: "Our AI schedules your tasks" (black box, no con
 **Decision**: All data stored locally in SQLite, no cloud synchronization.
 
 **Why**:
+
 - Your tasks are your private information
 - No dependency on external services
 - Works completely offline
@@ -142,6 +152,7 @@ Compare this to Motion/Reclaim: "Our AI schedules your tasks" (black box, no con
 - Full control over your data
 
 **Synchronization options**:
+
 - Git (recommended): Version control for your tasks.db
 - File sync: Dropbox, Google Drive, etc. (manual)
 - Future: Consider DAT/IPFS for decentralized sync
@@ -187,6 +198,7 @@ See the Redmine example in section "Business Logic Complexity" below. I faced th
 **3. Individual Users Didn't Need It**
 
 After removing parent-child relationships, I tested with real workflows. Turns out:
+
 - Dependencies + tags cover 99% of organization needs
 - With only 1-3 concurrent tasks, mental hierarchy is sufficient
 - The complexity wasn't worth it
@@ -204,12 +216,14 @@ These observations align with broader industry patterns:
 > — Getting Things Done Forums
 
 David Allen's GTD approach emphasizes:
+
 - **Planning phase**: Use hierarchical outlines (mental or on paper)
 - **Execution phase**: Flat list of "next actions"
 - Parent tasks are planning artifacts, not execution items
 
 **Taskwarrior's Approach**:
 Taskwarrior, the most successful terminal-based task manager, uses **dependencies only**:
+
 - No native subtask feature
 - Community plugins exist but aren't mainstream
 - Proven to work for thousands of users over 15+ years
@@ -221,6 +235,7 @@ Our experience confirmed what these established approaches already knew: for ind
 **1. Data Model Complexity**
 
 With parent-child relationships:
+
 ```python
 class Task:
     parent_id: Optional[int]
@@ -235,6 +250,7 @@ class Task:
 ```
 
 With dependencies only:
+
 ```python
 class Task:
     depends_on: list[int]
@@ -245,12 +261,14 @@ class Task:
 **2. Optimization Algorithm Complexity**
 
 Scheduling with hierarchies:
+
 - Do we schedule parent tasks? If so, when?
 - Are parent durations fixed or computed from children?
 - Can children be scheduled independently?
 - How to handle partial parent completion?
 
 Scheduling with dependencies:
+
 - Clear: schedule tasks whose dependencies are met
 - Predictable: algorithms behave consistently
 - Testable: easy to verify correctness
@@ -258,12 +276,14 @@ Scheduling with dependencies:
 **3. UI Complexity**
 
 TUI with hierarchies requires:
+
 - Tree view with expand/collapse
 - Indentation management
 - Parent-child navigation keybindings
 - Filtering becomes complex (show parents without children?)
 
 TUI with flat list:
+
 - Simple table view
 - Fast navigation
 - Easy filtering and searching
@@ -276,6 +296,7 @@ Parent-child relationships create numerous edge cases and ambiguous behaviors:
 **Real-world example: Redmine (team project management tool)**
 
 Redmine supports task hierarchies but faces these issues:
+
 - **Auto-start dilemma**: When you start a child task, should the parent auto-start? If yes, how many levels up?
 - **Chain deletion**: If you delete a task in the middle of an IN_PROGRESS chain, what happens to parent and siblings?
 - **Orphaned children**: What if parent is deleted but children remain?
@@ -285,11 +306,13 @@ Redmine supports task hierarchies but faces these issues:
 - **Assignment**: Can you assign parent without children? Vice versa?
 
 **Each question requires a design decision**, and different tools solve them differently:
+
 - Redmine: Parent doesn't auto-start when children start (surprising to users)
 - Jira: Complex permission rules for subtask operations
 - Asana: Circular reference detection with multiple algorithms
 
 **With dependencies only**, these questions don't exist:
+
 - Tasks are independent entities
 - Dependencies define order, not ownership
 - No automatic status propagation
@@ -299,6 +322,7 @@ Redmine supports task hierarchies but faces these issues:
 **5. Concurrent Task Reality**
 
 **Individual users typically work on 1-3 tasks simultaneously at most**:
+
 - Primary task (currently focused on)
 - 1-2 background tasks (waiting, paused, or context-switched)
 
@@ -312,7 +336,8 @@ This is fundamentally different from team projects:
 | Context switching | You decide | Coordinated handoffs |
 
 **Example: Individual developer's day**
-```
+
+```text
 9:00  - Start "Implement login API" (IN_PROGRESS)
 10:30 - Blocked, waiting for design review
       - Pause, start "Fix bug #123" (IN_PROGRESS)
@@ -325,7 +350,8 @@ This is fundamentally different from team projects:
 Only 1-2 tasks active at any moment. **No need for complex hierarchy to track this.**
 
 **Example: Team project (50+ concurrent tasks)**
-```
+
+```text
 Epic: User Authentication System
 ├── Story: Login UI
 │   ├── Task: Design mockup (Designer, IN_PROGRESS)
@@ -361,6 +387,7 @@ For individuals, **mental hierarchy + dependency tracking** is sufficient.
 **Use case**: Break down "Write blog post" into steps.
 
 **Solution 1: Dependencies + Tags**
+
 ```bash
 taskdog add "Blog: Research topic" --tag blog --priority 8
 taskdog add "Blog: Outline" --tag blog --priority 7 --depends-on 1
@@ -371,6 +398,7 @@ taskdog table --tag blog  # See all related tasks
 ```
 
 **Solution 2: Checklist in Notes**
+
 ```bash
 taskdog add "Write blog post" --priority 8
 taskdog note 1
@@ -393,6 +421,7 @@ taskdog note 1
 ```
 
 **Solution 3: Granular Tasks**
+
 ```bash
 # Just create 6 tasks, it's fine!
 # You're not managing 100 tasks per project
@@ -408,6 +437,7 @@ All three approaches work perfectly without parent-child relationships.
 ### vs. Taskwarrior
 
 **Similarities**:
+
 - Individual focus
 - Dependencies instead of hierarchies
 - Terminal-first interface
@@ -415,6 +445,7 @@ All three approaches work perfectly without parent-child relationships.
 - Powerful filtering and reporting
 
 **Taskdog advantages**:
+
 - Modern Python codebase (Taskwarrior is C++)
 - Multiple optimization algorithms (9 choices)
 - Full-featured TUI (taskwarrior-tui is separate project)
@@ -422,6 +453,7 @@ All three approaches work perfectly without parent-child relationships.
 - Simpler data format (SQLite vs. custom format)
 
 **Taskwarrior advantages**:
+
 - Mature ecosystem (15+ years)
 - Extensive third-party tools
 - Mobile apps (via Taskwarrior Server)
@@ -432,6 +464,7 @@ All three approaches work perfectly without parent-child relationships.
 ### vs. Motion / Reclaim.ai
 
 **Motion/Reclaim approach**:
+
 - Black-box AI scheduling
 - Cloud-based SaaS ($19-34/month)
 - Requires calendar integration
@@ -439,6 +472,7 @@ All three approaches work perfectly without parent-child relationships.
 - No algorithm transparency
 
 **Taskdog approach**:
+
 - 9 transparent algorithms you can understand
 - Free and open-source
 - Fully offline capable
@@ -446,10 +480,12 @@ All three approaches work perfectly without parent-child relationships.
 - Full API for custom AI integration
 
 **Trade-off**:
+
 - Motion: "Just works" but expensive and opaque
 - Taskdog: Requires learning but free and transparent
 
 **Why Taskdog is better for engineers**:
+
 1. You can integrate YOUR choice of AI (ChatGPT, Claude, local LLMs)
 2. You understand exactly how scheduling works
 3. Your data stays on your machine
@@ -459,6 +495,7 @@ All three approaches work perfectly without parent-child relationships.
 ### vs. Asana / Jira / ClickUp
 
 **Team tools approach**:
+
 - Rich parent-child task hierarchies
 - Team collaboration features
 - Complex permission systems
@@ -466,6 +503,7 @@ All three approaches work perfectly without parent-child relationships.
 - Heavy UI
 
 **Taskdog approach**:
+
 - Flat structure with dependencies
 - Individual focus
 - Simple data model
@@ -473,6 +511,7 @@ All three approaches work perfectly without parent-child relationships.
 - Lightweight TUI
 
 **When to use which**:
+
 - **Asana/Jira**: Managing team projects with 5+ people
 - **Taskdog**: Managing your personal tasks and projects
 
@@ -483,6 +522,7 @@ They serve completely different markets.
 Features that align with our philosophy:
 
 ### Near-term (v0.5-v0.6)
+
 - **Recurring tasks**: Daily/weekly/monthly patterns
 - **Task templates**: Quick creation from saved configurations
 - **Calendar integration**: iCal export, sync with Google Calendar (read-only)
@@ -490,12 +530,14 @@ Features that align with our philosophy:
 - **MCP server**: Claude Desktop integration
 
 ### Medium-term (v0.7-v0.8)
+
 - **Git integration**: Link tasks to commits/branches
 - **Import/export**: From Taskwarrior, org-mode, todo.txt
 - **Custom fields**: User-defined attributes
 - **Hooks system**: Run scripts on task events
 
 ### Long-term (v1.0+)
+
 - **PostgreSQL support**: For power users with massive task counts
 - **Plugin system**: Extend functionality without forking
 - **Mobile TUI**: Optimized for smaller terminals
@@ -508,6 +550,7 @@ All future features will be evaluated against our core principles.
 Features that violate our philosophy:
 
 ### Never
+
 - **Parent-child task hierarchies**: Use dependencies + tags + notes instead
 - **Team collaboration**: Use Asana/Jira for teams
 - **Cloud synchronization**: Use git or file sync
@@ -517,7 +560,9 @@ Features that violate our philosophy:
 - **Built-in Pomodoro timer**: Use dedicated tools (e.g., `pomo`)
 
 ### Rationale
+
 These features would:
+
 1. Increase complexity beyond individual needs
 2. Blur the focus on personal task management
 3. Require cloud infrastructure (against privacy principle)
@@ -540,6 +585,7 @@ pip install taskdog taskdog-server
 ```
 
 The repository provides:
+
 - Python packages (taskdog-core, taskdog-server, taskdog-ui)
 - systemd/launchd service files for auto-start
 - Configuration examples
@@ -569,11 +615,13 @@ If you need Docker, authentication, reverse proxy, or backup automation, conside
 - Sets up backup automation (restic, borg, etc.)
 
 This separation keeps:
+
 - **taskdog**: Simple, focused on the application
 - **taskdog-stack**: Infrastructure concerns, customizable per deployment
 
 **Example structure for taskdog-stack**:
-```
+
+```text
 taskdog-stack/
 ├── docker-compose.yml
 ├── .env.example
@@ -600,6 +648,7 @@ If you want to contribute to Taskdog, ask yourself:
 Examples:
 
 **Good contributions**:
+
 - New optimization algorithm (transparent, individual-focused)
 - Better TUI keybindings (improves core experience)
 - Import from other task managers (helps migration)
@@ -607,6 +656,7 @@ Examples:
 - Bug fixes (always welcome)
 
 **Contributions we'd decline**:
+
 - "Add subtasks/parent-child relationships" (violates flat structure principle)
 - "Add real-time team collaboration" (not for individuals)
 - "Add cloud sync service" (privacy violation)
@@ -621,6 +671,7 @@ Taskdog's design philosophy can be summarized in one sentence:
 > **A transparent, privacy-respecting task manager for individuals who want to understand and control how their time is optimized.**
 
 We believe that:
+
 - Individuals deserve tools designed for them, not dumbed-down team tools
 - Transparency beats black-box AI for users who want to learn
 - Simplicity and focus create better experiences than feature bloat

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -19,6 +19,7 @@ make install
 ```
 
 This installs two commands:
+
 - `taskdog` - CLI and TUI interface
 - `taskdog-server` - API server (required for taskdog to work)
 
@@ -66,6 +67,7 @@ systemctl --user status taskdog-server
 ```
 
 The server will now:
+
 - Start automatically when you log in
 - Restart automatically if it crashes
 - Run in the background
@@ -100,6 +102,7 @@ taskdog tui
 ### TUI Keyboard Shortcuts
 
 Once in the TUI (`taskdog tui`):
+
 - `a` - Add new task
 - `s` - Start selected task
 - `d` - Complete (done) task
@@ -115,6 +118,7 @@ Once in the TUI (`taskdog tui`):
 **Problem**: Config file missing or `enabled = false`
 
 **Solution**:
+
 ```bash
 # Check if config exists
 cat ~/.config/taskdog/config.toml
@@ -127,6 +131,7 @@ cat ~/.config/taskdog/config.toml
 **Problem**: Server is not running
 
 **Solution**:
+
 ```bash
 # Check if server is running
 systemctl --user status taskdog-server
@@ -143,6 +148,7 @@ taskdog-server
 **Problem**: Port mismatch between config and server
 
 **Solution**:
+
 ```bash
 # Check what port the server is using
 systemctl --user status taskdog-server  # Look for --port in the command
@@ -159,6 +165,7 @@ nano ~/.config/taskdog/config.toml
 **Problem**: Port already in use
 
 **Solution**:
+
 ```bash
 # Check what's using port 8000
 ss -tlnp | grep 8000

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A task management system with CLI/TUI interfaces and REST API server, featuring 
 ![TUI Screenshot](docs/images/theme-textual-dark.svg)
 
 **Architecture**: UV workspace monorepo with three packages:
+
 - **taskdog-core**: Core business logic and SQLite persistence
 - **taskdog-server**: FastAPI REST API server
 - **taskdog-ui**: CLI and TUI interfaces
@@ -90,6 +91,7 @@ make install-local
 ```
 
 **What gets installed:**
+
 - `taskdog` - CLI and TUI interface
 - `taskdog-server` - FastAPI REST API server
 - **Linux**: systemd user service for automatic startup
@@ -98,6 +100,7 @@ make install-local
 **Platform-Specific Service Management:**
 
 **Linux (systemd):**
+
 ```bash
 systemctl --user start taskdog-server    # Start server
 systemctl --user status taskdog-server   # Check status
@@ -106,6 +109,7 @@ journalctl --user -u taskdog-server -f   # View logs
 ```
 
 **macOS (launchd):**
+
 ```bash
 launchctl start com.github.kohei-wada.taskdog-server   # Start server
 launchctl stop com.github.kohei-wada.taskdog-server    # Stop server
@@ -114,6 +118,7 @@ tail -f ~/Library/Logs/taskdog-server.log              # View logs
 ```
 
 **Common Make targets:**
+
 ```bash
 make install          # Install as global commands via uv tool
 make check-deps       # Check if required tools are installed
@@ -126,12 +131,14 @@ make uninstall        # Remove global installations
 ## Quick Start
 
 **1. Start the API server** (required for all operations):
+
 ```bash
 taskdog-server
 # Runs on http://127.0.0.1:8000 by default
 ```
 
 **2. Configure API connection** in `~/.config/taskdog/config.toml`:
+
 ```toml
 [api]
 enabled = true
@@ -140,6 +147,7 @@ port = 8000
 ```
 
 **3. Start managing tasks**:
+
 ```bash
 # Create tasks
 taskdog add "Design phase" -p 150
@@ -167,6 +175,7 @@ taskdog tui            # Interactive TUI
 Taskdog includes a full-screen terminal user interface (TUI) for managing tasks interactively.
 
 **Features:**
+
 - Real-time task search and filtering
 - Keyboard shortcuts for quick operations
 - Sort by deadline, priority, planned start, or ID
@@ -174,6 +183,7 @@ Taskdog includes a full-screen terminal user interface (TUI) for managing tasks 
 - Task details panel with dependencies
 
 **Keyboard Shortcuts:**
+
 - `a` - Add new task
 - `s` - Start selected task
 - `P` - Pause selected task
@@ -194,6 +204,7 @@ Taskdog includes a full-screen terminal user interface (TUI) for managing tasks 
 - `q` - Quit
 
 Launch the TUI with:
+
 ```bash
 taskdog tui
 ```
@@ -247,6 +258,7 @@ taskdog-server --workers 4               # Production with multiple workers
 ```
 
 **Quick API Examples:**
+
 ```bash
 # Create task
 curl -X POST http://localhost:8000/api/v1/tasks/ \
@@ -265,6 +277,7 @@ curl -X POST http://localhost:8000/api/v1/tasks/1/start
 ## Commands
 
 **Common Commands:**
+
 ```bash
 # Task management
 taskdog add "Task name" -p 150           # Create task with priority
@@ -294,6 +307,7 @@ taskdog optimize -a balanced             # Use balanced algorithm
 **Config file**: `~/.config/taskdog/config.toml`
 
 **Minimal configuration:**
+
 ```toml
 [api]
 enabled = true
@@ -302,6 +316,7 @@ port = 8000
 ```
 
 **With theme and optimization:**
+
 ```toml
 [api]
 enabled = true
@@ -331,6 +346,7 @@ default_algorithm = "balanced"
 **Requirements**: Python 3.11+, [uv](https://github.com/astral-sh/uv)
 
 **Quick start:**
+
 ```bash
 # Setup
 make install-dev                    # Install with dev dependencies
@@ -346,6 +362,7 @@ make check                          # Lint + typecheck
 ```
 
 **Architecture**: UV workspace monorepo with Clean Architecture principles.
+
 - **taskdog-core**: Domain, Application, Infrastructure layers
 - **taskdog-server**: FastAPI REST API (Presentation layer)
 - **taskdog-ui**: CLI/TUI interfaces (Presentation layer)
@@ -362,6 +379,7 @@ Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for det
 - Project structure and architecture
 
 **CI/CD**: All pull requests automatically run:
+
 - Linting (`make lint`)
 - Type checking (`make typecheck`)
 - Tests with coverage (`make coverage`)

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -11,6 +11,7 @@ make install
 ```
 
 This will:
+
 1. Install the `taskdog-server` command globally
 2. Copy the systemd service file to `~/.config/systemd/user/taskdog-server.service`
 3. Enable the service for automatic startup
@@ -66,10 +67,12 @@ taskdog table
 ### Common Issues
 
 **Error: "Cannot connect to API server"**
+
 - Check if server is running: `systemctl --user status taskdog-server`
 - Start the server: `systemctl --user start taskdog-server`
 
 **Error: "API mode is required"**
+
 - Set `enabled = true` in config file (see Method A above)
 - Or set TASKDOG_API_URL environment variable (see Method B above)
 
@@ -129,6 +132,7 @@ systemctl --user enable taskdog-server
 ## Configuration
 
 The default service configuration:
+
 - **Host**: 127.0.0.1 (local only)
 - **Port**: 8000
 - **Workers**: 1 (required for WebSocket real-time sync)
@@ -155,16 +159,19 @@ systemctl --user restart taskdog-server
 Example modifications:
 
 **Change host and port (listen on all interfaces):**
+
 ```ini
 ExecStart=%h/.local/bin/taskdog-server --host 0.0.0.0 --port 9000 --workers 1
 ```
 
 **Enable development mode with auto-reload:**
+
 ```ini
 ExecStart=%h/.local/bin/taskdog-server --host 127.0.0.1 --port 8000 --reload
 ```
 
 **WARNING: Multiple workers not supported with WebSocket**
+
 ```ini
 # This will NOT work for WebSocket real-time sync:
 # ExecStart=%h/.local/bin/taskdog-server --host 127.0.0.1 --port 8000 --workers 4
@@ -176,16 +183,19 @@ ExecStart=%h/.local/bin/taskdog-server --host 127.0.0.1 --port 8000 --reload
 ### Service Won't Start
 
 1. Check logs:
+
    ```bash
    journalctl --user -u taskdog-server -n 50
    ```
 
 2. Verify the command works manually:
+
    ```bash
    ~/.local/bin/taskdog-server --help
    ```
 
 3. Check if the port is already in use:
+
    ```bash
    ss -tlnp | grep 8000
    ```
@@ -193,11 +203,13 @@ ExecStart=%h/.local/bin/taskdog-server --host 127.0.0.1 --port 8000 --reload
 ### Service Crashes on Startup
 
 - Check permissions on the data directory:
+
   ```bash
   ls -ld ~/.local/share/taskdog/
   ```
 
 - Ensure the database file is not corrupted:
+
   ```bash
   sqlite3 ~/.local/share/taskdog/tasks.db "PRAGMA integrity_check;"
   ```
@@ -205,11 +217,13 @@ ExecStart=%h/.local/bin/taskdog-server --host 127.0.0.1 --port 8000 --reload
 ### Logs Not Appearing
 
 - Ensure journald is running:
+
   ```bash
   systemctl --user status
   ```
 
 - Check systemd user service status:
+
   ```bash
   loginctl user-status
   ```
@@ -231,6 +245,7 @@ make uninstall
 ```
 
 This will:
+
 1. Stop the service
 2. Disable auto-start
 3. Remove the service file
@@ -257,6 +272,7 @@ systemctl --user start taskdog-server
 ## Security Considerations
 
 The default service configuration includes security hardening:
+
 - `NoNewPrivileges=true`: Prevents privilege escalation
 - `PrivateTmp=true`: Uses private /tmp directory
 - `ProtectSystem=strict`: Makes most of the filesystem read-only

--- a/docs/API.md
+++ b/docs/API.md
@@ -71,6 +71,7 @@ All API endpoints are prefixed with `/api/v1/` unless otherwise noted.
 ```
 
 HTTP status codes follow REST conventions:
+
 - `200` - Success
 - `201` - Created
 - `204` - No Content (successful deletion)
@@ -84,15 +85,19 @@ HTTP status codes follow REST conventions:
 ### Documentation
 
 #### GET /docs
+
 Interactive Swagger UI documentation
 
 #### GET /redoc
+
 Alternative ReDoc documentation
 
 #### GET /health
+
 Health check endpoint
 
 **Response:**
+
 ```json
 {
   "status": "healthy"
@@ -104,9 +109,11 @@ Health check endpoint
 Base path: `/api/v1/tasks/`
 
 #### GET /api/v1/tasks/
+
 List tasks with filtering
 
 **Query Parameters:**
+
 - `status` (string, optional) - Filter by status: pending, in_progress, completed, canceled
 - `tags` (string[], optional) - Filter by tags (OR logic)
 - `start_date` (string, optional) - Filter by planned start date (YYYY-MM-DD)
@@ -116,6 +123,7 @@ List tasks with filtering
 - `reverse` (boolean, optional) - Reverse sort order (default: false)
 
 **Response:**
+
 ```json
 [
   {
@@ -140,9 +148,11 @@ List tasks with filtering
 ```
 
 #### POST /api/v1/tasks/
+
 Create a new task
 
 **Request Body:**
+
 ```json
 {
   "name": "Task name",
@@ -160,14 +170,17 @@ Create a new task
 **Response:** 201 Created with task object
 
 #### GET /api/v1/tasks/{task_id}
+
 Get task details
 
 **Response:** Task object (same structure as list)
 
 #### PATCH /api/v1/tasks/{task_id}
+
 Update task fields
 
 **Request Body:**
+
 ```json
 {
   "name": "Updated name",
@@ -179,9 +192,11 @@ Update task fields
 **Response:** Updated task object
 
 #### DELETE /api/v1/tasks/{task_id}
+
 Delete task
 
 **Query Parameters:**
+
 - `hard` (boolean, optional) - Permanent deletion if true, soft delete if false (default: false)
 
 **Response:** 204 No Content
@@ -191,6 +206,7 @@ Delete task
 Base path: `/api/v1/tasks/{task_id}/`
 
 #### POST /api/v1/tasks/{task_id}/start
+
 Start a task
 
 Records actual start time and changes status to IN_PROGRESS.
@@ -198,6 +214,7 @@ Records actual start time and changes status to IN_PROGRESS.
 **Response:** Updated task object
 
 #### POST /api/v1/tasks/{task_id}/complete
+
 Complete a task
 
 Records actual end time and changes status to COMPLETED.
@@ -205,6 +222,7 @@ Records actual end time and changes status to COMPLETED.
 **Response:** Updated task object
 
 #### POST /api/v1/tasks/{task_id}/pause
+
 Pause a task
 
 Resets status to PENDING and clears timestamps.
@@ -212,6 +230,7 @@ Resets status to PENDING and clears timestamps.
 **Response:** Updated task object
 
 #### POST /api/v1/tasks/{task_id}/cancel
+
 Cancel a task
 
 Changes status to CANCELED.
@@ -219,6 +238,7 @@ Changes status to CANCELED.
 **Response:** Updated task object
 
 #### POST /api/v1/tasks/{task_id}/reopen
+
 Reopen a completed or canceled task
 
 Resets status to PENDING.
@@ -226,9 +246,11 @@ Resets status to PENDING.
 **Response:** Updated task object
 
 #### POST /api/v1/tasks/{task_id}/log-hours
+
 Log actual hours worked
 
 **Request Body:**
+
 ```json
 {
   "hours": 8.0,
@@ -242,6 +264,7 @@ Log actual hours worked
 **Response:** Updated task object
 
 #### POST /api/v1/tasks/{task_id}/archive
+
 Archive a task (soft delete)
 
 Sets `is_archived` to true. Task can be restored later.
@@ -249,6 +272,7 @@ Sets `is_archived` to true. Task can be restored later.
 **Response:** 204 No Content
 
 #### POST /api/v1/tasks/{task_id}/restore
+
 Restore an archived task
 
 Sets `is_archived` to false.
@@ -260,9 +284,11 @@ Sets `is_archived` to false.
 Base path: `/api/v1/tasks/{task_id}/`
 
 #### POST /api/v1/tasks/{task_id}/dependencies
+
 Add a dependency
 
 **Request Body:**
+
 ```json
 {
   "depends_on_id": 2
@@ -276,14 +302,17 @@ Creates a dependency: task {task_id} depends on task {depends_on_id}.
 **Error:** 400 if circular dependency detected
 
 #### DELETE /api/v1/tasks/{task_id}/dependencies/{dep_id}
+
 Remove a dependency
 
 **Response:** Updated task object
 
 #### PUT /api/v1/tasks/{task_id}/tags
+
 Set task tags (replaces existing)
 
 **Request Body:**
+
 ```json
 {
   "tags": ["backend", "api", "urgent"]
@@ -297,9 +326,11 @@ Set task tags (replaces existing)
 Base path: `/api/v1/tasks/{task_id}/notes/`
 
 #### GET /api/v1/tasks/{task_id}/notes
+
 Get task notes
 
 **Response:**
+
 ```json
 {
   "content": "# Notes\n\nMarkdown content here..."
@@ -307,9 +338,11 @@ Get task notes
 ```
 
 #### PUT /api/v1/tasks/{task_id}/notes
+
 Update task notes
 
 **Request Body:**
+
 ```json
 {
   "content": "# Updated Notes\n\nNew markdown content..."
@@ -319,6 +352,7 @@ Update task notes
 **Response:** 204 No Content
 
 #### DELETE /api/v1/tasks/{task_id}/notes
+
 Delete task notes
 
 **Response:** 204 No Content
@@ -328,13 +362,16 @@ Delete task notes
 Base path: `/api/v1/`
 
 #### GET /api/v1/statistics
+
 Get task statistics
 
 **Query Parameters:**
+
 - `period` (string, optional) - all, 7d, 30d (default: all)
 - `focus` (string, optional) - all, basic, time, estimation, deadline, priority, trends (default: all)
 
 **Response:**
+
 ```json
 {
   "total_tasks": 10,
@@ -350,14 +387,17 @@ Get task statistics
 ```
 
 #### GET /api/v1/gantt
+
 Get Gantt chart data
 
 **Query Parameters:**
+
 - Same filtering options as GET /api/v1/tasks/
 - `start_date` (string, optional) - Chart start date
 - `end_date` (string, optional) - Chart end date
 
 **Response:**
+
 ```json
 {
   "tasks": [...],
@@ -373,9 +413,11 @@ Get Gantt chart data
 ```
 
 #### GET /api/v1/tags/statistics
+
 Get tag statistics
 
 **Response:**
+
 ```json
 {
   "backend": 5,
@@ -389,9 +431,11 @@ Get tag statistics
 Base path: `/api/v1/`
 
 #### POST /api/v1/optimize
+
 Run schedule optimization
 
 **Request Body:**
+
 ```json
 {
   "start_date": "2025-10-22",
@@ -402,12 +446,14 @@ Run schedule optimization
 ```
 
 **All fields optional:**
+
 - `start_date` - Optimization start date (default: today)
 - `max_hours_per_day` - Daily hour limit (default: from config or 6.0)
 - `algorithm` - Algorithm to use (default: greedy)
 - `force` - Force re-optimization even if tasks already scheduled
 
 **Available algorithms:**
+
 - `greedy` - Schedule highest priority tasks first
 - `balanced` - Distribute workload evenly
 - `backward` - Schedule from deadline backwards
@@ -419,6 +465,7 @@ Run schedule optimization
 - `monte_carlo` - Monte Carlo simulation
 
 **Response:**
+
 ```json
 {
   "scheduled_count": 8,
@@ -432,9 +479,11 @@ Run schedule optimization
 ```
 
 #### GET /api/v1/algorithms
+
 List available optimization algorithms
 
 **Response:**
+
 ```json
 {
   "algorithms": [
@@ -450,6 +499,7 @@ List available optimization algorithms
 ### Real-time Updates
 
 #### WebSocket /ws
+
 Real-time task notifications
 
 Connect to WebSocket endpoint for real-time updates:
@@ -465,6 +515,7 @@ ws.onmessage = (event) => {
 ```
 
 **Event types:**
+
 - `task_created` - New task created
 - `task_updated` - Task fields updated
 - `task_deleted` - Task deleted
@@ -558,6 +609,7 @@ done
 ### Common Errors
 
 **404 Not Found**
+
 ```json
 {
   "detail": "Task with ID 999 not found"
@@ -565,6 +617,7 @@ done
 ```
 
 **400 Bad Request**
+
 ```json
 {
   "detail": "Cannot start task: Task is already completed"
@@ -572,6 +625,7 @@ done
 ```
 
 **422 Validation Error**
+
 ```json
 {
   "detail": [

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -19,12 +19,15 @@ Complete reference for all Taskdog CLI commands.
 ## Task Creation & Updates
 
 ### add - Create a new task
+
 ```bash
 taskdog add "Task name" [-p PRIORITY] [--fixed] [-d DEP_ID] [-t TAG]
 ```
+
 Create a new task with optional priority, dependencies, and tags. Multiple `-d` and `-t` flags are allowed.
 
 **Examples:**
+
 ```bash
 taskdog add "Design phase" -p 150
 taskdog add "Implementation" -p 100 -d 1 -t backend -t api
@@ -32,70 +35,88 @@ taskdog add "Team meeting" --fixed  # Won't be rescheduled
 ```
 
 ### deadline - Set task deadline
+
 ```bash
 taskdog deadline ID DATE
 ```
+
 Set or update task deadline. Supports `YYYY-MM-DD` or `YYYY-MM-DD HH:MM:SS` format.
 
 **Examples:**
+
 ```bash
 taskdog deadline 1 2025-10-20
 taskdog deadline 2 "2025-10-22 18:00:00"
 ```
 
 ### priority - Set task priority
+
 ```bash
 taskdog priority ID N
 ```
+
 Set task priority (higher = more important). Default is 5.
 
 **Examples:**
+
 ```bash
 taskdog priority 1 150
 ```
 
 ### est - Set estimated duration
+
 ```bash
 taskdog est ID HOURS
 ```
+
 Set estimated duration in hours for the task.
 
 **Examples:**
+
 ```bash
 taskdog est 1 16
 taskdog est 2 8.5
 ```
 
 ### schedule - Set planned schedule
+
 ```bash
 taskdog schedule ID START [END]
 ```
+
 Set planned start and optional end time. If end time is omitted, uses estimated_duration.
 
 **Examples:**
+
 ```bash
 taskdog schedule 1 "2025-10-22 09:00"
 taskdog schedule 2 "2025-10-22 10:00" "2025-10-22 11:00"
 ```
 
 ### rename - Rename task
+
 ```bash
 taskdog rename ID NAME
 ```
+
 Change the task name.
 
 **Examples:**
+
 ```bash
 taskdog rename 1 "New task name"
 ```
 
 ### update - Multi-field update
+
 ```bash
 taskdog update ID [--name] [--priority] [--status] [--planned-start] [--planned-end] [--deadline] [--estimated-duration]
 ```
+
 Update multiple task fields at once.
 
 **Examples:**
+
 ```bash
 taskdog update 1 --priority 200 --deadline 2025-10-25
 ```
@@ -103,84 +124,105 @@ taskdog update 1 --priority 200 --deadline 2025-10-25
 ## Task Management
 
 ### start - Start tasks
+
 ```bash
 taskdog start ID...
 ```
+
 Start one or more tasks. Records actual start time and changes status to IN_PROGRESS.
 
 **Examples:**
+
 ```bash
 taskdog start 1
 taskdog start 2 3 4  # Batch operation
 ```
 
 ### done - Complete tasks
+
 ```bash
 taskdog done ID...
 ```
+
 Mark tasks as completed. Records actual end time.
 
 **Examples:**
+
 ```bash
 taskdog done 1
 taskdog done 2 3 4  # Batch operation
 ```
 
 ### pause - Pause tasks
+
 ```bash
 taskdog pause ID...
 ```
+
 Pause tasks and reset to PENDING status. Clears timestamps.
 
 **Examples:**
+
 ```bash
 taskdog pause 1
 taskdog pause 2 3  # Batch operation
 ```
 
 ### cancel - Cancel tasks
+
 ```bash
 taskdog cancel ID...
 ```
+
 Mark tasks as CANCELED.
 
 **Examples:**
+
 ```bash
 taskdog cancel 1
 taskdog cancel 2 3  # Batch operation
 ```
 
 ### reopen - Reopen tasks
+
 ```bash
 taskdog reopen ID...
 ```
+
 Reopen completed or canceled tasks. Resets to PENDING status.
 
 **Examples:**
+
 ```bash
 taskdog reopen 1
 taskdog reopen 2 3  # Batch operation
 ```
 
 ### rm - Remove tasks
+
 ```bash
 taskdog rm ID... [--hard]
 ```
+
 Remove tasks. Default is soft delete (sets is_archived=true). Use `--hard` for permanent deletion.
 
 **Examples:**
+
 ```bash
 taskdog rm 1        # Soft delete (can be restored)
 taskdog rm 2 --hard # Permanent deletion
 ```
 
 ### restore - Restore soft-deleted tasks
+
 ```bash
 taskdog restore ID...
 ```
+
 Restore previously archived (soft-deleted) tasks.
 
 **Examples:**
+
 ```bash
 taskdog restore 1
 taskdog restore 2 3  # Batch operation
@@ -189,23 +231,29 @@ taskdog restore 2 3  # Batch operation
 ## Dependencies
 
 ### add-dependency - Add task dependency
+
 ```bash
 taskdog add-dependency TASK_ID DEPENDS_ON_ID
 ```
+
 Add a dependency relationship. Includes circular dependency detection.
 
 **Examples:**
+
 ```bash
 taskdog add-dependency 2 1  # Task 2 depends on task 1
 ```
 
 ### remove-dependency - Remove task dependency
+
 ```bash
 taskdog remove-dependency TASK_ID DEP_ID
 ```
+
 Remove a dependency relationship.
 
 **Examples:**
+
 ```bash
 taskdog remove-dependency 2 1
 ```
@@ -213,6 +261,7 @@ taskdog remove-dependency 2 1
 ## Tags Management
 
 ### tags - Manage tags
+
 ```bash
 taskdog tags              # List all tags with counts
 taskdog tags ID           # Show tags for a task
@@ -220,6 +269,7 @@ taskdog tags ID TAG1...   # Set tags for a task (replaces existing)
 ```
 
 **Examples:**
+
 ```bash
 taskdog tags                    # List all tags
 taskdog tags 1                  # Show task 1's tags
@@ -229,12 +279,15 @@ taskdog tags 1 urgent backend   # Set tags for task 1
 ## Time Tracking
 
 ### log-hours - Log actual hours worked
+
 ```bash
 taskdog log-hours ID HOURS [-d DATE]
 ```
+
 Log actual hours worked on a task. Default date is today.
 
 **Examples:**
+
 ```bash
 taskdog log-hours 1 8
 taskdog log-hours 2 4.5 -d 2025-10-20
@@ -243,6 +296,7 @@ taskdog log-hours 2 4.5 -d 2025-10-20
 ## Optimization
 
 ### optimize - Auto-schedule tasks
+
 ```bash
 taskdog optimize [--start-date DATE] [--max-hours-per-day N] [-a ALGORITHM] [-f]
 ```
@@ -250,6 +304,7 @@ taskdog optimize [--start-date DATE] [--max-hours-per-day N] [-a ALGORITHM] [-f]
 Auto-generate optimal task schedules based on priorities, deadlines, and dependencies.
 
 **Available Algorithms:**
+
 - `greedy` (default) - Schedule highest priority tasks first
 - `balanced` - Distribute workload evenly across days
 - `backward` - Schedule from deadline backwards
@@ -261,12 +316,14 @@ Auto-generate optimal task schedules based on priorities, deadlines, and depende
 - `monte_carlo` - Use Monte Carlo simulation
 
 **Features:**
+
 - Respects fixed tasks and dependencies
 - Distributes workload across weekdays
 - Avoids weekend scheduling
 - Honors max_hours_per_day constraint
 
 **Examples:**
+
 ```bash
 taskdog optimize
 taskdog optimize --start-date 2025-10-22 --max-hours-per-day 8
@@ -277,6 +334,7 @@ taskdog optimize -f  # Force re-optimization
 ## Visualization
 
 ### table - Table view
+
 ```bash
 taskdog table [OPTIONS]
 ```
@@ -284,6 +342,7 @@ taskdog table [OPTIONS]
 Display tasks in table format with filtering and sorting.
 
 **Options:**
+
 - `-s/--sort FIELD` - Sort by: id, priority, deadline, name, status, planned_start
 - `-r/--reverse` - Reverse sort order
 - `-a/--all` - Include archived tasks (default: non-archived only)
@@ -294,6 +353,7 @@ Display tasks in table format with filtering and sorting.
 - `--end-date DATE` - Filter by planned end date (to)
 
 **Examples:**
+
 ```bash
 taskdog table
 taskdog table -s priority -r
@@ -302,6 +362,7 @@ taskdog table -a  # Show archived tasks too
 ```
 
 ### gantt - Gantt chart
+
 ```bash
 taskdog gantt [OPTIONS]
 ```
@@ -309,6 +370,7 @@ taskdog gantt [OPTIONS]
 Display visual timeline with workload analysis. Supports same filter/sort options as table.
 
 **Features:**
+
 - Visual timeline with daily hours
 - Status symbols (◆)
 - Weekend coloring
@@ -316,6 +378,7 @@ Display visual timeline with workload analysis. Supports same filter/sort option
 - Strikethrough for finished tasks
 
 **Examples:**
+
 ```bash
 taskdog gantt
 taskdog gantt -s deadline
@@ -323,22 +386,26 @@ taskdog gantt --start-date 2025-10-20 --end-date 2025-10-30
 ```
 
 ### today - Today's tasks
+
 ```bash
 taskdog today [--sort FIELD] [--reverse]
 ```
 
 Show tasks relevant for today:
+
 - Deadline is today
 - Planned schedule includes today
 - Status is IN_PROGRESS
 
 **Examples:**
+
 ```bash
 taskdog today
 taskdog today -s priority
 ```
 
 ### week - This week's tasks
+
 ```bash
 taskdog week [--sort FIELD] [--reverse]
 ```
@@ -346,12 +413,14 @@ taskdog week [--sort FIELD] [--reverse]
 Show tasks relevant for this week (same filtering logic as today).
 
 **Examples:**
+
 ```bash
 taskdog week
 taskdog week -s deadline
 ```
 
 ### show - Task details
+
 ```bash
 taskdog show ID [--raw]
 ```
@@ -359,12 +428,14 @@ taskdog show ID [--raw]
 Show detailed information for a task, including notes. Notes are rendered as markdown by default.
 
 **Examples:**
+
 ```bash
 taskdog show 1
 taskdog show 1 --raw  # Show raw markdown
 ```
 
 ### export - Export tasks
+
 ```bash
 taskdog export [OPTIONS]
 ```
@@ -372,6 +443,7 @@ taskdog export [OPTIONS]
 Export tasks to JSON or CSV format. Exports non-archived tasks by default.
 
 **Options:**
+
 - `--format FORMAT` - json (default) or csv
 - `-o/--output FILE` - Output file path
 - `-f/--fields LIST` - Custom field selection
@@ -382,6 +454,7 @@ Export tasks to JSON or CSV format. Exports non-archived tasks by default.
 - `--end-date DATE` - Filter by date range
 
 **Examples:**
+
 ```bash
 taskdog export
 taskdog export --format csv -o tasks.csv
@@ -389,6 +462,7 @@ taskdog export --status pending -t backend
 ```
 
 ### report - Generate markdown report
+
 ```bash
 taskdog report [OPTIONS]
 ```
@@ -396,9 +470,11 @@ taskdog report [OPTIONS]
 Generate markdown workload report grouped by date. Useful for exporting to Notion or other documentation tools.
 
 **Options:**
+
 - Same filtering options as table/export
 
 **Examples:**
+
 ```bash
 taskdog report
 taskdog report --start-date 2025-10-20 --end-date 2025-10-30
@@ -408,6 +484,7 @@ taskdog report -t backend -o weekly-report.md
 ## Analytics
 
 ### stats - Task statistics
+
 ```bash
 taskdog stats [--period PERIOD] [--focus FOCUS]
 ```
@@ -415,10 +492,12 @@ taskdog stats [--period PERIOD] [--focus FOCUS]
 Display task statistics and analytics.
 
 **Options:**
+
 - `-p/--period` - all (default), 7d, 30d
 - `-f/--focus` - all (default), basic, time, estimation, deadline, priority, trends
 
 **Examples:**
+
 ```bash
 taskdog stats
 taskdog stats -p 7d -f time
@@ -428,6 +507,7 @@ taskdog stats --period 30d --focus trends
 ## Notes & TUI
 
 ### note - Edit task notes
+
 ```bash
 taskdog note ID
 ```
@@ -435,11 +515,13 @@ taskdog note ID
 Edit markdown notes for a task using `$EDITOR`.
 
 **Examples:**
+
 ```bash
 taskdog note 1
 ```
 
 ### tui - Interactive TUI
+
 ```bash
 taskdog tui
 ```
@@ -447,6 +529,7 @@ taskdog tui
 Launch full-screen interactive terminal user interface.
 
 **Key features:**
+
 - Real-time task search and filtering
 - Keyboard shortcuts for quick operations
 - Sort by deadline, priority, planned start, or ID
@@ -471,6 +554,7 @@ Tasks can be in one of four states:
 Tasks can be organized with tags for better categorization and filtering.
 
 **Examples:**
+
 ```bash
 # Add task with tags
 taskdog add "Backend API" --tag backend --tag api
@@ -486,6 +570,7 @@ taskdog table --tag api --tag db  # OR logic: tasks with 'api' OR 'db'
 ```
 
 **Tag behavior:**
+
 - Tags are case-sensitive
 - Multiple tags can be assigned to a task
 - Tags are automatically created when first used

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -55,6 +55,7 @@ cors_origins = ["http://localhost:3000", "http://localhost:8000"]
 ```
 
 **Fields:**
+
 - `cors_origins` (list of strings) - Allowed CORS origins for web browser access. Used for future Web UI support.
 
 **Environment variable:** `TASKDOG_API_CORS_ORIGINS` (comma-separated list)
@@ -69,6 +70,7 @@ theme = "textual-dark"        # TUI theme (default: "textual-dark")
 ```
 
 **Fields:**
+
 - `theme` (string) - TUI color theme. Available options:
   - `textual-dark` - Default dark theme
   - `textual-light` - Light theme
@@ -87,6 +89,7 @@ default_algorithm = "greedy"   # Default scheduling algorithm (default: "greedy"
 ```
 
 **Fields:**
+
 - `max_hours_per_day` (float) - Maximum hours to schedule per day. Used by optimizer to distribute workload.
 - `default_algorithm` (string) - Default optimization algorithm. Available options:
   - `greedy` - Schedule highest priority tasks first
@@ -100,6 +103,7 @@ default_algorithm = "greedy"   # Default scheduling algorithm (default: "greedy"
   - `monte_carlo` - Use Monte Carlo simulation
 
 **CLI Override:**
+
 ```bash
 taskdog optimize --max-hours-per-day 8 -a balanced
 ```
@@ -114,9 +118,11 @@ default_priority = 5           # Default task priority (default: 5)
 ```
 
 **Fields:**
+
 - `default_priority` (integer) - Default priority for new tasks. Higher values = higher priority.
 
 **CLI Override:**
+
 ```bash
 taskdog add "Task name" -p 150
 ```
@@ -132,6 +138,7 @@ default_end_hour = 18          # Business day end hour (default: 18)
 ```
 
 **Fields:**
+
 - `default_start_hour` (integer) - Business day start hour (0-23). Used when scheduling tasks without specific times.
 - `default_end_hour` (integer) - Business day end hour (0-23). Used for workload calculations.
 
@@ -147,11 +154,13 @@ country = "JP"                 # ISO 3166-1 alpha-2 country code
 ```
 
 **Fields:**
+
 - `country` (string, optional) - ISO 3166-1 alpha-2 country code for holiday checking.
   - Examples: `"JP"` (Japan), `"US"` (United States), `"GB"` (United Kingdom), `"DE"` (Germany)
   - Default: `None` (no holiday checking)
 
 **Behavior:**
+
 - When set, the optimizer will avoid scheduling tasks on national holidays for the specified country.
 - Requires internet connection to fetch holiday data on first use (cached locally).
 
@@ -166,6 +175,7 @@ backend = "sqlite"             # Storage backend (default: "sqlite")
 ```
 
 **Fields:**
+
 - `database_url` (string) - Path to SQLite database file. Supports `~` expansion.
 - `backend` (string) - Storage backend type. Currently only `"sqlite"` is supported.
 
@@ -178,12 +188,14 @@ backend = "sqlite"             # Storage backend (default: "sqlite")
 **Location:** `$XDG_DATA_HOME/taskdog/tasks.db` (fallback: `~/.local/share/taskdog/tasks.db`)
 
 **Features:**
+
 - Transactional writes with ACID guarantees
 - Automatic rollback on errors
 - Indexed queries for efficient filtering
 - Connection pooling and proper resource management
 
 **Backup:**
+
 ```bash
 cp ~/.local/share/taskdog/tasks.db ~/.local/share/taskdog/tasks.db.backup
 ```
@@ -386,6 +398,7 @@ backend = "sqlite"
 **Error:** "API connection error" or "Cannot connect to server"
 
 **Solution:**
+
 1. Start the API server: `taskdog-server`
 2. Verify server is running: `curl http://localhost:8000/health`
 3. Check host and port in `cli.toml` match the running server
@@ -396,6 +409,7 @@ backend = "sqlite"
 **Error:** TUI still uses default theme
 
 **Solution:**
+
 1. Ensure `[ui]` section is present in `~/.config/taskdog/config.toml`
 2. Restart TUI: `taskdog tui`
 3. Check theme name spelling (must match exactly)
@@ -405,6 +419,7 @@ backend = "sqlite"
 **Error:** Tasks scheduled for more hours than max_hours_per_day
 
 **Solution:**
+
 1. Fixed tasks (`is_fixed = true`) count towards daily limit but cannot be moved
 2. Check if multiple tasks overlap in schedule
 3. Increase `max_hours_per_day` if needed
@@ -415,6 +430,7 @@ backend = "sqlite"
 **Error:** "Database file not found" or "No such file or directory"
 
 **Solution:**
+
 1. Database is created automatically on first use
 2. Ensure parent directory exists: `mkdir -p ~/.local/share/taskdog`
 3. Check `database_url` path in config file

--- a/docs/OPTIMIZATION_ARCHITECTURE.md
+++ b/docs/OPTIMIZATION_ARCHITECTURE.md
@@ -55,6 +55,7 @@ class OptimizationStrategy(ABC):
 ```
 
 **Benefits:**
+
 - Eliminates code duplication across 9 strategies
 - Ensures consistent behavior (initialization, failure recording, etc.)
 - Clear extension points via abstract methods
@@ -100,6 +101,7 @@ class AllocationContext:
 ```
 
 **Benefits:**
+
 - Reduces parameter explosion (7 → 2 parameters per method)
 - Groups related constraints and state
 - Supports nested method calls (Genetic/Monte Carlo strategies)
@@ -112,6 +114,7 @@ class AllocationContext:
 **Location:** `packages/taskdog-core/src/taskdog_core/application/services/optimization/optimization_strategy.py`
 
 **Responsibilities:**
+
 - Defines template method `optimize_tasks()`
 - Provides protected helper methods for common operations
 - Enforces consistent workflow across all strategies
@@ -190,6 +193,7 @@ Supported algorithms: `greedy`, `balanced`, `backward`, `priority_first`, `earli
 **Location:** `packages/taskdog-core/src/taskdog_core/application/use_cases/optimize_schedule.py`
 
 Entry point that:
+
 1. Filters schedulable tasks (`is_schedulable()`)
 2. Creates strategy via StrategyFactory
 3. Calls `strategy.optimize_tasks()`
@@ -214,15 +218,18 @@ Entry point that:
 ### 1. Greedy (Default)
 
 **Sorting:**
+
 - Primary: Days until deadline (earlier first)
 - Secondary: Priority (higher first)
 - Tertiary: Task ID
 
 **Allocation:**
+
 - Forward from start_date
 - Fills each day to maximum before moving to next
 
 **Characteristics:**
+
 - Fast completion (front-loading)
 - Simple and predictable
 - Good for tight deadlines
@@ -230,14 +237,17 @@ Entry point that:
 ### 2. Balanced
 
 **Sorting:**
+
 - Same as Greedy (deadline, priority)
 
 **Allocation:**
+
 - Distributes hours evenly across available days
 - Target hours per day = total_duration / available_weekdays
 - Prevents burnout from front-loading
 
 **Characteristics:**
+
 - Better work-life balance
 - More realistic workload
 - Good for long-term projects
@@ -245,14 +255,17 @@ Entry point that:
 ### 3. Backward (Just-In-Time)
 
 **Sorting:**
+
 - Tasks without deadlines first
 - Then by deadline (furthest first)
 
 **Allocation:**
+
 - Backward from deadline
 - Allocates as late as possible
 
 **Characteristics:**
+
 - Maximum flexibility
 - Just-In-Time delivery
 - Good when requirements may change
@@ -260,13 +273,16 @@ Entry point that:
 ### 4. PriorityFirst
 
 **Sorting:**
+
 - Priority only (high to low)
 - Ignores deadlines completely
 
 **Allocation:**
+
 - Inherits from Greedy (front-loads)
 
 **Characteristics:**
+
 - Pure priority-based
 - Good for tasks without deadlines
 - Focuses on importance over urgency
@@ -274,13 +290,16 @@ Entry point that:
 ### 5. EarliestDeadline (EDF)
 
 **Sorting:**
+
 - Deadline only (earliest first)
 - Ignores priority completely
 
 **Allocation:**
+
 - Inherits from Greedy (front-loads)
 
 **Characteristics:**
+
 - Pure deadline-based
 - Minimizes deadline misses
 - Good for time-critical work
@@ -288,20 +307,24 @@ Entry point that:
 ### 6. DependencyAware (Critical Path Method)
 
 **Sorting:**
+
 - Primary: Blocking count (tasks that block others first)
 - Secondary: Deadline
 - Tertiary: Priority
 
 **Allocation:**
+
 - Inherits from Greedy (front-loads)
 
 **Characteristics:**
+
 - Schedules bottleneck tasks first
 - Minimizes overall project duration
 - Uses task.depends_on relationships
 
 **Example:**
-```
+
+```text
 Task A depends on Task B and Task C
 → Task B blocks Task A (blocking count = 1)
 → Task C blocks Task A (blocking count = 1)
@@ -311,13 +334,16 @@ Task A depends on Task B and Task C
 ### 7. RoundRobin
 
 **Sorting:**
+
 - None (uses iteration order)
 
 **Allocation:**
+
 - Cycles through tasks, allocating small chunks
 - Distributes time fairly across all tasks
 
 **Characteristics:**
+
 - Fair time distribution
 - No starvation (all tasks get time)
 - Good for parallel work
@@ -325,19 +351,23 @@ Task A depends on Task B and Task C
 ### 8. Genetic
 
 **Sorting:**
+
 - Fitness-based (evolutionary)
 - Evolves task orderings over generations
 
 **Allocation:**
+
 - Best ordering found after N generations
 - Uses Greedy allocation for each ordering
 
 **Characteristics:**
+
 - Finds near-optimal solutions
 - Computationally expensive (50 generations × 20 population)
 - Good for complex scheduling problems
 
 **Parameters:**
+
 - Population: 20
 - Generations: 50
 - Crossover rate: 0.8
@@ -346,14 +376,17 @@ Task A depends on Task B and Task C
 ### 9. MonteCarlo
 
 **Sorting:**
+
 - Random sampling of orderings
 - Evaluates fitness of each sample
 
 **Allocation:**
+
 - Best ordering found after N simulations
 - Uses Greedy allocation for each ordering
 
 **Characteristics:**
+
 - Probabilistic optimization
 - Computationally expensive (100 simulations)
 - Good for exploring solution space
@@ -362,7 +395,7 @@ Task A depends on Task B and Task C
 
 ### Optimization Workflow
 
-```
+```text
 OptimizeScheduleUseCase
   ↓
   ├─ Filter schedulable tasks (is_schedulable())
@@ -441,6 +474,7 @@ def _prepare_task_for_allocation(self, task: Task) -> Task | None:
 ```
 
 **Usage:**
+
 ```python
 task_copy = self._prepare_task_for_allocation(task)
 if task_copy is None:
@@ -474,6 +508,7 @@ def _calculate_available_hours(
 ```
 
 **Handles:**
+
 - Maximum hours per day constraint
 - Already allocated hours
 - Remaining hours for today (if current_time provided)
@@ -519,6 +554,7 @@ def _rollback_allocations(
 ```
 
 **Usage:**
+
 ```python
 task_daily_allocations = {}
 # ... allocation logic ...
@@ -631,6 +667,7 @@ class TestMyStrategy(BaseOptimizationStrategyTest):
 **Problem:** GeneticOptimizationStrategy and MonteCarloOptimizationStrategy called non-existent `greedy_strategy._get_holiday_checker()`, causing `holiday_checker` to always be `None`.
 
 **Solution:**
+
 - Added `self.holiday_checker` instance variable
 - Store `holiday_checker` in `optimize_tasks()`
 - Pass `self.holiday_checker` to temporary contexts
@@ -642,6 +679,7 @@ class TestMyStrategy(BaseOptimizationStrategyTest):
 **Problem:** Greedy, Balanced, and Backward had identical validation logic (6 lines × 3 = 18 lines duplication).
 
 **Solution:**
+
 - Extracted `_prepare_task_for_allocation()` to base class
 - Validates task, creates deep copy, defensive check
 - Returns `Task | None`
@@ -653,6 +691,7 @@ class TestMyStrategy(BaseOptimizationStrategyTest):
 **Problem:** DependencyAwareOptimizationStrategy had `_calculate_dependency_depths()` that always returned 0 (vestigial from removed parent-child relationships).
 
 **Solution:**
+
 - Removed `_calculate_dependency_depths()` method
 - Simplified sorting logic to direct deadline/priority sort
 
@@ -663,6 +702,7 @@ class TestMyStrategy(BaseOptimizationStrategyTest):
 **Problem:** DependencyAwareOptimizationStrategy was functionally identical to Greedy (sorted by deadline/priority, ignored `depends_on` field).
 
 **Solution:**
+
 - Implemented true Critical Path Method
 - Calculate blocking count (how many tasks depend on each task)
 - Sort by: blocking count (desc), deadline (asc), priority (desc)
@@ -671,6 +711,7 @@ class TestMyStrategy(BaseOptimizationStrategyTest):
 **Impact:** DependencyAware now provides unique value, uses `depends_on` field.
 
 **Example:**
+
 ```python
 # Before: deadline/priority sort (same as Greedy)
 sorted(tasks, key=lambda t: (t.deadline or MAX, -t.priority))

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,6 +15,7 @@ Taskdog uses **two separate configuration files** for clear separation of concer
 **Location**: `~/.config/taskdog/config.toml`
 
 **Contains**:
+
 - Task defaults (default priority)
 - Optimization settings (max hours per day, default algorithm)
 - Time settings (default start/end hours)
@@ -33,6 +34,7 @@ Taskdog uses **two separate configuration files** for clear separation of concer
 **Location**: `~/.config/taskdog/cli.toml`
 
 **Contains**:
+
 - API connection settings (host, port)
 - Future: Keybindings customization
 - Future: Theme/color preferences
@@ -58,6 +60,7 @@ No configuration needed!
 ### Custom Setup
 
 1. **Copy example files**:
+
    ```bash
    mkdir -p ~/.config/taskdog
    cp examples/config.toml ~/.config/taskdog/
@@ -65,6 +68,7 @@ No configuration needed!
    ```
 
 2. **Edit as needed**:
+
    ```bash
    # Server config (business logic)
    $EDITOR ~/.config/taskdog/config.toml
@@ -74,13 +78,14 @@ No configuration needed!
    ```
 
 3. **Restart server** (if config.toml changed):
+
    ```bash
    systemctl --user restart taskdog-server
    ```
 
 ## Configuration File Relationship
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │                         User                                │
 └────────┬───────────────────────────────────┬────────────────┘
@@ -128,6 +133,7 @@ This separation provides several benefits:
 ## Common Scenarios
 
 ### Scenario 1: Default Local Setup
+
 **No config files needed!**
 
 ```bash
@@ -136,7 +142,9 @@ taskdog table   # Uses defaults
 ```
 
 ### Scenario 2: Custom Server Port
+
 **Server** (`~/.config/taskdog/config.toml`):
+
 ```toml
 [api]
 enabled = true
@@ -144,13 +152,16 @@ port = 3000
 ```
 
 **CLI** (`~/.config/taskdog/cli.toml`):
+
 ```toml
 [api]
 port = 3000
 ```
 
 ### Scenario 3: Remote Server
+
 **Server** (on remote machine):
+
 ```toml
 [api]
 enabled = true
@@ -159,6 +170,7 @@ port = 8000
 ```
 
 **CLI** (on local machine):
+
 ```toml
 [api]
 host = "192.168.1.100"  # Remote server IP
@@ -166,7 +178,9 @@ port = 8000
 ```
 
 ### Scenario 4: Custom Business Logic
+
 **Only edit config.toml**:
+
 ```toml
 [task]
 default_priority = 7  # Higher default priority
@@ -186,6 +200,7 @@ CLI needs no changes - it automatically uses server's settings.
 Both configs support environment variable overrides:
 
 ### CLI (`cli.toml`)
+
 ```bash
 export TASKDOG_API_HOST=192.168.1.100
 export TASKDOG_API_PORT=3000
@@ -193,7 +208,9 @@ taskdog table
 ```
 
 ### Server (`config.toml`)
+
 No environment variables currently supported. Use config file or command-line args:
+
 ```bash
 taskdog-server --host 0.0.0.0 --port 3000
 ```
@@ -211,31 +228,38 @@ The old single-config approach still works for the server. CLI just gained its o
 ## Troubleshooting
 
 ### "Cannot connect to API server"
+
 **Problem**: CLI can't reach server
 
 **Check**:
+
 1. Is server running? `systemctl --user status taskdog-server`
 2. Check CLI config: `cat ~/.config/taskdog/cli.toml`
 3. Check server config: `cat ~/.config/taskdog/config.toml`
 4. Test connection: `curl http://127.0.0.1:8000/health`
 
 **Common fixes**:
+
 - Start server: `systemctl --user start taskdog-server`
 - Match ports in both configs
 - Use `127.0.0.1` (not `0.0.0.0`) in CLI config
 
 ### "Invalid configuration"
+
 **Problem**: Config file has syntax errors
 
 **Fix**:
+
 1. Validate TOML syntax: Copy example file and edit carefully
 2. Check for typos in section names: `[api]`, `[task]`, etc.
 3. Ensure correct types: numbers without quotes, strings with quotes
 
 ### Server doesn't use my defaults
+
 **Problem**: Custom priority/algorithm not applied
 
 **Check**:
+
 1. Are you editing the right file? Server uses `config.toml`, not `cli.toml`
 2. Did you restart server? `systemctl --user restart taskdog-server`
 3. Check file location: `~/.config/taskdog/config.toml`

--- a/examples/note_template.md
+++ b/examples/note_template.md
@@ -1,6 +1,7 @@
 # {{task_name}}
 
 ## Task Info
+
 - **ID**: {{task_id}}
 - **Priority**: {{priority}}
 - **Status**: {{status}}
@@ -9,16 +10,21 @@
 - **Tags**: {{tags}}
 
 ## Overview
+
 [Task overview here]
 
 ## Details
+
 - [ ] Subtask 1
 - [ ] Subtask 2
 - [ ] Subtask 3
 
 ## Technical Notes
+
 [Technical details, references, links, etc.]
 
 ## Progress Log
+
 ### {{created_at}}
+
 [Work started]

--- a/packages/taskdog-core/README.md
+++ b/packages/taskdog-core/README.md
@@ -27,7 +27,7 @@ pip install -e ".[dev]"
 
 Follows Clean Architecture principles:
 
-```
+```text
 Domain (entities, services, repositories)
   ↑
 Application (use cases, queries, DTOs)

--- a/packages/taskdog-ui/ARCHITECTURE.md
+++ b/packages/taskdog-ui/ARCHITECTURE.md
@@ -21,12 +21,14 @@ Each pattern serves a specific purpose and should be used in the appropriate con
 **Purpose**: Single Source of Truth (SSoT) for all shared application state.
 
 **What goes in TUIState**:
+
 - Filter settings (e.g., `hide_completed`)
 - Sort settings (e.g., `sort_by`, `sort_reverse`)
 - Data caches (e.g., `tasks_cache`, `viewmodels_cache`, `gantt_cache`)
 - Any state accessed by multiple widgets
 
 **Access pattern**:
+
 ```python
 # In widgets
 from taskdog.tui.app import TaskdogTUI
@@ -37,12 +39,14 @@ value = app.state.hide_completed
 ```
 
 **Key characteristics**:
+
 - Centralized: All widgets access the same state instance
 - Pull-based: Widgets read from state when needed
 - Explicit updates: State changes don't automatically trigger UI updates
 - Framework-agnostic: Not tied to Textual's reactive system
 
 **When to use**:
+
 - State needs to be accessed by multiple widgets
 - State represents application-level configuration
 - State needs to survive widget lifecycle
@@ -57,6 +61,7 @@ value = app.state.hide_completed
 **Purpose**: Notify components about events that occurred elsewhere.
 
 **Current events**:
+
 - `TaskCreated(task_id)` - Task was created
 - `TaskUpdated(task_id)` - Task was modified
 - `TaskDeleted(task_id)` - Task was removed
@@ -66,6 +71,7 @@ value = app.state.hide_completed
 - `GanttResizeRequested(...)` - Gantt recalculation needed
 
 **Usage pattern**:
+
 ```python
 # Post message
 self.post_message(TaskUpdated(task.id))
@@ -76,12 +82,14 @@ def on_task_updated(self, event: TaskUpdated) -> None:
 ```
 
 **Key characteristics**:
+
 - Decoupled: Sender doesn't know about receivers
 - Bubbling: Messages travel up the widget hierarchy
 - Multi-listener: Multiple widgets can handle the same message
 - Asynchronous: Messages processed via event queue
 
 **When to use**:
+
 - Notifying parent widgets about child events
 - Broadcasting events to multiple listeners
 - Decoupling components (child doesn't need parent reference)
@@ -94,12 +102,14 @@ def on_task_updated(self, event: TaskUpdated) -> None:
 **Purpose**: Manage widget-internal UI state with automatic updates.
 
 **What goes in reactive variables**:
+
 - Search query in SearchInput
 - Selection count in TaskTable
 - Expanded/collapsed state in widgets
 - Any state that only affects one widget's display
 
 **Usage pattern**:
+
 ```python
 from textual.reactive import reactive
 
@@ -112,12 +122,14 @@ class MyWidget(Widget):
 ```
 
 **Key characteristics**:
+
 - Widget-scoped: State belongs to single widget
 - Push-based: Changes automatically trigger watch methods
 - Implicit updates: No manual notification needed
 - Textual-native: Uses framework's built-in reactivity
 
 **When to use**:
+
 - State only affects one widget
 - Want automatic UI updates on state change
 - State is purely UI-related (not business logic)
@@ -145,6 +157,7 @@ class MyWidget(Widget):
 **State**: `TUIState.hide_completed` (shared across app)
 
 **Why TUIState**:
+
 - Multiple widgets need this (TaskTable, GanttWidget)
 - Application-level setting
 - Needs to survive widget recreation
@@ -161,6 +174,7 @@ def action_toggle_completed(self) -> None:
 **Event**: `TaskUpdated` message
 
 **Why Messages**:
+
 - Command executed → notify app → reload data
 - Decouples command from app
 - App can handle update without command knowing implementation
@@ -179,6 +193,7 @@ def on_task_updated(self, event: TaskUpdated) -> None:
 **State**: `SearchInput.query` reactive variable
 
 **Why Reactive**:
+
 - Only SearchInput cares about this
 - Want automatic event posting on change
 - Widget-internal UI state
@@ -197,6 +212,7 @@ class SearchInput(Container):
 **State**: `TaskTable.selection_count` reactive variable
 
 **Why Reactive**:
+
 - Only TaskTable displays this
 - Want automatic footer update
 - Widget-internal UI state
@@ -215,6 +231,7 @@ class TaskTable(DataTable):
 ## Anti-Patterns to Avoid
 
 ### ❌ Don't use reactive for shared state
+
 ```python
 # BAD: Other widgets can't access this
 class TaskdogTUI(App):
@@ -222,6 +239,7 @@ class TaskdogTUI(App):
 ```
 
 ### ❌ Don't use TUIState for widget-internal state
+
 ```python
 # BAD: Pollutes global state
 class TUIState:
@@ -229,12 +247,14 @@ class TUIState:
 ```
 
 ### ❌ Don't use Messages for return values
+
 ```python
 # BAD: Messages are for notifications, not data transfer
 self.post_message(GetTaskResult(task))  # Use direct method call instead
 ```
 
 ### ❌ Don't bypass TUIState
+
 ```python
 # BAD: State duplication
 class TaskTable(DataTable):
@@ -246,16 +266,19 @@ class TaskTable(DataTable):
 ## Architecture Evolution
 
 ### Phase 1: Scattered State (Before)
+
 - State duplicated across 8+ locations
 - Manual synchronization required
 - High bug risk
 
 ### Phase 2: Centralized State (Current)
+
 - TUIState as Single Source of Truth
 - Messages for event notifications
 - Eliminated state duplication
 
 ### Phase 3: Selective Reactive (Now)
+
 - Widget-internal state uses reactive
 - Shared state remains in TUIState
 - Hybrid approach for optimal balance

--- a/packages/taskdog-ui/CLI_CONFIG.md
+++ b/packages/taskdog-ui/CLI_CONFIG.md
@@ -15,13 +15,13 @@ The CLI/TUI is a thin client that delegates all business logic to the server. Al
 
 The CLI configuration file is located at:
 
-```
+```text
 ~/.config/taskdog/cli.toml
 ```
 
 Or, if `XDG_CONFIG_HOME` is set:
 
-```
+```text
 $XDG_CONFIG_HOME/taskdog/cli.toml
 ```
 
@@ -51,6 +51,7 @@ theme = "textual-dark"  # TUI theme (default: "textual-dark")
 ```
 
 **Available themes**:
+
 - `textual-dark` (default) - Textual's dark theme
 - `textual-light` - Textual's light theme
 - `nord` - Nord color scheme
@@ -184,6 +185,7 @@ The separation means:
 **Solutions**:
 
 1. Check if server is running:
+
    ```bash
    systemctl --user status taskdog-server
    # Or manually:
@@ -191,17 +193,20 @@ The separation means:
    ```
 
 2. Check server host/port:
+
    ```bash
    # Server default: 127.0.0.1:8000
    # CLI default: 127.0.0.1:8000
    ```
 
 3. Verify CLI config matches server config:
+
    ```bash
    cat ~/.config/taskdog/cli.toml
    ```
 
 4. Test connection manually:
+
    ```bash
    curl http://127.0.0.1:8000/health
    # Should return: {"status":"healthy"}
@@ -214,6 +219,7 @@ The separation means:
 **Solution**:
 
 1. Check TOML syntax:
+
    ```bash
    cat ~/.config/taskdog/cli.toml
    ```
@@ -224,6 +230,7 @@ The separation means:
    - Invalid port (must be integer)
 
 3. Start fresh with minimal config:
+
    ```toml
    [api]
    host = "127.0.0.1"

--- a/packages/taskdog-ui/README.md
+++ b/packages/taskdog-ui/README.md
@@ -7,12 +7,14 @@ Command-line interface and terminal user interface for Taskdog task management s
 This package provides two user interfaces for Taskdog:
 
 ### CLI (Command-Line Interface)
+
 - 30+ commands for task management
 - Rich terminal output with colors and formatting
 - Batch operations support
 - Export capabilities (JSON, CSV, Markdown)
 
 ### TUI (Terminal User Interface)
+
 - Full-screen interactive interface powered by Textual
 - Real-time task table with filtering and search
 - Gantt chart visualization
@@ -74,6 +76,7 @@ port = 8000
 ```
 
 Or set environment variable:
+
 ```bash
 export TASKDOG_API_URL=http://127.0.0.1:8000
 ```
@@ -116,6 +119,7 @@ taskdog tui
 ```
 
 Keyboard shortcuts:
+
 - `a`: Add task
 - `s`: Start task
 - `d`: Complete task


### PR DESCRIPTION
## Summary

- Add `markdownlint-cli2` (v0.17.2) for markdown linting with auto-fix
- Add `actionlint` (v1.7.7) for GitHub Actions workflow linting
- Create `.markdownlint.yaml` with project-specific rules
- Fix all existing markdown lint errors across documentation files

## Changes

### Pre-commit hooks added
- **markdownlint-cli2**: Lints markdown files with `--fix` for auto-correction
- **actionlint**: Validates GitHub Actions workflow files

### Markdownlint configuration (`.markdownlint.yaml`)
Disabled rules for project style:
- MD013 (line length)
- MD033 (inline HTML - for badges)
- MD036 (emphasis as heading)
- MD029 (ordered list prefix)
- MD041 (first line heading)
- MD051 (link fragments)

### Fixed markdown files
- Added language specifiers (`text`) to code blocks (MD040)
- Auto-fixed formatting issues (blank lines between elements)

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] `pre-commit run markdownlint-cli2 --all-files` passes
- [x] `pre-commit run actionlint --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)