### PR TITLE
fix(core): add name validation to prevent long task names causing server crash

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/update_task.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/update_task.py
@@ -1,5 +1,6 @@
 """Use case for updating a task."""
 
+from dataclasses import replace
 from datetime import datetime
 
 from taskdog_core.application.dto.update_task_input import UpdateTaskInput
@@ -122,8 +123,10 @@ class UpdateTaskUseCase(UseCase[UpdateTaskInput, TaskUpdateOutput]):
         self._update_status(task, input_dto, updated_fields)
         self._update_standard_fields(task, input_dto, updated_fields)
 
-        # Save changes
+        # Rebuild task to trigger __post_init__ validation (Always-Valid Entity)
+        # This ensures validation is consistent between create and update operations
         if updated_fields:
+            task = replace(task)
             self.repository.save(task)
 
         return TaskUpdateOutput.from_task_and_fields(task, updated_fields)

--- a/packages/taskdog-server/src/taskdog_server/api/models/requests.py
+++ b/packages/taskdog-server/src/taskdog_server/api/models/requests.py
@@ -6,13 +6,16 @@ from datetime import datetime
 from pydantic import BaseModel, Field, field_validator
 
 from taskdog_core.domain.entities.task import TaskStatus
+from taskdog_core.shared.constants import MAX_TASK_NAME_LENGTH
 from taskdog_server.api.validators import validate_tags as _validate_tags
 
 
 class CreateTaskRequest(BaseModel):
     """Request model for creating a task."""
 
-    name: str = Field(..., min_length=1, description="Task name")
+    name: str = Field(
+        ..., min_length=1, max_length=MAX_TASK_NAME_LENGTH, description="Task name"
+    )
     priority: int | None = Field(
         None, gt=0, description="Task priority (higher = more important)"
     )
@@ -40,7 +43,9 @@ class UpdateTaskRequest(BaseModel):
     All fields are optional. Only provided fields will be updated.
     """
 
-    name: str | None = Field(None, min_length=1, description="New task name")
+    name: str | None = Field(
+        None, min_length=1, max_length=MAX_TASK_NAME_LENGTH, description="New task name"
+    )
     priority: int | None = Field(None, gt=0, description="New priority")
     status: TaskStatus | None = Field(None, description="New status")
     planned_start: datetime | None = Field(None, description="New planned start")


### PR DESCRIPTION
## Summary
- Use `dataclasses.replace()` in `UpdateTaskUseCase` to trigger `__post_init__` validation
- Add `max_length` constraint to API request models
- Handle 422 validation errors in CLI API client

## Problem
Updating a task with invalid values (e.g., name > 255 chars) would save to DB but cause 500 error on subsequent reads because `UpdateTaskUseCase` used `setattr()` which bypasses `Task.__post_init__` validation.

Also, CLI didn't handle FastAPI's 422 Pydantic validation errors properly.

## Solution
1. `UpdateTaskUseCase` now rebuilds the Task entity via `replace()` after updates, which triggers `__post_init__` validation. This maintains the **Always-Valid Entity** pattern.

2. API layer validates via Pydantic `max_length` (returns 422).

3. CLI `BaseApiClient` now handles 422 errors and formats Pydantic validation messages for user-friendly display.

## Changes
- `UpdateTaskUseCase`: Add `dataclasses.replace(task)` before save
- `requests.py`: Add `max_length=MAX_TASK_NAME_LENGTH` to name fields
- `base_client.py`: Handle 422 status code with `_extract_validation_error_detail()`

## Test plan
- [x] All core tests pass (`make test-core`)
- [x] All server tests pass (`make test-server`)
- [x] All UI tests pass (`make test-ui`)
- [x] Type check passes (`make typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)