### PR TITLE
test(ui): improve CLI command test coverage

### DIFF
--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_table_helpers.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_table_helpers.py
@@ -1,0 +1,112 @@
+"""Tests for table_helpers module."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from taskdog.cli.commands.table_helpers import render_table
+from taskdog.cli.context import CliContext
+
+
+class TestRenderTable:
+    """Test cases for render_table helper function."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Set up test fixtures."""
+        self.console_writer = MagicMock()
+        self.api_client = MagicMock()
+        self.config = MagicMock()
+
+        self.cli_context = CliContext(
+            console_writer=self.console_writer,
+            api_client=self.api_client,
+            config=self.config,
+        )
+
+    def test_render_table_basic(self):
+        """Test basic table rendering."""
+        # Setup
+        mock_output = MagicMock()
+        mock_view_models = [MagicMock(), MagicMock()]
+
+        with (
+            patch(
+                "taskdog.cli.commands.table_helpers.TablePresenter"
+            ) as mock_presenter_cls,
+            patch(
+                "taskdog.cli.commands.table_helpers.RichTableRenderer"
+            ) as mock_renderer_cls,
+        ):
+            mock_presenter = MagicMock()
+            mock_presenter.present.return_value = mock_view_models
+            mock_presenter_cls.return_value = mock_presenter
+
+            mock_renderer = MagicMock()
+            mock_renderer_cls.return_value = mock_renderer
+
+            # Execute
+            render_table(self.cli_context, mock_output)
+
+            # Verify
+            mock_presenter_cls.assert_called_once_with(self.api_client)
+            mock_presenter.present.assert_called_once_with(mock_output)
+            mock_renderer_cls.assert_called_once_with(self.console_writer)
+            mock_renderer.render.assert_called_once_with(mock_view_models, fields=None)
+
+    def test_render_table_with_fields(self):
+        """Test table rendering with specific fields."""
+        # Setup
+        mock_output = MagicMock()
+        mock_view_models = [MagicMock()]
+        fields = ["id", "name", "status"]
+
+        with (
+            patch(
+                "taskdog.cli.commands.table_helpers.TablePresenter"
+            ) as mock_presenter_cls,
+            patch(
+                "taskdog.cli.commands.table_helpers.RichTableRenderer"
+            ) as mock_renderer_cls,
+        ):
+            mock_presenter = MagicMock()
+            mock_presenter.present.return_value = mock_view_models
+            mock_presenter_cls.return_value = mock_presenter
+
+            mock_renderer = MagicMock()
+            mock_renderer_cls.return_value = mock_renderer
+
+            # Execute
+            render_table(self.cli_context, mock_output, fields=fields)
+
+            # Verify
+            mock_renderer.render.assert_called_once_with(
+                mock_view_models, fields=fields
+            )
+
+    def test_render_table_empty(self):
+        """Test table rendering with empty task list."""
+        # Setup
+        mock_output = MagicMock()
+        mock_view_models = []  # Empty list
+
+        with (
+            patch(
+                "taskdog.cli.commands.table_helpers.TablePresenter"
+            ) as mock_presenter_cls,
+            patch(
+                "taskdog.cli.commands.table_helpers.RichTableRenderer"
+            ) as mock_renderer_cls,
+        ):
+            mock_presenter = MagicMock()
+            mock_presenter.present.return_value = mock_view_models
+            mock_presenter_cls.return_value = mock_presenter
+
+            mock_renderer = MagicMock()
+            mock_renderer_cls.return_value = mock_renderer
+
+            # Execute
+            render_table(self.cli_context, mock_output)
+
+            # Verify - should still render (empty table)
+            mock_renderer.render.assert_called_once_with(mock_view_models, fields=None)


### PR DESCRIPTION
## Summary

- Improve CLI command test coverage from 92% to 97%
- Add tests for low-coverage modules: `note.py`, `table_helpers.py`, `schedule.py`
- Add 12 new tests total

## Changes

### test_note.py (7 tests added)
- `test_task_not_found` - TaskNotFoundException when task not found
- `test_file_read_oserror` - OSError on file read
- `test_file_read_unicode_error` - UnicodeDecodeError on file read  
- `test_editor_not_found` - RuntimeError when $EDITOR not found
- `test_editor_execution_error` - CalledProcessError on editor execution
- `test_editor_keyboard_interrupt` - KeyboardInterrupt handling
- `test_editor_save_oserror` - OSError when saving edited content

### test_table_helpers.py (new file, 3 tests)
- `test_render_table_basic` - Basic table rendering
- `test_render_table_with_fields` - Table with specific fields
- `test_render_table_empty` - Empty task list

### test_schedule_command.py (2 tests added)
- `test_schedule_format_with_null_start` - N/A formatting when start is None
- `test_schedule_format_with_null_end` - N/A formatting when end is None

## Coverage Results

| File | Before | After |
|------|--------|-------|
| CLI commands overall | 92% | **97%** |
| `note.py` | 64% | **94%** |
| `table_helpers.py` | 45% | **100%** |
| `schedule.py` | 85% | **100%** |
| Test count | 235 | **247** |

## Test plan
- [x] All 247 CLI command tests pass
- [x] All 837 UI tests pass
- [x] Pre-commit hooks pass (ruff, mypy)

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)