### PR TITLE
fix: display search count on TUI startup

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/services/task_ui_manager.py
+++ b/packages/taskdog-ui/src/taskdog/tui/services/task_ui_manager.py
@@ -146,12 +146,11 @@ class TaskUIManager:
                 all=False,  # Non-archived by default
             )
 
-        # Update Table widget
-        if main_screen.task_table:
-            main_screen.task_table.refresh_tasks(
-                task_data.table_view_models,
-                keep_scroll_position=keep_scroll_position,
-            )
+        # Update Table widget (via main_screen to update search result count)
+        main_screen.refresh_tasks(
+            task_data.table_view_models,
+            keep_scroll_position=keep_scroll_position,
+        )
 
     def recalculate_gantt(self, start_date: date, end_date: date) -> None:
         """Recalculate gantt data for a new date range.


### PR DESCRIPTION
## Summary
- TUI起動時に検索ボックスの `(matched/total)` カウントが表示されない問題を修正
- `TaskUIManager` が `main_screen.refresh_tasks()` を経由せず `task_table.refresh_tasks()` を直接呼んでいたため、`_update_search_result()` がバイパスされていた

## Test plan
- [x] TUIを起動し、検索ボックスに `(n/n)` 形式でタスク数が表示されることを確認
- [x] `make test-ui` が全てパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)