### PR TITLE
fix(server): remove undefined context placeholder from JSON log format

### DIFF
--- a/packages/taskdog-server/src/taskdog_server/infrastructure/logging/config.py
+++ b/packages/taskdog-server/src/taskdog_server/infrastructure/logging/config.py
@@ -36,8 +36,7 @@ def configure_logging(
     # Configure format
     if format_str == "json":
         # JSON format for production (parseable by log aggregation tools)
-        # Python 3.12+ supports JSON serialization natively
-        log_format = '{"time":"%(asctime)s","level":"%(levelname)s","logger":"%(name)s","message":"%(message)s","context":%(context)s}'
+        log_format = '{"time":"%(asctime)s","level":"%(levelname)s","logger":"%(name)s","message":"%(message)s"}'
     else:
         # Text format for development (human-readable)
         log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"


### PR DESCRIPTION
## Summary
- JSON logging format から未定義の `%(context)s` プレースホルダーを削除
- JSON logging 使用時に KeyError が発生するバグを修正

## Changes
- `packages/taskdog-server/src/taskdog_server/infrastructure/logging/config.py`

## Test plan
- [x] `make test-server` - 246 passed

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)