### PR TITLE
fix: prevent TUI dialog crashes on invalid input

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/algorithm_selection_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/algorithm_selection_dialog.py
@@ -157,7 +157,16 @@ class AlgorithmSelectionDialog(
             self._show_validation_error("Start date is required", start_date_input)
             return
 
-        # Parse values (validation handled by Textual validators)
+        # Check if inputs are valid (Textual shows validation error automatically)
+        if not max_hours_input.is_valid:
+            max_hours_input.focus()
+            return
+
+        if not start_date_input.is_valid:
+            start_date_input.focus()
+            return
+
+        # Parse values
         max_hours_str = max_hours_input.value.strip()
         max_hours = float(max_hours_str) if max_hours_str else None
 

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/task_form_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/task_form_dialog.py
@@ -119,19 +119,40 @@ class TaskFormDialog(BaseModalDialog[TaskFormData | None]):
             return
 
         # Parse priority (optional, defaults to config value)
-        # Validation is handled by Textual's Number validator
         from taskdog.tui.constants.ui_settings import (
             DEFAULT_END_HOUR,
             DEFAULT_START_HOUR,
             DEFAULT_TASK_PRIORITY,
         )
 
+        # Validate numeric fields before parsing (Textual shows validation error automatically)
+        if not priority_input.is_valid:
+            priority_input.focus()
+            return
+
+        if not duration_input.is_valid:
+            duration_input.focus()
+            return
+
         priority_str = priority_input.value.strip()
         priority = int(priority_str) if priority_str else DEFAULT_TASK_PRIORITY
 
-        # Parse duration (optional, validated by Textual's Number validator)
+        # Parse duration (optional)
         duration_str = duration_input.value.strip()
         duration = float(duration_str) if duration_str else None
+
+        # Validate datetime fields before parsing (Textual shows validation error automatically)
+        if not deadline_input.is_valid:
+            deadline_input.focus()
+            return
+
+        if not planned_start_input.is_valid:
+            planned_start_input.focus()
+            return
+
+        if not planned_end_input.is_valid:
+            planned_end_input.focus()
+            return
 
         # Parse datetime fields using DateTimeValidator.parse()
         deadline_validator = DateTimeValidator("deadline", DEFAULT_END_HOUR)
@@ -142,7 +163,16 @@ class TaskFormDialog(BaseModalDialog[TaskFormData | None]):
         planned_start = planned_start_validator.parse(planned_start_input.value)
         planned_end = planned_end_validator.parse(planned_end_input.value)
 
-        # Parse dependencies (optional, validated by Textual's Regex validator)
+        # Validate dependencies and tags before parsing
+        if not dependencies_input.is_valid:
+            dependencies_input.focus()
+            return
+
+        if not tags_input.is_valid:
+            tags_input.focus()
+            return
+
+        # Parse dependencies (optional)
         dependencies_str = dependencies_input.value.strip()
         if dependencies_str:
             dependencies = [
@@ -151,7 +181,7 @@ class TaskFormDialog(BaseModalDialog[TaskFormData | None]):
         else:
             dependencies = []
 
-        # Parse tags (optional, validated by Textual's Regex validator)
+        # Parse tags (optional)
         tags_str = tags_input.value.strip()
         tags = [x.strip() for x in tags_str.split(",") if x.strip()] if tags_str else []
 

--- a/packages/taskdog-ui/src/taskdog/tui/styles/dialogs.tcss
+++ b/packages/taskdog-ui/src/taskdog/tui/styles/dialogs.tcss
@@ -105,7 +105,7 @@ HelpDialog {
 
 /* Algorithm Selection Dialog */
 #algorithm-dialog {
-    max-height: 22;
+    max-height: 28;
 }
 
 #algorithm-list {

--- a/packages/taskdog-ui/tests/presentation/tui/forms/validators/test_optimization_validators.py
+++ b/packages/taskdog-ui/tests/presentation/tui/forms/validators/test_optimization_validators.py
@@ -1,0 +1,109 @@
+"""Tests for StartDateTextualValidator."""
+
+import unittest
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from parameterized import parameterized
+
+from taskdog.tui.forms.validators import StartDateTextualValidator
+
+
+class TestStartDateTextualValidator(unittest.TestCase):
+    """Test cases for StartDateTextualValidator."""
+
+    @parameterized.expand(
+        [
+            # Empty/whitespace cases (required field - should fail)
+            ("empty_string_is_invalid", "", False),
+            ("whitespace_only_is_invalid", "   ", False),
+            # Date format cases
+            ("date_format_yyyy_mm_dd_is_valid", "2025-12-01", True),
+            ("date_format_mm_dd_is_valid", "12/01", True),
+            ("date_format_with_time_is_valid", "2025-12-01 09:00", True),
+            # Relative date keywords
+            ("today_is_valid", "today", True),
+            ("tomorrow_is_valid", "tomorrow", True),
+            ("yesterday_is_valid", "yesterday", True),
+            ("today_uppercase_is_valid", "TODAY", True),
+            ("tomorrow_mixed_case_is_valid", "Tomorrow", True),
+            # Invalid cases
+            ("invalid_date_returns_error", "invalid-date", False),
+            ("random_text_returns_error", "not a date", False),
+            ("random_word_returns_error", "asdfgh", False),
+            ("japanese_text_returns_error", "あいうえお", False),
+            ("special_chars_returns_error", "!@#$%^", False),
+            ("numbers_only_returns_error", "12345", False),
+            ("emoji_returns_error", "🎉🎊", False),
+            ("sql_injection_returns_error", "'; DROP TABLE tasks;--", False),
+        ]
+    )
+    def test_validate(self, scenario, input_value, expected_valid):
+        """Test validation of start date values."""
+        validator = StartDateTextualValidator()
+        result = validator.validate(input_value)
+
+        self.assertEqual(result.is_valid, expected_valid, f"Failed for: {scenario}")
+
+        if not expected_valid:
+            self.assertIsNotNone(result.failure_descriptions)
+            self.assertTrue(len(result.failure_descriptions) > 0)
+
+    @patch("taskdog.tui.forms.validators.optimization_validators.datetime")
+    def test_parse_today(self, mock_datetime):
+        """Test parsing 'today' returns current date."""
+        mock_now = datetime(2025, 12, 1, 10, 0, 0)
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+
+        validator = StartDateTextualValidator()
+        result = validator.parse("today")
+
+        self.assertEqual(result.date(), mock_now.date())
+
+    @patch("taskdog.tui.forms.validators.optimization_validators.datetime")
+    def test_parse_tomorrow(self, mock_datetime):
+        """Test parsing 'tomorrow' returns next day."""
+        mock_now = datetime(2025, 12, 1, 10, 0, 0)
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+
+        validator = StartDateTextualValidator()
+        result = validator.parse("tomorrow")
+
+        expected = mock_now.date() + timedelta(days=1)
+        self.assertEqual(result.date(), expected)
+
+    @patch("taskdog.tui.forms.validators.optimization_validators.datetime")
+    def test_parse_yesterday(self, mock_datetime):
+        """Test parsing 'yesterday' returns previous day."""
+        mock_now = datetime(2025, 12, 1, 10, 0, 0)
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+
+        validator = StartDateTextualValidator()
+        result = validator.parse("yesterday")
+
+        expected = mock_now.date() - timedelta(days=1)
+        self.assertEqual(result.date(), expected)
+
+    def test_parse_standard_date_format(self):
+        """Test parsing standard date formats."""
+        validator = StartDateTextualValidator()
+
+        result = validator.parse("2025-12-15")
+        self.assertEqual(result.year, 2025)
+        self.assertEqual(result.month, 12)
+        self.assertEqual(result.day, 15)
+
+    def test_normalize_date_string_preserves_non_keywords(self):
+        """Test that non-keyword strings are passed through unchanged."""
+        validator = StartDateTextualValidator()
+
+        # _normalize_date_string should return the original value
+        self.assertEqual(validator._normalize_date_string("2025-12-01"), "2025-12-01")
+        self.assertEqual(validator._normalize_date_string("next monday"), "next monday")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add validation checks before parsing in TaskFormDialog and AlgorithmSelectionDialog to prevent crashes on invalid input
- Support relative date keywords (today, tomorrow, yesterday) in StartDateTextualValidator
- Increase optimize dialog height to prevent content cutoff
- Add tests for StartDateTextualValidator

## Test plan
- [x] Run `make typecheck` - passes
- [x] Run unit tests for optimization validators - passes
- [ ] Manual test: Enter invalid input in TUI dialogs (add, edit, optimize) and verify no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)