### PR TITLE
feat: add Docker support for taskdog-server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,54 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg
+*.egg-info/
+dist/
+build/
+eggs/
+*.manifest
+*.spec
+
+# Virtual environments
+.venv/
+venv/
+ENV/
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+.nox/
+
+# Type checking
+.mypy_cache/
+
+# Linting
+.ruff_cache/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Git
+.git/
+.gitignore
+
+# Documentation build
+docs/_build/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Project specific
+*.db
+*.sqlite
+*.sqlite3

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,8 +1,60 @@
-# Systemd User Service Setup
+# Contrib - Deployment and Infrastructure
+
+This directory contains deployment configurations and infrastructure files for running Taskdog Server.
+
+## Contents
+
+| Directory | Description | Platform |
+|-----------|-------------|----------|
+| [docker/](docker/) | Docker container setup | Any (Docker) |
+| [systemd/](systemd/) | Systemd user service | Linux |
+| [launchd/](launchd/) | Launchd property list | macOS |
+
+## Quick Start
+
+Choose your preferred deployment method:
+
+### Docker (Recommended for isolation)
+
+```bash
+# Build and run
+docker build -f contrib/docker/Dockerfile -t taskdog-server .
+docker run -d -p 8000:8000 -v taskdog-data:/data taskdog-server
+```
+
+See [docker/README.md](docker/README.md) for details.
+
+### Systemd (Linux)
+
+```bash
+# Automatic setup via make install
+make install
+
+# Manual start
+systemctl --user start taskdog-server
+systemctl --user enable taskdog-server
+```
+
+See [Systemd Setup](#systemd-user-service-setup) below for details.
+
+### Launchd (macOS)
+
+```bash
+# Automatic setup via make install
+make install
+
+# Service starts automatically
+```
+
+See [launchd/taskdog-server.plist](launchd/taskdog-server.plist) for the property list.
+
+---
+
+## Systemd User Service Setup
 
 Taskdog Server can run as a systemd user service for automatic startup and management.
 
-## Installation
+### Installation
 
 The systemd service is automatically installed when you run:
 
@@ -17,7 +69,7 @@ This will:
 3. Enable the service for automatic startup
 4. Reload the systemd daemon
 
-## Important: CLI/TUI Requires Running Server
+### Important: CLI/TUI Requires Running Server
 
 **The `taskdog` CLI and TUI commands require the server to be running.** Without a running server, all CLI/TUI commands will fail with connection errors.
 
@@ -76,7 +128,7 @@ taskdog table
 - Set `enabled = true` in config file (see Method A above)
 - Or set TASKDOG_API_URL environment variable (see Method B above)
 
-## Starting the Service
+### Starting the Service
 
 After installation, start the service with:
 
@@ -90,9 +142,9 @@ Check the status:
 systemctl --user status taskdog-server
 ```
 
-## Service Management
+### Service Management
 
-### View Logs
+#### View Logs
 
 ```bash
 # Follow logs in real-time
@@ -105,31 +157,31 @@ journalctl --user -u taskdog-server -n 50
 journalctl --user -u taskdog-server -b
 ```
 
-### Stop the Service
+#### Stop the Service
 
 ```bash
 systemctl --user stop taskdog-server
 ```
 
-### Restart the Service
+#### Restart the Service
 
 ```bash
 systemctl --user restart taskdog-server
 ```
 
-### Disable Auto-Start
+#### Disable Auto-Start
 
 ```bash
 systemctl --user disable taskdog-server
 ```
 
-### Re-enable Auto-Start
+#### Re-enable Auto-Start
 
 ```bash
 systemctl --user enable taskdog-server
 ```
 
-## Configuration
+### Configuration
 
 The default service configuration:
 
@@ -141,7 +193,7 @@ The default service configuration:
 
 **Note**: WebSocket real-time synchronization requires `--workers 1`. Multiple workers are not supported yet due to lack of inter-process communication (would require Redis Pub/Sub or similar).
 
-### Customizing the Service
+#### Customizing the Service
 
 To customize the service (host, port, workers, etc.), edit the service file:
 
@@ -178,9 +230,9 @@ ExecStart=%h/.local/bin/taskdog-server --host 127.0.0.1 --port 8000 --reload
 # Use --workers 1 for WebSocket support
 ```
 
-## Troubleshooting
+### Troubleshooting
 
-### Service Won't Start
+#### Service Won't Start
 
 1. Check logs:
 
@@ -200,7 +252,7 @@ ExecStart=%h/.local/bin/taskdog-server --host 127.0.0.1 --port 8000 --reload
    ss -tlnp | grep 8000
    ```
 
-### Service Crashes on Startup
+#### Service Crashes on Startup
 
 - Check permissions on the data directory:
 
@@ -214,7 +266,7 @@ ExecStart=%h/.local/bin/taskdog-server --host 127.0.0.1 --port 8000 --reload
   sqlite3 ~/.local/share/taskdog/tasks.db "PRAGMA integrity_check;"
   ```
 
-### Logs Not Appearing
+#### Logs Not Appearing
 
 - Ensure journald is running:
 
@@ -228,7 +280,7 @@ ExecStart=%h/.local/bin/taskdog-server --host 127.0.0.1 --port 8000 --reload
   loginctl user-status
   ```
 
-### Service Not Auto-Starting on Boot
+#### Service Not Auto-Starting on Boot
 
 Enable lingering for your user (allows user services to run without login):
 
@@ -236,7 +288,7 @@ Enable lingering for your user (allows user services to run without login):
 loginctl enable-linger $USER
 ```
 
-## Uninstallation
+### Uninstallation
 
 To remove the systemd service:
 
@@ -252,7 +304,7 @@ This will:
 4. Reload the systemd daemon
 5. Uninstall the `taskdog-server` command
 
-## Manual Installation
+### Manual Installation
 
 If you prefer to manage the service manually without `make install`:
 
@@ -269,7 +321,7 @@ systemctl --user enable taskdog-server
 systemctl --user start taskdog-server
 ```
 
-## Security Considerations
+### Security Considerations
 
 The default service configuration includes security hardening:
 

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,0 +1,44 @@
+# Taskdog Server Dockerfile
+# https://github.com/Kohei-Wada/taskdog
+#
+# Build:
+#   docker build -f contrib/docker/Dockerfile -t taskdog-server .
+#
+# Run:
+#   docker run -d -p 8000:8000 -v taskdog-data:/data taskdog-server
+
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+
+WORKDIR /app
+
+# Copy workspace configuration and packages
+COPY pyproject.toml uv.lock ./
+COPY packages/ ./packages/
+
+# Install taskdog-server package (includes taskdog-core as dependency)
+RUN uv sync --locked --no-dev --package taskdog-server
+
+# Create non-root user and data directory
+RUN useradd -m -u 1000 taskdog \
+    && mkdir -p /data \
+    && chown -R taskdog:taskdog /data /app
+
+USER taskdog
+
+# Expose API port
+EXPOSE 8000
+
+# Data persistence volume
+VOLUME /data
+
+# Health check using Python (no curl needed)
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
+
+# Environment variables
+# SQLAlchemy requires sqlite:/// prefix for database URL
+ENV TASKDOG_STORAGE_DATABASE_URL=sqlite:////data/tasks.db
+
+# Start taskdog-server
+# Note: --workers 1 is required for WebSocket real-time sync
+ENTRYPOINT ["uv", "run", "taskdog-server", "--host", "0.0.0.0", "--port", "8000", "--workers", "1"]

--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -1,0 +1,189 @@
+# Docker Setup
+
+Run Taskdog Server in a Docker container.
+
+## Quick Start
+
+```bash
+# Build the image (from repository root)
+docker build -f contrib/docker/Dockerfile -t taskdog-server .
+
+# Run with data persistence
+docker run -d \
+  --name taskdog-server \
+  -p 8000:8000 \
+  -v taskdog-data:/data \
+  taskdog-server
+
+# Verify it's running
+curl http://localhost:8000/health
+```
+
+## Usage
+
+### Build
+
+```bash
+cd /path/to/taskdog
+docker build -f contrib/docker/Dockerfile -t taskdog-server .
+```
+
+### Run
+
+**Basic (ephemeral data):**
+
+```bash
+docker run -d -p 8000:8000 taskdog-server
+```
+
+**With data persistence (recommended):**
+
+```bash
+docker run -d \
+  --name taskdog-server \
+  -p 8000:8000 \
+  -v taskdog-data:/data \
+  taskdog-server
+```
+
+**With host directory mount:**
+
+```bash
+docker run -d \
+  --name taskdog-server \
+  -p 8000:8000 \
+  -v /path/to/your/data:/data \
+  taskdog-server
+```
+
+### Stop and Remove
+
+```bash
+docker stop taskdog-server
+docker rm taskdog-server
+```
+
+## Configuration
+
+### Environment Variables
+
+All Taskdog configuration can be set via environment variables with the `TASKDOG_` prefix:
+
+```bash
+docker run -d \
+  -p 8000:8000 \
+  -v taskdog-data:/data \
+  -e TASKDOG_OPTIMIZATION_MAX_HOURS_PER_DAY=8 \
+  -e TASKDOG_OPTIMIZATION_DEFAULT_ALGORITHM=balanced \
+  -e TASKDOG_REGION_COUNTRY=JP \
+  taskdog-server
+```
+
+**Note:** The database URL uses SQLAlchemy format: `sqlite:////data/tasks.db` (four slashes for absolute path).
+
+See [CONFIGURATION.md](../../docs/CONFIGURATION.md) for all available options.
+
+### Custom Port
+
+```bash
+# Map to a different host port
+docker run -d -p 3000:8000 -v taskdog-data:/data taskdog-server
+```
+
+## Data Persistence
+
+The container stores data in `/data`:
+
+- `tasks.db` - SQLite database with all tasks
+- `notes/` - Markdown notes for tasks (if used)
+
+**Important:** Always use a volume mount (`-v`) to persist data across container restarts.
+
+### Backup
+
+```bash
+# Stop the container first
+docker stop taskdog-server
+
+# Copy data from volume
+docker run --rm -v taskdog-data:/data -v $(pwd):/backup alpine \
+  tar czf /backup/taskdog-backup.tar.gz -C /data .
+
+# Restart the container
+docker start taskdog-server
+```
+
+### Restore
+
+```bash
+docker run --rm -v taskdog-data:/data -v $(pwd):/backup alpine \
+  sh -c "cd /data && tar xzf /backup/taskdog-backup.tar.gz"
+```
+
+## Connecting CLI/TUI
+
+The CLI and TUI are installed on your host machine and connect to the containerized server:
+
+```bash
+# Install CLI/TUI on host (not in container)
+cd /path/to/taskdog
+make install-ui
+
+# Configure to connect to Docker container
+export TASKDOG_API_URL=http://localhost:8000
+
+# Or create config file
+mkdir -p ~/.config/taskdog
+cat > ~/.config/taskdog/config.toml << 'EOF'
+[api]
+host = "127.0.0.1"
+port = 8000
+EOF
+
+# Use CLI
+taskdog table
+taskdog add "My first task"
+
+# Use TUI
+taskdog tui
+```
+
+## Health Check
+
+The container includes a health check that polls `/health` every 30 seconds using Python's `urllib` (no curl needed):
+
+```bash
+# Check container health status
+docker inspect --format='{{.State.Health.Status}}' taskdog-server
+
+# View health check logs
+docker inspect --format='{{json .State.Health}}' taskdog-server | jq
+
+# Manual health check from host
+curl http://localhost:8000/health
+```
+
+## Logs
+
+```bash
+# View logs
+docker logs taskdog-server
+
+# Follow logs
+docker logs -f taskdog-server
+```
+
+## Limitations
+
+- **WebSocket:** The container runs with `--workers 1` (required for WebSocket real-time sync)
+- **CLI/TUI:** Must be installed on host, not containerized (interactive terminal required)
+
+## Advanced: taskdog-stack
+
+For more advanced setups including:
+
+- Docker Compose orchestration
+- Webhook integration (n8n, etc.)
+- External service connections
+
+See [taskdog-stack](https://github.com/Kohei-Wada/taskdog-stack) (coming soon).

--- a/docs/DESIGN_PHILOSOPHY.md
+++ b/docs/DESIGN_PHILOSOPHY.md
@@ -511,31 +511,43 @@ uv tool install taskdog-server
 pip install taskdog taskdog-server
 ```
 
-The repository provides:
+### What This Repository Includes
 
 - Python packages (taskdog-core, taskdog-server, taskdog-ui)
 - systemd/launchd service files for auto-start
+- **Basic Dockerfile** for containerized deployment (see `contrib/docker/`)
 - Configuration examples
 
 ### What This Repository Does NOT Include
 
-- Docker/container configurations
+- Docker Compose / orchestration configurations
 - Kubernetes manifests
 - Reverse proxy configurations
 - Authentication/authorization infrastructure
 - Backup automation
 
-### Why No Docker in This Repository?
+### Docker Philosophy
 
-1. **Simplicity**: Individual users don't need containerization for a personal tool
-2. **Separation of concerns**: Package distribution ≠ infrastructure management
-3. **Avoid over-engineering**: `taskdog-server` runs fine as a simple process
+This repository provides a **minimal Dockerfile** for users who prefer containerization, but keeps infrastructure concerns separate:
+
+**What we provide:**
+
+- Single `Dockerfile` for `taskdog-server`
+- Basic documentation for building and running
+
+**What we leave to users (or taskdog-stack):**
+
+- Docker Compose orchestration
+- Multi-service setups (webhooks, proxies, etc.)
+- Production deployment configurations
+
+This strikes a balance between accessibility and simplicity.
 
 ### For Users Who Need Infrastructure
 
-If you need Docker, authentication, reverse proxy, or backup automation, consider creating a separate **taskdog-stack** repository that:
+If you need Docker Compose, authentication, reverse proxy, or backup automation, consider creating a separate **taskdog-stack** repository that:
 
-- References taskdog as a dependency
+- Uses the Dockerfile from this repo as a base
 - Adds docker-compose.yml with your preferred setup
 - Includes authentication (Authelia, OAuth2 Proxy, etc.)
 - Configures reverse proxy (Traefik, Caddy, nginx)
@@ -543,7 +555,7 @@ If you need Docker, authentication, reverse proxy, or backup automation, conside
 
 This separation keeps:
 
-- **taskdog**: Simple, focused on the application
+- **taskdog**: Simple, focused on the application + basic container support
 - **taskdog-stack**: Infrastructure concerns, customizable per deployment
 
 **Example structure for taskdog-stack**:

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -43,7 +43,20 @@ EOF
 
 ## Step 3: Start the Server (1 minute)
 
-### Option A: Manual Start (Quick Test)
+### Option A: Docker (Recommended for isolation)
+
+```bash
+# Build and run the container
+docker build -f contrib/docker/Dockerfile -t taskdog-server .
+docker run -d --name taskdog-server -p 8000:8000 -v taskdog-data:/data taskdog-server
+
+# Verify it's running
+curl http://localhost:8000/health
+```
+
+See [contrib/docker/README.md](../contrib/docker/README.md) for more details.
+
+### Option B: Manual Start (Quick Test)
 
 ```bash
 # Start the server in a terminal
@@ -52,7 +65,7 @@ taskdog-server
 # Keep this terminal running
 ```
 
-### Option B: Systemd Service (Recommended)
+### Option C: Systemd Service (Linux, Recommended for local)
 
 ```bash
 # Start the service


### PR DESCRIPTION
## Summary

- Add Dockerfile for running taskdog-server in a container
- Use official uv image (`ghcr.io/astral-sh/uv:python3.13-bookworm-slim`) for lightweight build
- Health check using Python urllib (no curl dependency needed)
- Non-root user execution for security
- Volume mount at `/data` for SQLite persistence
- Update documentation:
  - `contrib/README.md`: Add deployment options overview (Docker, systemd, launchd)
  - `contrib/docker/README.md`: Detailed Docker usage guide
  - `docs/QUICKSTART.md`: Add Docker as a server startup option
  - `docs/DESIGN_PHILOSOPHY.md`: Clarify Docker support philosophy

## Usage

```bash
# Build
docker build -f contrib/docker/Dockerfile -t taskdog-server .

# Run with persistence
docker run -d -p 8000:8000 -v taskdog-data:/data taskdog-server
```

## Test plan

- [x] Docker image builds successfully
- [x] Container starts and health check passes
- [x] API endpoints work (create task, list tasks)
- [x] Data persists across container restarts (volume mount)
- [x] Markdown lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)