### PR TITLE
feat(websocket): add X-User-Name header support for user identification

### DIFF
--- a/packages/taskdog-server/src/taskdog_server/api/routers/analytics.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/analytics.py
@@ -244,6 +244,7 @@ async def optimize_schedule(
     broadcaster: EventBroadcasterDep,
     run_async: bool = Query(False, description="Run optimization in background"),
     x_client_id: Annotated[str | None, Header()] = None,
+    x_user_name: Annotated[str | None, Header()] = None,
 ) -> OptimizationResponse:
     """Optimize task schedules using specified algorithm.
 
@@ -253,6 +254,7 @@ async def optimize_schedule(
         broadcaster: Event broadcaster dependency
         run_async: If True, run in background and return immediately
         x_client_id: Optional client ID from WebSocket connection
+        x_user_name: Optional user name from API gateway
 
     Returns:
         Optimization results with summary and failures
@@ -304,6 +306,7 @@ async def optimize_schedule(
             len(result.failed_tasks),
             request.algorithm,
             x_client_id,
+            x_user_name,
         )
 
         # Convert DTO to response model

--- a/packages/taskdog-server/src/taskdog_server/api/routers/lifecycle.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/lifecycle.py
@@ -19,6 +19,7 @@ async def start_task(
     controller: LifecycleControllerDep,
     broadcaster: EventBroadcasterDep,
     x_client_id: Annotated[str | None, Header()] = None,
+    x_user_name: Annotated[str | None, Header()] = None,
 ) -> TaskOperationResponse:
     """Start a task (change status to IN_PROGRESS and record start time).
 
