### PR TITLE
test: migrate from unittest to pytest (Phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,9 +74,9 @@ make coverage                    # Run all tests with coverage report (sorted by
                                  # Used in CI - test failure will stop execution
 
 # Single test file (run from package directory)
-cd packages/taskdog-core && PYTHONPATH=src uv run python -m unittest tests/test_module.py
+cd packages/taskdog-core && PYTHONPATH=src uv run python -m pytest tests/test_module.py -v
 # Specific test method
-cd packages/taskdog-core && PYTHONPATH=src uv run python -m unittest tests.test_module.TestClass.test_method
+cd packages/taskdog-core && PYTHONPATH=src uv run python -m pytest tests/test_module.py::TestClass::test_method -v
 
 # Code Quality
 make lint                        # Ruff linter on all packages
@@ -114,7 +114,7 @@ journalctl --user -u taskdog-server -f   # View logs in real-time
 # See contrib/README.md for detailed documentation
 ```
 
-**Testing**: Uses `unittest` framework. Tests mirror package structure under `packages/*/tests/`. Use `unittest.mock` for dependencies.
+**Testing**: Uses `pytest` framework (can run both pytest and unittest style tests). Tests mirror package structure under `packages/*/tests/`. Use `unittest.mock` for dependencies.
 
 ## Working with the Monorepo
 

--- a/Makefile
+++ b/Makefile
@@ -168,30 +168,27 @@ test-all: test ## Run all tests (alias for test)
 
 test-core: ## Run tests for taskdog-core only
 	@echo "Running taskdog-core tests..."
-	cd packages/taskdog-core && PYTHONPATH=src uv run python -m unittest discover -s tests/ -t .
+	cd packages/taskdog-core && PYTHONPATH=src uv run python -m pytest tests/ -v
 
 test-server: ## Run tests for taskdog-server only
 	@echo "Running taskdog-server tests..."
-	cd packages/taskdog-server && PYTHONPATH=src PYTHONWARNINGS="ignore::ResourceWarning" uv run python -m unittest discover -s tests/ -t .
+	cd packages/taskdog-server && PYTHONPATH=src uv run python -m pytest tests/ -v
 
 test-ui: ## Run tests for taskdog-ui only
 	@echo "Running taskdog-ui tests..."
-	cd packages/taskdog-ui && PYTHONPATH=src uv run python -m unittest discover -s tests/ -t .
+	cd packages/taskdog-ui && PYTHONPATH=src uv run python -m pytest tests/ -v
 
 coverage: ## Run tests with coverage and show report in terminal (sorted by coverage, low to high)
 	@echo "Running tests with coverage..."
 	@echo ""
 	@echo "📊 taskdog-core coverage (sorted: low → high):"
-	cd packages/taskdog-core && PYTHONPATH=src uv run coverage run -m unittest discover -s tests/ -t .
-	cd packages/taskdog-core && uv run coverage report --show-missing --sort=Cover
+	cd packages/taskdog-core && PYTHONPATH=src uv run python -m pytest tests/ --cov=taskdog_core --cov-report=term-missing:skip-covered
 	@echo ""
 	@echo "📊 taskdog-server coverage (sorted: low → high):"
-	cd packages/taskdog-server && PYTHONPATH=src PYTHONWARNINGS="ignore::ResourceWarning" uv run coverage run -m unittest discover -s tests/ -t .
-	cd packages/taskdog-server && uv run coverage report --show-missing --sort=Cover
+	cd packages/taskdog-server && PYTHONPATH=src uv run python -m pytest tests/ --cov=taskdog_server --cov-report=term-missing:skip-covered
 	@echo ""
 	@echo "📊 taskdog-ui coverage (sorted: low → high):"
-	cd packages/taskdog-ui && PYTHONPATH=src uv run coverage run -m unittest discover -s tests/ -t .
-	cd packages/taskdog-ui && uv run coverage report --show-missing --sort=Cover
+	cd packages/taskdog-ui && PYTHONPATH=src uv run python -m pytest tests/ --cov=taskdog --cov-report=term-missing:skip-covered
 	@echo ""
 	@echo "✓ Coverage report complete!"
 	@echo ""

--- a/packages/taskdog-core/pyproject.toml
+++ b/packages/taskdog-core/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
     "mypy>=1.0.0",
     "ruff>=0.7.0",
     "parameterized>=0.9.0",

--- a/packages/taskdog-ui/tests/conftest.py
+++ b/packages/taskdog-ui/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Pytest configuration for taskdog-ui tests.
+
+This file configures pytest to ignore broken tests that were not previously
+discovered by unittest but are found by pytest. These tests need to be fixed
+in a separate PR.
+"""
+
+# List of paths to ignore during test collection
+# These tests use wrong types (Task entity instead of ViewModel) or have
+# missing __init__.py files that prevented unittest from discovering them
+collect_ignore = [
+    "presentation/tui/widgets",
+    "tui/services",
+]

--- a/packages/taskdog-ui/tests/presentation/exporters/test_json_task_exporter.py
+++ b/packages/taskdog-ui/tests/presentation/exporters/test_json_task_exporter.py
@@ -22,7 +22,6 @@ class TestJsonTaskExporter(unittest.TestCase):
             is_fixed=False,
             depends_on=[],
             tags=[],
-            has_notes=False,
             estimated_duration=None,
             actual_duration_hours=None,
             planned_start=None,
@@ -30,11 +29,10 @@ class TestJsonTaskExporter(unittest.TestCase):
             actual_start=None,
             actual_end=None,
             deadline=None,
-            daily_allocations={},
-            actual_daily_hours={},
-            created_at=None,
-            updated_at=None,
+            created_at=datetime(2024, 12, 20, 10, 0),
+            updated_at=datetime(2024, 12, 20, 10, 0),
             is_archived=False,
+            is_finished=False,
         )
 
         self.task2 = TaskRowDto(
@@ -45,7 +43,6 @@ class TestJsonTaskExporter(unittest.TestCase):
             is_fixed=True,
             depends_on=[1],
             tags=["urgent", "backend"],
-            has_notes=True,
             estimated_duration=10.5,
             actual_duration_hours=12.0,
             planned_start=datetime(2025, 1, 1, 9, 0),
@@ -53,11 +50,10 @@ class TestJsonTaskExporter(unittest.TestCase):
             actual_start=datetime(2025, 1, 1, 9, 30),
             actual_end=datetime(2025, 1, 5, 17, 45),
             deadline=datetime(2025, 1, 10, 23, 59),
-            daily_allocations={"2025-01-01": 5.0, "2025-01-02": 5.5},
-            actual_daily_hours={"2025-01-01": 5.5},
             created_at=datetime(2024, 12, 20, 10, 0),
             updated_at=datetime(2025, 1, 5, 18, 0),
             is_archived=False,
+            is_finished=True,
         )
 
     def test_export_returns_json_string(self) -> None:
@@ -113,7 +109,6 @@ class TestJsonTaskExporter(unittest.TestCase):
             is_fixed=False,
             depends_on=[],
             tags=["日本語"],
-            has_notes=False,
             estimated_duration=None,
             actual_duration_hours=None,
             planned_start=None,
@@ -121,11 +116,10 @@ class TestJsonTaskExporter(unittest.TestCase):
             actual_start=None,
             actual_end=None,
             deadline=None,
-            daily_allocations={},
-            actual_daily_hours={},
-            created_at=None,
-            updated_at=None,
+            created_at=datetime(2024, 12, 20, 10, 0),
+            updated_at=datetime(2024, 12, 20, 10, 0),
             is_archived=False,
+            is_finished=False,
         )
         exporter = JsonTaskExporter()
 
@@ -149,16 +143,17 @@ class TestJsonTaskExporter(unittest.TestCase):
         self.assertIn("2025-01-01", task_data["planned_start"])
         self.assertIn("2025-01-05", task_data["actual_end"])
 
-    def test_export_handles_dict_fields(self) -> None:
-        """Test export preserves dictionary fields like daily_allocations."""
+    def test_export_handles_numeric_fields(self) -> None:
+        """Test export preserves numeric fields correctly."""
         exporter = JsonTaskExporter()
 
         result = exporter.export([self.task2])
 
         parsed = json.loads(result)
         task_data = parsed[0]
-        self.assertEqual(task_data["daily_allocations"]["2025-01-01"], 5.0)
-        self.assertEqual(task_data["daily_allocations"]["2025-01-02"], 5.5)
+        self.assertEqual(task_data["estimated_duration"], 10.5)
+        self.assertEqual(task_data["actual_duration_hours"], 12.0)
+        self.assertEqual(task_data["priority"], 2)
 
     def test_export_handles_list_fields(self) -> None:
         """Test export preserves list fields like tags and depends_on."""
@@ -232,7 +227,7 @@ class TestJsonTaskExporter(unittest.TestCase):
         parsed = json.loads(result)
         task_data = parsed[0]
         self.assertTrue(task_data["is_fixed"])
-        self.assertTrue(task_data["has_notes"])
+        self.assertTrue(task_data["is_finished"])
         self.assertFalse(task_data["is_archived"])
 
     def test_export_preserves_float_fields(self) -> None:
@@ -280,7 +275,6 @@ class TestJsonTaskExporter(unittest.TestCase):
         task_data = parsed[0]
         self.assertEqual(task_data["depends_on"], [])
         self.assertEqual(task_data["tags"], [])
-        self.assertEqual(task_data["daily_allocations"], {})
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ dev = [
   "mypy>=1.8.0",
   "types-python-dateutil>=2.8.0",
   "types-sqlalchemy",
-  "coverage>=7.0.0",
+  "pytest>=7.0.0",
+  "pytest-cov>=4.0.0",
 ]
 
 # UV workspace configuration

--- a/uv.lock
+++ b/uv.lock
@@ -738,6 +738,8 @@ dependencies = [
 dev = [
     { name = "mypy" },
     { name = "parameterized" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "ruff" },
 ]
 
@@ -746,6 +748,8 @@ requires-dist = [
     { name = "holidays", specifier = ">=0.60.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "parameterized", marker = "extra == 'dev'", specifier = ">=0.9.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "python-dateutil", specifier = ">=2.8.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
@@ -837,9 +841,10 @@ source = { editable = "." }
 
 [package.optional-dependencies]
 dev = [
-    { name = "coverage" },
     { name = "mypy" },
     { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "ruff" },
     { name = "types-python-dateutil" },
     { name = "types-sqlalchemy" },
@@ -847,9 +852,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.6.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3.0" },
     { name = "types-python-dateutil", marker = "extra == 'dev'", specifier = ">=2.8.0" },
     { name = "types-sqlalchemy", marker = "extra == 'dev'" },


### PR DESCRIPTION
## Summary
- Add pytest and pytest-cov to dev dependencies
- Update Makefile test commands to use pytest
- Fix broken exporter tests discovered by pytest
- Temporarily exclude broken TUI widget/service tests

Closes #402 (Phase 1 only)

## Changes
- `packages/taskdog-core/pyproject.toml`: Add pytest deps
- `pyproject.toml` (root): Add pytest deps, remove coverage
- `Makefile`: Use `python -m pytest` for test commands
- `CLAUDE.md`: Update test command examples
- Fix exporter tests to use `TaskRowDto` correctly
- Add `conftest.py` to exclude broken tests for now

## Test Results
- taskdog-core: 1012 passed, 24 skipped
- taskdog-server: 246 passed  
- taskdog-ui: 552 passed, 24 skipped

## Notes
Phase 2 and 3 from issue #402 (new test style, gradual refactoring) will be done in separate PRs.

Some tests in `tests/presentation/tui/widgets` and `tests/tui/services` were discovered by pytest but not by unittest (missing `__init__.py`). These tests are broken and temporarily excluded via `conftest.py`. They should be fixed in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)