### PR TITLE
fix(server): close audit log repository in test fixtures

### DIFF
--- a/packages/taskdog-server/tests/conftest.py
+++ b/packages/taskdog-server/tests/conftest.py
@@ -57,7 +57,10 @@ def session_repository():
 @pytest.fixture(scope="session")
 def session_audit_log_repository():
     """Session-scoped in-memory audit log repository."""
-    return SqliteAuditLogRepository("sqlite:///file::memory:?cache=shared&uri=true")
+    repo = SqliteAuditLogRepository("sqlite:///file::memory:?cache=shared&uri=true")
+    yield repo
+    if hasattr(repo, "close"):
+        repo.close()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- Add proper cleanup for `session_audit_log_repository` fixture to close the SQLite connection pool when the test session ends

## Changes

- Change from `return` to `yield` pattern
- Add `close()` call in fixture teardown
- Follows same pattern as `session_repository` fixture

Closes #455

## Test plan

- [x] `make test-server` passes (287 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)