@@ -27,6 +28,7 @@ async def start_task(
         controller: Lifecycle controller dependency
         broadcaster: Event broadcaster dependency
         x_client_id: Optional client ID from WebSocket connection
+        x_user_name: Optional user name from API gateway
 
     Returns:
         Updated task data with actual_start timestamp
@@ -37,7 +39,7 @@ async def start_task(
     result = controller.start_task(task_id)
 
     # Broadcast WebSocket event in background (exclude the requester)
-    broadcaster.task_status_changed(result, "PENDING", x_client_id)
+    broadcaster.task_status_changed(result, "PENDING", x_client_id, x_user_name)
 
     return convert_to_task_operation_response(result)
 
@@ -49,6 +51,7 @@ async def complete_task(
     controller: LifecycleControllerDep,
     broadcaster: EventBroadcasterDep,
     x_client_id: Annotated[str | None, Header()] = None,
+    x_user_name: Annotated[str | None, Header()] = None,
 ) -> TaskOperationResponse:
     """Complete a task (change status to COMPLETED and record end time).
 
@@ -57,6 +60,7 @@ async def complete_task(
         controller: Lifecycle controller dependency
         broadcaster: Event broadcaster dependency
         x_client_id: Optional client ID from WebSocket connection
+        x_user_name: Optional user name from API gateway
 
     Returns:
         Updated task data with actual_end timestamp
@@ -67,7 +71,7 @@ async def complete_task(
     result = controller.complete_task(task_id)
 
     # Broadcast WebSocket event in background (exclude the requester)
-    broadcaster.task_status_changed(result, "IN_PROGRESS", x_client_id)
+    broadcaster.task_status_changed(result, "IN_PROGRESS", x_client_id, x_user_name)
 
     return convert_to_task_operation_response(result)
 
@@ -79,6 +83,7 @@ async def pause_task(
     controller: LifecycleControllerDep,
     broadcaster: EventBroadcasterDep,
     x_client_id: Annotated[str | None, Header()] = None,
+    x_user_name: Annotated[str | None, Header()] = None,
 ) -> TaskOperationResponse:
     """Pause a task (change status to PENDING and clear timestamps).
 
@@ -87,6 +92,7 @@ async def pause_task(
         controller: Lifecycle controller dependency
         broadcaster: Event broadcaster dependency
         x_client_id: Optional client ID from WebSocket connection
+        x_user_name: Optional user name from API gateway
 
     Returns:
         Updated task data with cleared timestamps
@@ -97,7 +103,7 @@ async def pause_task(
     result = controller.pause_task(task_id)
 
     # Broadcast WebSocket event in background (exclude the requester)
-    broadcaster.task_status_changed(result, "IN_PROGRESS", x_client_id)
+    broadcaster.task_status_changed(result, "IN_PROGRESS", x_client_id, x_user_name)
 
     return convert_to_task_operation_response(result)
 
@@ -109,6 +115,7 @@ async def cancel_task(
     controller: LifecycleControllerDep,
     broadcaster: EventBroadcasterDep,
     x_client_id: Annotated[str | None, Header()] = None,
+    x_user_name: Annotated[str | None, Header()] = None,
 ) -> TaskOperationResponse:
     """Cancel a task (change status to CANCELED and record end time).
 
@@ -117,6 +124,7 @@ async def cancel_task(
         controller: Lifecycle controller dependency
         broadcaster: Event broadcaster dependency
         x_client_id: Optional client ID from WebSocket connection
+        x_user_name: Optional user name from API gateway
 
     Returns:
         Updated task data with actual_end timestamp
@@ -127,7 +135,7 @@ async def cancel_task(
     result = controller.cancel_task(task_id)
 
     # Broadcast WebSocket event in background (exclude the requester)
-    broadcaster.task_status_changed(result, "IN_PROGRESS", x_client_id)
+    broadcaster.task_status_changed(result, "IN_PROGRESS", x_client_id, x_user_name)
 
     return convert_to_task_operation_response(result)
 
@@ -139,6 +147,7 @@ async def reopen_task(
     controller: LifecycleControllerDep,
     broadcaster: EventBroadcasterDep,
     x_client_id: Annotated[str | None, Header()] = None,
+    x_user_name: Annotated[str | None, Header()] = None,
 ) -> TaskOperationResponse:
     """Reopen a task (change status to PENDING and clear timestamps).
 
@@ -147,6 +156,7 @@ async def reopen_task(
         controller: Lifecycle controller dependency
         broadcaster: Event broadcaster dependency
         x_client_id: Optional client ID from WebSocket connection
+        x_user_name: Optional user name from API gateway
 
     Returns:
         Updated task data with cleared timestamps
@@ -157,6 +167,6 @@ async def reopen_task(
     result = controller.reopen_task(task_id)
 
     # Broadcast WebSocket event in background (exclude the requester)
-    broadcaster.task_status_changed(result, "COMPLETED", x_client_id)
+    broadcaster.task_status_changed(result, "COMPLETED", x_client_id, x_user_name)
 
     return convert_to_task_operation_response(result)

--- a/packages/taskdog-server/src/taskdog_server/api/routers/notes.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/notes.py
@@ -56,6 +56,7 @@ async def update_task_notes(
     notes_repo: NotesRepositoryDep,
     broadcaster: EventBroadcasterDep,
     x_client_id: Annotated[str | None, Header()] = None,
+    x_user_name: Annotated[str | None, Header()] = None,
 ) -> NotesResponse:
     """Update task notes.
 
@@ -66,6 +67,7 @@ async def update_task_notes(
         notes_repo: Notes repository dependency
         broadcaster: Event broadcaster dependency
         x_client_id: Optional client ID from WebSocket connection
+        x_user_name: Optional user name from API gateway
 
     Returns:
         Updated notes content and metadata
@@ -83,7 +85,7 @@ async def update_task_notes(
     has_notes = notes_repo.has_notes(task_id)
 
     # Broadcast WebSocket event in background (exclude the requester)
-    broadcaster.task_notes_updated(task_id, task.name, x_client_id)
+    broadcaster.task_notes_updated(task_id, task.name, x_client_id, x_user_name)
 
     return NotesResponse(task_id=task_id, content=request.content, has_notes=has_notes)
 
@@ -96,6 +98,7 @@ async def delete_task_notes(
     notes_repo: NotesRepositoryDep,
     broadcaster: EventBroadcasterDep,
     x_client_id: Annotated[str | None, Header()] = None,
+    x_user_name: Annotated[str | None, Header()] = None,
 ) -> None:
     """Delete task notes.
 
@@ -105,6 +108,7 @@ async def delete_task_notes(
         notes_repo: Notes repository dependency
         broadcaster: Event broadcaster dependency
         x_client_id: Optional client ID from WebSocket connection
+        x_user_name: Optional user name from API gateway
 
     Raises:
         HTTPException: 404 if task not found
@@ -118,4 +122,4 @@ async def delete_task_notes(
     notes_repo.write_notes(task_id, "")
 
     # Broadcast WebSocket event in background (exclude the requester)
-    broadcaster.task_notes_updated(task_id, task.name, x_client_id)
+    broadcaster.task_notes_updated(task_id, task.name, x_client_id, x_user_name)

--- a/packages/taskdog-server/src/taskdog_server/api/routers/relationships.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/relationships.py
@@ -29,6 +29,7 @@ async def add_dependency(
     controller: RelationshipControllerDep,
     broadcaster: EventBroadcasterDep,
     x_client_id: Annotated[str | None, Header()] = None,
+    x_user_name: Annotated[str | None, Header()] = None,
 ) -> TaskOperationResponse:
     """Add a dependency to a task.
 
@@ -38,6 +39,7 @@ async def add_dependency(
         controller: Relationship controller dependency
         broadcaster: Event broadcaster dependency
         x_client_id: Optional client ID from WebSocket connection
+        x_user_name: Optional user name from API gateway
 
     Returns:
         Updated task data with new dependency
@@ -48,7 +50,7 @@ async def add_dependency(
     result = controller.add_dependency(task_id, request.depends_on_id)
 
     # Broadcast WebSocket event in background (exclude the requester)
-    broadcaster.task_updated(result, ["depends_on"], x_client_id)
+    broadcaster.task_updated(result, ["depends_on"], x_client_id, x_user_name)
 
     return convert_to_task_operation_response(result)
 
@@ -63,6 +65,7 @@ async def remove_dependency(
     controller: RelationshipControllerDep,
     broadcaster: EventBroadcasterDep,
     x_client_id: Annotated[str | None, Header()] = None,
+    x_user_name: Annotated[str | None, Header()] = None,
 ) -> TaskOperationResponse:
     """Remove a dependency from a task.
 
@@ -72,6 +75,7 @@ async def remove_dependency(
         controller: Relationship controller dependency
         broadcaster: Event broadcaster dependency
         x_client_id: Optional client ID from WebSocket connection
+        x_user_name: Optional user name from API gateway
 
     Returns:
         Updated task data without the dependency
@@ -82,7 +86,7 @@ async def remove_dependency(
     result = controller.remove_dependency(task_id, depends_on_id)
 
     # Broadcast WebSocket event in background (exclude the requester)
-    broadcaster.task_updated(result, ["depends_on"], x_client_id)
+    broadcaster.task_updated(result, ["depends_on"], x_client_id, x_user_name)
 
     return convert_to_task_operation_response(result)
 
@@ -95,6 +99,7 @@ async def set_task_tags(
     controller: RelationshipControllerDep,
     broadcaster: EventBroadcasterDep,
     x_client_id: Annotated[str | None, Header()] = None,
+    x_user_name: Annotated[str | None, Header()] = None,
 ) -> TaskOperationResponse:
     """Set task tags (replaces existing tags).
 
@@ -104,6 +109,7 @@ async def set_task_tags(
         controller: Relationship controller dependency
         broadcaster: Event broadcaster dependency
         x_client_id: Optional client ID from WebSocket connection
+        x_user_name: Optional user name from API gateway
 
     Returns:
         Updated task data with new tags
@@ -114,7 +120,7 @@ async def set_task_tags(
     result = controller.set_task_tags(task_id, request.tags)
 
     # Broadcast WebSocket event in background (exclude the requester)
-    broadcaster.task_updated(result, ["tags"], x_client_id)
+    broadcaster.task_updated(result, ["tags"], x_client_id, x_user_name)
 
     return convert_to_task_operation_response(result)
 
@@ -127,6 +133,7 @@ async def log_hours(
     controller: RelationshipControllerDep,
     broadcaster: EventBroadcasterDep,
     x_client_id: Annotated[str | None, Header()] = None,
+    x_user_name: Annotated[str | None, Header()] = None,
 ) -> TaskOperationResponse:
     """Log actual hours worked on a task for a specific date.
 
@@ -136,6 +143,7 @@ async def log_hours(
         controller: Relationship controller dependency
         broadcaster: Event broadcaster dependency
         x_client_id: Optional client ID from WebSocket connection
+        x_user_name: Optional user name from API gateway
 
     Returns:
         Updated task data with logged hours
@@ -147,6 +155,6 @@ async def log_hours(
     result = controller.log_hours(task_id, request.hours, log_date.isoformat())
 
     # Broadcast WebSocket event in background (exclude the requester)
-    broadcaster.task_updated(result, ["actual_daily_hours"], x_client_id)
+    broadcaster.task_updated(result, ["actual_daily_hours"], x_client_id, x_user_name)
 
     return convert_to_task_operation_response(result)

--- a/packages/taskdog-server/src/taskdog_server/api/routers/tasks.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/tasks.py
@@ -41,6 +41,7 @@ async def create_task(
     controller: CrudControllerDep,
     broadcaster: EventBroadcasterDep,
     x_client_id: Annotated[str | None, Header()] = None,
+    x_user_name: Annotated[str | None, Header()] = None,
 ) -> TaskOperationResponse:
     """Create a new task.
 
@@ -49,6 +50,7 @@ async def create_task(
         controller: CRUD controller dependency
         broadcaster: Event broadcaster dependency
         x_client_id: Optional client ID from WebSocket connection
+        x_user_name: Optional user name from API gateway
 
     Returns:
         Created task data
@@ -68,7 +70,7 @@ async def create_task(
     )
 
     # Broadcast WebSocket event in background (exclude the requester)
-    broadcaster.task_created(result, x_client_id)
+    broadcaster.task_created(result, x_client_id, x_user_name)
 
     return convert_to_task_operation_response(result)
 
@@ -259,6 +261,7 @@ async def update_task(
     controller: CrudControllerDep,
     broadcaster: EventBroadcasterDep,
     x_client_id: Annotated[str | None, Header()] = None,
+    x_user_name: Annotated[str | None, Header()] = None,
 ) -> UpdateTaskResponse:
     """Update task fields.
 
@@ -268,6 +271,7 @@ async def update_task(
         controller: CRUD controller dependency
         broadcaster: Event broadcaster dependency
         x_client_id: Optional client ID from WebSocket connection
+        x_user_name: Optional user name from API gateway
 
     Returns:
         Updated task data
@@ -289,7 +293,9 @@ async def update_task(
     )
 
     # Broadcast WebSocket event in background (exclude the requester)
-    broadcaster.task_updated(result.task, result.updated_fields, x_client_id)
+    broadcaster.task_updated(
+        result.task, result.updated_fields, x_client_id, x_user_name
+    )
 
     return convert_to_update_task_response(result)
 
@@ -301,6 +307,7 @@ async def archive_task(
     controller: CrudControllerDep,
     broadcaster: EventBroadcasterDep,
     x_client_id: Annotated[str | None, Header()] = None,
+    x_user_name: Annotated[str | None, Header()] = None,
 ) -> TaskOperationResponse:
     """Archive (soft delete) a task.
 
@@ -309,6 +316,7 @@ async def archive_task(
         controller: CRUD controller dependency
         broadcaster: Event broadcaster dependency
         x_client_id: Optional client ID from WebSocket connection
+        x_user_name: Optional user name from API gateway
 
     Returns:
         Archived task data
@@ -319,7 +327,7 @@ async def archive_task(
     result = controller.archive_task(task_id)
 
     # Broadcast WebSocket event in background (exclude the requester)
-    broadcaster.task_updated(result, ["is_archived"], x_client_id)
+    broadcaster.task_updated(result, ["is_archived"], x_client_id, x_user_name)
 
     return convert_to_task_operation_response(result)
 
@@ -331,6 +339,7 @@ async def restore_task(
     controller: CrudControllerDep,
     broadcaster: EventBroadcasterDep,
     x_client_id: Annotated[str | None, Header()] = None,
+    x_user_name: Annotated[str | None, Header()] = None,
 ) -> TaskOperationResponse:
     """Restore an archived task.
 
@@ -339,6 +348,7 @@ async def restore_task(
         controller: CRUD controller dependency
         broadcaster: Event broadcaster dependency
         x_client_id: Optional client ID from WebSocket connection
+        x_user_name: Optional user name from API gateway
 
     Returns:
         Restored task data
@@ -349,7 +359,7 @@ async def restore_task(
     result = controller.restore_task(task_id)
 
     # Broadcast WebSocket event in background (exclude the requester)
-    broadcaster.task_updated(result, ["is_archived"], x_client_id)
+    broadcaster.task_updated(result, ["is_archived"], x_client_id, x_user_name)
 
     return convert_to_task_operation_response(result)
 
@@ -362,6 +372,7 @@ async def delete_task(
     query_controller: QueryControllerDep,
     broadcaster: EventBroadcasterDep,
     x_client_id: Annotated[str | None, Header()] = None,
+    x_user_name: Annotated[str | None, Header()] = None,
 ) -> None:
     """Permanently delete a task.
 
@@ -371,6 +382,7 @@ async def delete_task(
         query_controller: Query controller dependency (for fetching task name before deletion)
         broadcaster: Event broadcaster dependency
         x_client_id: Optional client ID from WebSocket connection
+        x_user_name: Optional user name from API gateway
 
     Raises:
         HTTPException: 404 if task not found
@@ -385,4 +397,4 @@ async def delete_task(
     controller.remove_task(task_id)
 
     # Broadcast WebSocket event in background (exclude the requester)
-    broadcaster.task_deleted(task_id, task_name, x_client_id)
+    broadcaster.task_deleted(task_id, task_name, x_client_id, x_user_name)

--- a/packages/taskdog-ui/src/taskdog/tui/services/event_handler_registry.py
+++ b/packages/taskdog-ui/src/taskdog/tui/services/event_handler_registry.py
@@ -143,14 +143,20 @@ class EventHandlerRegistry:
             )
 
     def _get_display_source(self, message: dict[str, Any]) -> str | None:
-        """Get display source client ID if different from this client.
+        """Get display source (user name or client ID) if different from this client.
 
         Args:
-            message: Message containing source_client_id
+            message: Message containing source_user_name and/or source_client_id
 
         Returns:
-            Source client ID if different from this client, None otherwise
+            User name if available, otherwise client ID if different from this client
         """
+        # Prefer user name over client ID
+        source_user_name = message.get("source_user_name")
+        if isinstance(source_user_name, str) and source_user_name:
+            return source_user_name
+
+        # Fall back to client ID
         source_client_id = message.get("source_client_id")
         if (
             isinstance(source_client_id, str)


### PR DESCRIPTION
## Summary
- Add support for `X-User-Name` HTTP header to display human-readable user names in WebSocket notifications
- API gateways (e.g., Kong) can inject user names resolved from API keys
- TUI now shows user names instead of UUIDs in real-time notifications

## Changes
- **Broadcaster**: Add `user_name` parameter to all broadcast methods, include `source_user_name` in payloads
- **Endpoints**: Add `x_user_name` header parameter to all mutation endpoints (tasks, lifecycle, relationships, analytics, notes)
- **TUI**: Prefer `source_user_name` over `source_client_id` in event handler registry

## Example
Before:
```
Task created: New Task (ID: 123) by abc123-def456-...
```

After (with Kong):
```
Task created: New Task (ID: 123) by kohei
```

## Test plan
- [x] `make test-server` - All 246 tests pass
- [x] `make test-ui` - All 822 tests pass
- [x] `make typecheck` - No type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)