### PR TITLE
feat(core): add input validation constraints for task name and tags

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/domain/constants.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/constants.py
@@ -22,3 +22,12 @@ MIN_FILE_SIZE_FOR_CONTENT = 0
 # Validation limits - Business rules
 MIN_PRIORITY_EXCLUSIVE = 0
 """Minimum priority value (exclusive). Priority must be > 0."""
+
+MAX_TASK_NAME_LENGTH = 255
+"""Maximum length of task name in characters."""
+
+MAX_TAG_LENGTH = 50
+"""Maximum length of a single tag in characters."""
+
+MAX_TAGS_PER_TASK = 20
+"""Maximum number of tags allowed per task."""

--- a/packages/taskdog-core/src/taskdog_core/domain/entities/task.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/entities/task.py
@@ -2,7 +2,13 @@ from dataclasses import dataclass, field
 from datetime import date, datetime
 from enum import Enum
 
-from taskdog_core.domain.constants import MIN_PRIORITY_EXCLUSIVE, SECONDS_PER_HOUR
+from taskdog_core.domain.constants import (
+    MAX_TAG_LENGTH,
+    MAX_TAGS_PER_TASK,
+    MAX_TASK_NAME_LENGTH,
+    MIN_PRIORITY_EXCLUSIVE,
+    SECONDS_PER_HOUR,
+)
 from taskdog_core.domain.exceptions.task_exceptions import TaskValidationError
 
 
