### PR TITLE
fix(server): add tag count and length validation to API

### DIFF
--- a/packages/taskdog-server/src/taskdog_server/api/validators.py
+++ b/packages/taskdog-server/src/taskdog_server/api/validators.py
@@ -1,8 +1,10 @@
 """Shared validators for Pydantic request models."""
 
+from taskdog_core.shared.constants import MAX_TAG_LENGTH, MAX_TAGS_PER_TASK
+
 
 def validate_tags(tags: list[str]) -> list[str]:
-    """Validate tags are non-empty and unique.
+    """Validate tags are non-empty, unique, and within limits.
 
     Args:
         tags: List of tag strings
@@ -11,12 +13,17 @@ def validate_tags(tags: list[str]) -> list[str]:
         Validated list of tags
 
     Raises:
-        ValueError: If any tag is empty or tags are not unique
+        ValueError: If validation fails
     """
     if not tags:
         return tags
-    if any(not tag.strip() for tag in tags):
-        raise ValueError("Tags must be non-empty")
+    if len(tags) > MAX_TAGS_PER_TASK:
+        raise ValueError(f"Cannot have more than {MAX_TAGS_PER_TASK} tags per task")
+    for tag in tags:
+        if not tag.strip():
+            raise ValueError("Tags must be non-empty")
+        if len(tag) > MAX_TAG_LENGTH:
+            raise ValueError(f"Tag cannot exceed {MAX_TAG_LENGTH} characters")
     if len(tags) != len(set(tags)):
         raise ValueError("Tags must be unique")
     return tags


### PR DESCRIPTION
## Summary
- Add `MAX_TAGS_PER_TASK` (20) validation to API
- Add `MAX_TAG_LENGTH` (50) validation to API

## Problem
API `validate_tags` was missing tag count and length limits that exist in `Task.__post_init__`. This could allow invalid tags to be sent to the server.

## Solution
Updated `validators.py` to check:
- Tag count <= 20
- Each tag length <= 50 characters

Now API validation matches domain entity validation.

## Test plan
- [x] All server tests pass (`make test-server`)
- [x] Type check passes (`make typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)