### PR TITLE
refactor(core): move MIN_PRIORITY_EXCLUSIVE to domain layer

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/domain/constants.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/constants.py
@@ -18,3 +18,7 @@ SECONDS_PER_DAY = 86400
 # File size validation
 MIN_FILE_SIZE_FOR_CONTENT = 0
 """Minimum file size in bytes to consider a file as having content."""
+
+# Validation limits - Business rules
+MIN_PRIORITY_EXCLUSIVE = 0
+"""Minimum priority value (exclusive). Priority must be > 0."""

--- a/packages/taskdog-core/src/taskdog_core/domain/entities/task.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/entities/task.py
@@ -2,9 +2,8 @@ from dataclasses import dataclass, field
 from datetime import date, datetime
 from enum import Enum
 
-from taskdog_core.domain.constants import SECONDS_PER_HOUR
+from taskdog_core.domain.constants import MIN_PRIORITY_EXCLUSIVE, SECONDS_PER_HOUR
 from taskdog_core.domain.exceptions.task_exceptions import TaskValidationError
-from taskdog_core.shared.constants import MIN_PRIORITY_EXCLUSIVE
 
 
 class TaskStatus(Enum):

--- a/packages/taskdog-core/src/taskdog_core/shared/constants/__init__.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/constants/__init__.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 
+from taskdog_core.domain.constants import MIN_PRIORITY_EXCLUSIVE
 from taskdog_core.shared.constants.config_defaults import (
     DEFAULT_ALGORITHM,
     DEFAULT_END_HOUR,
@@ -9,7 +10,6 @@ from taskdog_core.shared.constants.config_defaults import (
     DEFAULT_PRIORITY,
     DEFAULT_START_HOUR,
     MAX_ESTIMATED_DURATION_HOURS,
-    MIN_PRIORITY_EXCLUSIVE,
 )
 from taskdog_core.shared.constants.file_management import (
     BACKUP_FILE_SUFFIX,

--- a/packages/taskdog-core/src/taskdog_core/shared/constants/config_defaults.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/constants/config_defaults.py
@@ -8,7 +8,6 @@ DEFAULT_ALGORITHM = "greedy"
 DEFAULT_PRIORITY = 5
 
 # === Validation Limits ===
-MIN_PRIORITY_EXCLUSIVE = 0  # Priority must be > 0
 MAX_ESTIMATED_DURATION_HOURS = 999  # Maximum estimated duration in hours
 
 # === Time Defaults ===


### PR DESCRIPTION
## Summary
- `MIN_PRIORITY_EXCLUSIVE` を `shared/constants/` から `domain/constants.py` に移動
- Clean Architecture の依存方向を修正（Domain層 → Shared層 の依存を解消）
- 後方互換性のため `shared/constants/__init__.py` で再エクスポート

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `domain/constants.py` | `MIN_PRIORITY_EXCLUSIVE = 0` を追加 |
| `domain/entities/task.py` | インポート元を `domain.constants` に変更 |
| `shared/constants/config_defaults.py` | `MIN_PRIORITY_EXCLUSIVE` を削除 |
| `shared/constants/__init__.py` | `domain.constants` から再エクスポート |

## Test plan
- [x] `make test-core` - 1063 passed
- [x] `make typecheck` - Success (367 files)

Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)