@@ -81,9 +87,13 @@ class Task:
         Raises:
             TaskValidationError: If any invariant is violated
         """
-        # Validate name (required and non-empty)
+        # Validate name (required, non-empty, and within length limit)
         if not self.name or not self.name.strip():
             raise TaskValidationError("Task name cannot be empty")
+        if len(self.name) > MAX_TASK_NAME_LENGTH:
+            raise TaskValidationError(
+                f"Task name cannot exceed {MAX_TASK_NAME_LENGTH} characters"
+            )
 
         # Validate priority (must be positive)
         if self.priority <= MIN_PRIORITY_EXCLUSIVE:
@@ -93,10 +103,18 @@ class Task:
         if self.estimated_duration is not None and self.estimated_duration <= 0:
             raise TaskValidationError("Estimated duration must be greater than 0")
 
-        # Validate tags (non-empty strings and unique)
+        # Validate tags (count limit, non-empty strings, length limit, unique)
+        if len(self.tags) > MAX_TAGS_PER_TASK:
+            raise TaskValidationError(
+                f"Cannot have more than {MAX_TAGS_PER_TASK} tags per task"
+            )
         for tag in self.tags:
             if not tag or not tag.strip():
                 raise TaskValidationError("Tag cannot be empty")
+            if len(tag) > MAX_TAG_LENGTH:
+                raise TaskValidationError(
+                    f"Tag cannot exceed {MAX_TAG_LENGTH} characters"
+                )
         if len(self.tags) != len(set(self.tags)):
             raise TaskValidationError("Tags must be unique")
 

--- a/packages/taskdog-core/src/taskdog_core/shared/constants/__init__.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/constants/__init__.py
@@ -2,7 +2,12 @@
 
 from datetime import datetime
 
-from taskdog_core.domain.constants import MIN_PRIORITY_EXCLUSIVE
+from taskdog_core.domain.constants import (
+    MAX_TAG_LENGTH,
+    MAX_TAGS_PER_TASK,
+    MAX_TASK_NAME_LENGTH,
+    MIN_PRIORITY_EXCLUSIVE,
+)
 from taskdog_core.shared.constants.config_defaults import (
     DEFAULT_ALGORITHM,
     DEFAULT_END_HOUR,
@@ -57,6 +62,9 @@ __all__ = [
     "ISO_8601_FORMAT",
     "MAX_ESTIMATED_DURATION_HOURS",
     "MAX_HOURS_PER_DAY_LIMIT",
+    "MAX_TAGS_PER_TASK",
+    "MAX_TAG_LENGTH",
+    "MAX_TASK_NAME_LENGTH",
     "MIN_HOURS_PER_DAY_EXCLUSIVE",
     "MIN_PRIORITY_EXCLUSIVE",
     "NOTES_DIR_NAME",

--- a/packages/taskdog-core/tests/domain/entities/test_task_validation.py
+++ b/packages/taskdog-core/tests/domain/entities/test_task_validation.py
@@ -2,6 +2,11 @@
 
 import pytest
 
+from taskdog_core.domain.constants import (
+    MAX_TAG_LENGTH,
+    MAX_TAGS_PER_TASK,
+    MAX_TASK_NAME_LENGTH,
+)
 from taskdog_core.domain.entities.task import Task, TaskStatus
 from taskdog_core.domain.exceptions.task_exceptions import TaskValidationError
 from taskdog_core.infrastructure.persistence.mappers.task_db_mapper import TaskDbMapper
@@ -178,3 +183,58 @@ class TestTaskValidation:
         with pytest.raises(TaskValidationError) as exc_info:
             mapper.from_dict(data)
         assert expected_error in str(exc_info.value)
+
+    @pytest.mark.parametrize(
+        "name,should_raise",
+        [
+            ("a" * MAX_TASK_NAME_LENGTH, False),
+            ("a" * (MAX_TASK_NAME_LENGTH + 1), True),
+        ],
+        ids=["name_at_limit", "name_over_limit"],
+    )
+    def test_name_length_validation(self, name, should_raise):
+        """Test task name length validation at boundary values."""
+        if should_raise:
+            with pytest.raises(TaskValidationError) as exc_info:
+                Task(name=name, priority=5)
+            assert f"cannot exceed {MAX_TASK_NAME_LENGTH}" in str(exc_info.value)
+        else:
+            task = Task(name=name, priority=5)
+            assert task.name == name
+
+    @pytest.mark.parametrize(
+        "tag,should_raise",
+        [
+            ("a" * MAX_TAG_LENGTH, False),
+            ("a" * (MAX_TAG_LENGTH + 1), True),
+        ],
+        ids=["tag_at_limit", "tag_over_limit"],
+    )
+    def test_tag_length_validation(self, tag, should_raise):
+        """Test individual tag length validation at boundary values."""
+        if should_raise:
+            with pytest.raises(TaskValidationError) as exc_info:
+                Task(name="Test Task", priority=5, tags=[tag])
+            assert f"cannot exceed {MAX_TAG_LENGTH}" in str(exc_info.value)
+        else:
+            task = Task(name="Test Task", priority=5, tags=[tag])
+            assert task.tags == [tag]
+
+    @pytest.mark.parametrize(
+        "tag_count,should_raise",
+        [
+            (MAX_TAGS_PER_TASK, False),
+            (MAX_TAGS_PER_TASK + 1, True),
+        ],
+        ids=["tags_at_limit", "tags_over_limit"],
+    )
+    def test_tags_count_validation(self, tag_count, should_raise):
+        """Test tags count validation at boundary values."""
+        tags = [f"tag{i}" for i in range(tag_count)]
+        if should_raise:
+            with pytest.raises(TaskValidationError) as exc_info:
+                Task(name="Test Task", priority=5, tags=tags)
+            assert f"more than {MAX_TAGS_PER_TASK}" in str(exc_info.value)
+        else:
+            task = Task(name="Test Task", priority=5, tags=tags)
+            assert len(task.tags) == tag_count

--- a/packages/taskdog-core/tests/infrastructure/persistence/database/test_sqlite_task_repository.py
+++ b/packages/taskdog-core/tests/infrastructure/persistence/database/test_sqlite_task_repository.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from taskdog_core.domain.constants import MAX_TAGS_PER_TASK
 from taskdog_core.domain.entities.task import Task, TaskStatus
 from taskdog_core.infrastructure.persistence.database.sqlite_task_repository import (
     SqliteTaskRepository,
@@ -480,16 +481,16 @@ class TestSqliteTaskRepository:
         assert retrieved is not None
         assert set(retrieved.tags) == set(original_tags)
 
-    def test_task_with_100_tags(self):
-        """Test task with 100 tags (large tag set) (Phase 4)."""
-        # Create task with 100 unique tags
-        tags = [f"tag-{i:03d}" for i in range(100)]
+    def test_task_with_max_tags(self):
+        """Test task with maximum allowed tags (Phase 4)."""
+        # Create task with maximum unique tags
+        tags = [f"tag-{i:03d}" for i in range(MAX_TAGS_PER_TASK)]
         task = self.repository.create("Task with many tags", priority=1, tags=tags)
 
         # Verify all tags were saved
         retrieved = self.repository.get_by_id(task.id)
         assert retrieved is not None
-        assert len(retrieved.tags) == 100
+        assert len(retrieved.tags) == MAX_TAGS_PER_TASK
         assert set(retrieved.tags) == set(tags)
 
     def test_repository_with_1000_unique_tags(self):


### PR DESCRIPTION
## Summary

Closes #416

- Add `MAX_TASK_NAME_LENGTH = 255` (task name maximum length)
- Add `MAX_TAG_LENGTH = 50` (individual tag maximum length)
- Add `MAX_TAGS_PER_TASK = 20` (maximum tags per task)
- Update Task entity `__post_init__` validation
- Add boundary value tests

## Test plan

- [x] `make test-core` passes (1119 tests)
- [x] `make typecheck` passes
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)