### PR TITLE
feat(ui): add audit log side panel to TUI

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -24,6 +24,7 @@ from taskdog.tui.constants.ui_settings import (
 from taskdog.tui.context import TUIContext
 from taskdog.tui.events import GanttResizeRequested, TasksRefreshed
 from taskdog.tui.palette.providers import (
+    AuditCommandProvider,
     ExportCommandProvider,
     ExportFormatProvider,
     HelpCommandProvider,
@@ -170,6 +171,7 @@ class TaskdogTUI(App):
 
     # Register custom command providers
     COMMANDS = App.COMMANDS | {
+        AuditCommandProvider,
         SortCommandProvider,
         OptimizeCommandProvider,
         ExportCommandProvider,
@@ -463,6 +465,14 @@ class TaskdogTUI(App):
     def action_command_palette(self) -> None:
         """Show the command palette."""
         self.push_screen(CommandPalette())
+
+    def toggle_audit_panel(self) -> None:
+        """Toggle the audit log side panel visibility.
+
+        Called from Command Palette via AuditCommandProvider.
+        """
+        if self.main_screen:
+            self.main_screen.toggle_audit_panel()
 
     def _refresh_elapsed_time(self) -> None:
         """Refresh the task table to update elapsed time for IN_PROGRESS tasks.

--- a/packages/taskdog-ui/src/taskdog/tui/commands/__init__.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/__init__.py
@@ -1,6 +1,7 @@
 """TUI command classes for action handling."""
 
 from taskdog.tui.commands.add import AddCommand
+from taskdog.tui.commands.audit import AuditCommand
 from taskdog.tui.commands.base import TUICommandBase
 from taskdog.tui.commands.cancel import CancelCommand
 from taskdog.tui.commands.done import DoneCommand
@@ -19,6 +20,7 @@ from taskdog.tui.commands.start import StartCommand
 
 COMMANDS: dict[str, type[TUICommandBase]] = {
     "add": AddCommand,
+    "audit": AuditCommand,
     "cancel": CancelCommand,
     "done": DoneCommand,
     "edit": EditCommand,

--- a/packages/taskdog-ui/src/taskdog/tui/commands/audit.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/audit.py
@@ -1,0 +1,12 @@
+"""Audit command for TUI - toggles audit log side panel."""
+
+from taskdog.tui.commands.base import TUICommandBase
+
+
+class AuditCommand(TUICommandBase):
+    """Command to toggle the audit log side panel visibility."""
+
+    def execute_impl(self) -> None:
+        """Execute the audit toggle command."""
+        if self.app.main_screen:
+            self.app.main_screen.toggle_audit_panel()

--- a/packages/taskdog-ui/src/taskdog/tui/palette/providers/__init__.py
+++ b/packages/taskdog-ui/src/taskdog/tui/palette/providers/__init__.py
@@ -1,5 +1,6 @@
 """Command providers for Taskdog TUI Command Palette."""
 
+from taskdog.tui.palette.providers.audit_provider import AuditCommandProvider
 from taskdog.tui.palette.providers.base import BaseListProvider
 from taskdog.tui.palette.providers.export_providers import (
     EXPORT_FORMATS,
@@ -15,6 +16,7 @@ from taskdog.tui.palette.providers.sort_providers import (
 
 __all__ = [
     "EXPORT_FORMATS",
+    "AuditCommandProvider",
     "BaseListProvider",
     "ExportCommandProvider",
     "ExportFormatProvider",

--- a/packages/taskdog-ui/src/taskdog/tui/palette/providers/audit_provider.py
+++ b/packages/taskdog-ui/src/taskdog/tui/palette/providers/audit_provider.py
@@ -1,0 +1,13 @@
+"""Command provider for audit log functionality."""
+
+from __future__ import annotations
+
+from taskdog.tui.palette.providers.base import SimpleSingleCommandProvider
+
+
+class AuditCommandProvider(SimpleSingleCommandProvider):
+    """Command provider for audit log panel toggle."""
+
+    COMMAND_NAME = "Audit Logs"
+    COMMAND_HELP = "Toggle audit log side panel"
+    COMMAND_CALLBACK_NAME = "toggle_audit_panel"

--- a/packages/taskdog-ui/src/taskdog/tui/services/event_handler_registry.py
+++ b/packages/taskdog-ui/src/taskdog/tui/services/event_handler_registry.py
@@ -62,6 +62,7 @@ class EventHandlerRegistry:
     def _handle_task_created(self, message: dict[str, Any]) -> None:
         """Handle task created event."""
         self._reload_tasks()
+        self._refresh_audit_panel()
         task_name = message.get("task_name", "Unknown")
         task_id = message.get("task_id")
         display_source = self._get_display_source(message)
@@ -73,6 +74,7 @@ class EventHandlerRegistry:
     def _handle_task_updated(self, message: dict[str, Any]) -> None:
         """Handle task updated event."""
         self._reload_tasks()
+        self._refresh_audit_panel()
         task_name = message.get("task_name", "Unknown")
         task_id = message.get("task_id")
         display_source = self._get_display_source(message)
@@ -90,6 +92,7 @@ class EventHandlerRegistry:
     def _handle_task_deleted(self, message: dict[str, Any]) -> None:
         """Handle task deleted event."""
         self._reload_tasks()
+        self._refresh_audit_panel()
         task_name = message.get("task_name", "Unknown")
         task_id = message.get("task_id")
         display_source = self._get_display_source(message)
@@ -101,6 +104,7 @@ class EventHandlerRegistry:
     def _handle_task_status_changed(self, message: dict[str, Any]) -> None:
         """Handle task status changed event."""
         self._reload_tasks()
+        self._refresh_audit_panel()
         task_name = message.get("task_name", "Unknown")
         task_id = message.get("task_id")
         display_source = self._get_display_source(message)
@@ -127,6 +131,7 @@ class EventHandlerRegistry:
         from taskdog.tui.messages import TUIMessageBuilder
 
         self._reload_tasks()
+        self._refresh_audit_panel()
         scheduled_count = message.get("scheduled_count", 0)
         failed_count = message.get("failed_count", 0)
         algorithm = message.get("algorithm", "unknown")
@@ -141,6 +146,15 @@ class EventHandlerRegistry:
             self.app.call_later(
                 self.app.task_ui_manager.load_tasks, keep_scroll_position=True
             )
+
+    def _refresh_audit_panel(self) -> None:
+        """Refresh audit panel if visible.
+
+        Schedules the refresh to run after the current event is processed.
+        Only refreshes if the main screen exists and the audit panel is visible.
+        """
+        if hasattr(self.app, "main_screen") and self.app.main_screen:
+            self.app.call_later(self.app.main_screen.refresh_audit_panel)
 
     def _get_display_source(self, message: dict[str, Any]) -> str | None:
         """Get display source (user name or client ID) if different from this client.

--- a/packages/taskdog-ui/src/taskdog/tui/styles/components.tcss
+++ b/packages/taskdog-ui/src/taskdog/tui/styles/components.tcss
@@ -143,3 +143,39 @@ Input {
     text-align: left;
     color: $accent;
 }
+
+/* Root container for full-width layout */
+#root-container {
+    width: 100%;
+    height: 100%;
+}
+
+/* Left content takes remaining space */
+#left-content {
+    width: 1fr;
+    height: 100%;
+}
+
+/* Audit Log Panel */
+#audit-panel {
+    width: 25%;
+    min-width: 40;
+    max-width: 80;
+    height: 100%;
+    padding: 1;
+    display: none;
+    border: double $primary;
+}
+
+#audit-panel.visible {
+    display: block;
+}
+
+#audit-panel:focus {
+    border: double $accent;
+}
+
+#audit-logs-content {
+    width: 100%;
+    height: auto;
+}

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/audit_log_widget.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/audit_log_widget.py
@@ -1,0 +1,199 @@
+"""Audit log widget for displaying real-time audit logs in TUI.
+
+This widget displays audit log entries in a side panel as cards,
+showing operation details with timestamps, success status, and client info.
+"""
+
+from collections import deque
+from typing import Any, ClassVar
+
+from rich.console import Group
+from rich.panel import Panel
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import VerticalScroll
+from textual.widgets import Static
+
+from taskdog.tui.widgets.base_widget import TUIWidget
+from taskdog_core.application.dto.audit_log_dto import AuditLogOutput
+
+
+class AuditLogWidget(VerticalScroll, TUIWidget):
+    """A widget for displaying audit logs in a side panel.
+
+    Features:
+    - Displays recent audit log entries
+    - Auto-updates when new logs are received
+    - Supports scrolling with Vi-style bindings
+    - Limited buffer to prevent memory issues
+    """
+
+    MAX_LOGS: ClassVar[int] = 50
+
+    BINDINGS: ClassVar = [
+        Binding(
+            "j",
+            "scroll_down",
+            "Scroll Down",
+            show=False,
+            tooltip="Scroll down one line (Vi-style)",
+        ),
+        Binding(
+            "k",
+            "scroll_up",
+            "Scroll Up",
+            show=False,
+            tooltip="Scroll up one line (Vi-style)",
+        ),
+        Binding(
+            "g",
+            "scroll_home",
+            "Top",
+            show=False,
+            tooltip="Scroll to top (Vi-style)",
+        ),
+        Binding(
+            "G",
+            "scroll_end",
+            "Bottom",
+            show=False,
+            tooltip="Scroll to bottom (Vi-style)",
+        ),
+        Binding(
+            "ctrl+d",
+            "page_down",
+            "Page Down",
+            show=False,
+            tooltip="Scroll down half a page",
+        ),
+        Binding(
+            "ctrl+u",
+            "page_up",
+            "Page Up",
+            show=False,
+            tooltip="Scroll up half a page",
+        ),
+    ]
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the audit log widget."""
+        super().__init__(*args, **kwargs)
+        self.can_focus = True
+        self._logs: deque[AuditLogOutput] = deque(maxlen=self.MAX_LOGS)
+        self._content_widget: Static | None = None
+
+    def compose(self) -> ComposeResult:
+        """Compose the widget layout."""
+        self._content_widget = Static("", id="audit-logs-content")
+        yield self._content_widget
+
+    def load_logs(self, logs: list[AuditLogOutput]) -> None:
+        """Load logs from API response.
+
+        Args:
+            logs: List of audit log entries (newest first from API)
+        """
+        self._logs.clear()
+        for log in logs:
+            self._logs.append(log)
+        self._render_logs()
+
+    def add_log(self, log: AuditLogOutput) -> None:
+        """Add a new log entry at the beginning.
+
+        Args:
+            log: New audit log entry
+        """
+        self._logs.appendleft(log)
+        self._render_logs()
+
+    def clear_logs(self) -> None:
+        """Clear all logs from the widget."""
+        self._logs.clear()
+        self._render_logs()
+
+    def _render_logs(self) -> None:
+        """Render all logs as cards."""
+        if not self._content_widget:
+            return
+
+        if not self._logs:
+            self._content_widget.update("[dim]No audit logs available[/dim]")
+            return
+
+        cards = [self._format_log_card(log) for log in self._logs]
+        self._content_widget.update(Group(*cards))
+
+    def _format_log_card(self, log: AuditLogOutput) -> Panel:
+        """Format a single log entry as a card.
+
+        Args:
+            log: Audit log entry to format
+
+        Returns:
+            Rich Panel representing the log entry
+        """
+        # Status and border color
+        if log.success:
+            status_icon = "[green]OK[/green]"
+            border_style = "green"
+        else:
+            status_icon = "[red]ER[/red]"
+            border_style = "red"
+
+        # Build card content
+        lines: list[Text] = []
+
+        # Line 1: Timestamp and status
+        ts = log.timestamp.strftime("%Y-%m-%d %H:%M:%S")
+        line1 = Text()
+        line1.append(ts, style="dim")
+        line1.append("  ")
+        line1.append_text(Text.from_markup(status_icon))
+        lines.append(line1)
+
+        # Line 2: Operation
+        line2 = Text()
+        line2.append(log.operation, style="cyan bold")
+        lines.append(line2)
+
+        # Line 3: Resource info (if exists)
+        if log.resource_id or log.resource_name:
+            line3 = Text()
+            if log.resource_id:
+                line3.append(f"#{log.resource_id}", style="yellow")
+            if log.resource_name:
+                if log.resource_id:
+                    line3.append(" ")
+                name = (
+                    log.resource_name[:30] + "..."
+                    if len(log.resource_name) > 30
+                    else log.resource_name
+                )
+                line3.append(name)
+            lines.append(line3)
+
+        # Line 4: Client (if exists)
+        if log.client_name:
+            line4 = Text()
+            line4.append(f"@{log.client_name}", style="dim italic")
+            lines.append(line4)
+
+        # Combine lines
+        content = Text("\n").join(lines)
+
+        return Panel(
+            content,
+            border_style=border_style,
+            padding=(0, 1),
+        )
+
+    @property
+    def log_count(self) -> int:
+        """Get the current number of logs.
+
+        Returns:
+            Number of logs currently in the widget
+        """
+        return len(self._logs)


### PR DESCRIPTION
## Summary
- TUIにAudit Logサイドパネルを追加
- Command Palette (`Ctrl+P`) から "Audit Logs" で表示切り替え
- カード形式でログエントリを表示（成功=緑、失敗=赤のボーダー）
- Vi-styleスクロール対応 (`j`/`k`, `g`/`G`, `Ctrl+d`/`Ctrl+u`)
- レスポンシブ幅（25%、min: 40, max: 80）
- 既存WebSocketイベント（task_created等）を再利用してリアルタイム更新

## Test plan
- [x] `Ctrl+P` → "Audit Logs" でパネルが表示される
- [x] タスク操作時にログが更新される
- [x] `j`/`k` でスクロールできる
- [x] 画面リサイズ時にパネル幅が調整される
- [x] フォーカス時にボーダー色が変わる

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)