### PR TITLE
docs: remove duplicate content and move DESIGN_PHILOSOPHY.md to docs/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,7 +403,7 @@ Commands in `src/presentation/cli/commands/`, registered in `cli.py`:
 
 ### Design Principles
 
-**Core Philosophy**: Taskdog is designed for **individual task management** following GTD principles. See [DESIGN_PHILOSOPHY.md](DESIGN_PHILOSOPHY.md) for detailed rationale.
+**Core Philosophy**: Taskdog is designed for **individual task management** following GTD principles. See [DESIGN_PHILOSOPHY.md](docs/DESIGN_PHILOSOPHY.md) for detailed rationale.
 
 **Key Design Decisions**:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -350,7 +350,7 @@ PYTHONPATH=src uv run python -m taskdog_server.main --help
 
 ## Design Philosophy
 
-Before adding new features, please review [DESIGN_PHILOSOPHY.md](DESIGN_PHILOSOPHY.md).
+Before adding new features, please review [DESIGN_PHILOSOPHY.md](docs/DESIGN_PHILOSOPHY.md).
 
 Taskdog is designed for **individual task management**, following GTD principles:
 
@@ -405,7 +405,7 @@ By contributing to Taskdog, you agree that your contributions will be licensed u
 ## Additional Resources
 
 - [CLAUDE.md](CLAUDE.md) - Detailed architecture and development guide
