### PR TITLE
feat(cli): add --host and --port global options

### DIFF
--- a/packages/taskdog-ui/src/taskdog/cli_main.py
+++ b/packages/taskdog-ui/src/taskdog/cli_main.py
@@ -71,7 +71,7 @@ class TaskdogGroup(click.Group):
 )
 @click.option(
     "--port",
-    type=int,
+    type=click.IntRange(1, 65535),
     default=None,
     help="API server port (overrides config/env)",
 )
@@ -90,11 +90,6 @@ def cli(ctx: click.Context, host: str | None, port: int | None) -> None:
 
     # CLI options override config/env settings
     api_host = host if host is not None else config.api.host
-    if port is not None and (port < 1 or port > 65535):
-        console_writer.validation_error(
-            f"Port must be between 1 and 65535, got: {port}"
-        )
-        ctx.exit(1)
     api_port = port if port is not None else config.api.port
 
     # Initialize API client (required for all CLI commands)

--- a/packages/taskdog-ui/tests/presentation/cli/test_cli_main.py
+++ b/packages/taskdog-ui/tests/presentation/cli/test_cli_main.py
@@ -132,37 +132,23 @@ class TestCliGlobalOptions:
         assert result.exit_code == 1
         assert "192.168.1.100:3000" in result.output
 
-    @patch("taskdog.cli_main.load_cli_config")
-    def test_port_validation_too_low(self, mock_load_config):
+    def test_port_validation_too_low(self):
         """Test that port 0 is rejected."""
-        # Setup
-        mock_config = MagicMock()
-        mock_config.api.host = "127.0.0.1"
-        mock_config.api.port = 8000
-        mock_load_config.return_value = mock_config
-
         # Execute
         result = self.runner.invoke(cli, ["--port", "0", "table"])
 
-        # Verify
-        assert result.exit_code == 1
-        assert "Port must be between 1 and 65535" in result.output
+        # Verify - Click returns exit code 2 for usage errors
+        assert result.exit_code == 2
+        assert "is not in the range 1<=x<=65535" in result.output
 
-    @patch("taskdog.cli_main.load_cli_config")
-    def test_port_validation_too_high(self, mock_load_config):
+    def test_port_validation_too_high(self):
         """Test that port > 65535 is rejected."""
-        # Setup
-        mock_config = MagicMock()
-        mock_config.api.host = "127.0.0.1"
-        mock_config.api.port = 8000
-        mock_load_config.return_value = mock_config
-
         # Execute
         result = self.runner.invoke(cli, ["--port", "65536", "table"])
 
-        # Verify
-        assert result.exit_code == 1
-        assert "Port must be between 1 and 65535" in result.output
+        # Verify - Click returns exit code 2 for usage errors
+        assert result.exit_code == 2
+        assert "is not in the range 1<=x<=65535" in result.output
 
     @patch("taskdog.infrastructure.api_client.TaskdogApiClient")
     @patch("taskdog.cli_main.load_cli_config")


### PR DESCRIPTION
## Summary
- Add `--host` and `--port` global options to CLI for specifying API server connection
- Options override config file and environment variable settings
- Error messages correctly display the overridden host/port values

Closes #424

## Priority Order (highest to lowest)
1. CLI options (`--host`, `--port`)
2. Environment variables (`TASKDOG_API_HOST`, `TASKDOG_API_PORT`)
3. Config file (`~/.config/taskdog/cli.toml`)
4. Default values (127.0.0.1:8000)

## Usage Examples
```bash
# Host only
taskdog --host 192.168.1.100 table

# Port only
taskdog --port 3000 table

# Both
taskdog --host 192.168.1.100 --port 3000 tui
```

## Test plan
- [x] Test `--host` option overrides config
- [x] Test `--port` option overrides config
- [x] Test both options override config
- [x] Test help displays new options
- [x] Test error message shows overridden values
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)