### PR TITLE
fix(tui): handle 500 server errors gracefully

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/domain/exceptions/task_exceptions.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/exceptions/task_exceptions.py
@@ -135,6 +135,22 @@ class AuthenticationError(TaskError):
         super().__init__(message)
 
 
+class ServerError(TaskError):
+    """Raised when API server returns 5xx error."""
+
+    def __init__(
+        self, status_code: int, message: str = "Server error occurred."
+    ) -> None:
+        """Initialize with status code and error message.
+
+        Args:
+            status_code: HTTP status code (5xx)
+            message: Human-readable error message
+        """
+        self.status_code = status_code
+        super().__init__(f"Server error ({status_code}): {message}")
+
+
 class TaskNotSchedulableError(TaskValidationError):
     """Raised when a single task cannot be scheduled."""
 

--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -38,6 +38,7 @@ from taskdog.tui.utils.css_loader import get_css_paths
 from taskdog_core.domain.exceptions.task_exceptions import (
     AuthenticationError,
     ServerConnectionError,
+    ServerError,
 )
 
 # CliConfig is used only for theme setting, not passed to TUIContext
@@ -324,6 +325,7 @@ class TaskdogTUI(App):
             main_screen_provider=lambda: self.main_screen,
             on_connection_error=self._handle_connection_error,
             on_auth_error=self._handle_auth_error,
+            on_server_error=self._handle_server_error,
         )
 
         # Load tasks after screen is fully mounted
@@ -366,6 +368,18 @@ class TaskdogTUI(App):
         """
         self.notify(
             f"Authentication failed: {error}. Check your API key.",
+            severity="error",
+            timeout=10,
+        )
+
+    def _handle_server_error(self, error: ServerError) -> None:
+        """Handle server errors (5xx) from TaskUIManager.
+
+        Args:
+            error: ServerError from API call
+        """
+        self.notify(
+            f"Server error: {error}. Press 'r' to retry.",
             severity="error",
             timeout=10,
         )


### PR DESCRIPTION
## Summary
- Add `ServerError` exception for 5xx HTTP responses
- Handle server errors gracefully in TUI to show notification instead of crashing
- Add callback mechanism in `TaskUIManager` for error handling

## Changes
- `task_exceptions.py`: Add `ServerError` exception class
- `base_client.py`: Handle 5xx responses with `ServerError`
- `task_ui_manager.py`: Add `on_server_error` callback
- `app.py`: Add `_handle_server_error` callback and wire to `TaskUIManager`
- `test_base_client.py`: Add tests for 401 and 5xx error handling

## Test plan
- [ ] Start TUI without server running → shows connection error notification
- [ ] Start TUI with server returning 500 → shows server error notification instead of crash
- [ ] Verify all tests pass with `make test-ui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)