-- [DESIGN_PHILOSOPHY.md](DESIGN_PHILOSOPHY.md) - Design principles and rationale
+- [DESIGN_PHILOSOPHY.md](docs/DESIGN_PHILOSOPHY.md) - Design principles and rationale
 - [README.md](README.md) - User documentation and features
 - [Conventional Commits](https://www.conventionalcommits.org/) - Commit message format
 - [UV Documentation](https://github.com/astral-sh/uv) - Package manager guide

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A task management system with CLI/TUI interfaces and REST API server, featuring 
 - **[Configuration Guide](docs/CONFIGURATION.md)** - All configuration options
 - **[Development Guide](CLAUDE.md)** - Architecture and development workflow
 - **[Contributing Guide](CONTRIBUTING.md)** - How to contribute
-- **[Design Philosophy](DESIGN_PHILOSOPHY.md)** - Why Taskdog works this way
+- **[Design Philosophy](docs/DESIGN_PHILOSOPHY.md)** - Why Taskdog works this way
 
 ## Features
 
@@ -70,7 +70,7 @@ Taskdog is designed for **individual task management**, following GTD (Getting T
 **Why no subtasks?**
 Individual users don't need complex hierarchies. Dependencies + tags cover 99% of personal task organization. This keeps the optimizer simple and your workflow focused.
 
-For detailed design rationale, see [DESIGN_PHILOSOPHY.md](DESIGN_PHILOSOPHY.md).
+For detailed design rationale, see [DESIGN_PHILOSOPHY.md](docs/DESIGN_PHILOSOPHY.md).
 
 ## Installation
 

--- a/docs/DESIGN_PHILOSOPHY.md
+++ b/docs/DESIGN_PHILOSOPHY.md
@@ -159,15 +159,9 @@ Compare this to Motion/Reclaim: "Our AI schedules your tasks" (black box, no con
 
 ## Why No Parent-Child Relationships?
 
-**TL;DR**: I tried. It didn't work well for individual task management.
+**TL;DR**: I tried. It didn't work well for individual task management. See "The Design Journey" section above for details.
 
-Early versions of Taskdog attempted to support parent-child task hierarchies. However, I found that this feature added significant complexity without proportional value for individual users.
-
-### The Attempt and Why I Abandoned It
-
-When I tried to implement parent-child relationships, I encountered three major problems:
-
-**1. Optimization Algorithms Became Unpredictable**
+### Why Optimization Became Unpredictable
 
 The core feature of Taskdog is schedule optimization. Parent-child relationships broke this:
 
@@ -190,45 +184,6 @@ The core feature of Taskdog is schedule optimization. Parent-child relationships
 ```
 
 Every optimization algorithm would need special handling for hierarchies. This made the codebase unmaintainable.
-
-**2. Business Logic Exploded in Complexity**
-
-See the Redmine example in section "Business Logic Complexity" below. I faced the same issues and realized I'd need to make arbitrary decisions for edge cases that had no clear right answer.
-
-**3. Individual Users Didn't Need It**
-
-After removing parent-child relationships, I tested with real workflows. Turns out:
-
-- Dependencies + tags cover 99% of organization needs
-- With only 1-3 concurrent tasks, mental hierarchy is sufficient
-- The complexity wasn't worth it
-
-**So I made a deliberate choice**: Optimize for individual task management, where parent-child relationships add complexity without value.
-
-This decision led to Taskdog's current positioning: **a tool for individuals, not teams**.
-
-### Additional Context
-
-These observations align with broader industry patterns:
-
-**GTD Philosophy**:
-> "The GTD methodology identifies multi-step projects with a desired outcome and a single 'next action' rather than mapping out all dependencies upfront."
-> — Getting Things Done Forums
-
-David Allen's GTD approach emphasizes:
-
-- **Planning phase**: Use hierarchical outlines (mental or on paper)
-- **Execution phase**: Flat list of "next actions"
-- Parent tasks are planning artifacts, not execution items
-
-**Taskwarrior's Approach**:
-Taskwarrior, the most successful terminal-based task manager, uses **dependencies only**:
-
-- No native subtask feature
-- Community plugins exist but aren't mainstream
-- Proven to work for thousands of users over 15+ years
-
-Our experience confirmed what these established approaches already knew: for individual task management, flat structure with dependencies is sufficient.
 
 ### Technical Details
 
@@ -258,22 +213,7 @@ class Task:
     # Simple, clear, no edge cases
 ```
 
-**2. Optimization Algorithm Complexity**
-
-Scheduling with hierarchies:
-
-- Do we schedule parent tasks? If so, when?
-- Are parent durations fixed or computed from children?
-- Can children be scheduled independently?
-- How to handle partial parent completion?
-
-Scheduling with dependencies:
-
-- Clear: schedule tasks whose dependencies are met
-- Predictable: algorithms behave consistently
-- Testable: easy to verify correctness
-
-**3. UI Complexity**
+**2. UI Complexity**
 
 TUI with hierarchies requires:
 
@@ -368,19 +308,6 @@ Epic: User Authentication System
 7+ people, 10+ concurrent tasks. **Hierarchy is necessary for coordination.**
 
 For personal task management with 1-3 concurrent tasks, parent-child relationships add complexity without benefit.
-
-**6. Individual vs. Team Needs**
-
-| Use Case | Individual | Team |
-|----------|-----------|------|
-| Task hierarchy depth | 1-2 levels | 3-5 levels |
-| Who creates subtasks? | Same person | Different people |
-| Parent meaning | Mental grouping | Milestone/deliverable |
-| Subtask reassignment | N/A | Common |
-| Need for structure | Low (in your head) | High (shared understanding) |
-| Concurrent tasks | 1-3 tasks | 10-100+ tasks |
-
-For individuals, **mental hierarchy + dependency tracking** is sufficient.
 
 ### How to Handle "But I Want Subtasks!"
 


### PR DESCRIPTION
## Summary
- Remove redundant sections that repeated information already covered elsewhere
- Move DESIGN_PHILOSOPHY.md to docs/ directory
- Update all references in CLAUDE.md, CONTRIBUTING.md, README.md

## Changes

### Removed duplicate sections
- "The Attempt and Why I Abandoned It" - duplicated "The Design Journey" (kept questions as "Why Optimization Became Unpredictable")
- "Additional Context" (GTD/Taskwarrior) - duplicated "Flat Structure Over Hierarchy"
- "Optimization Algorithm Complexity" in Technical Details - duplicated earlier section
- Second "Individual vs. Team Needs" table - duplicated first table

### File move
- `DESIGN_PHILOSOPHY.md` → `docs/DESIGN_PHILOSOPHY.md`

## Test plan
- [x] Verified markdown renders correctly
- [x] Verified all internal links work
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)