### PR TITLE
refactor(core): remove deprecated generate_next_id() from repository interface

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/domain/repositories/task_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/repositories/task_repository.py
@@ -170,15 +170,6 @@ class TaskRepository(ABC):
         pass
 
     @abstractmethod
-    def generate_next_id(self) -> int:
-        """Generate the next available task ID.
-
-        Returns:
-            The next available ID
-        """
-        pass
-
-    @abstractmethod
     def create(self, name: str, priority: int, **kwargs: Any) -> Task:
         """Create a new task with auto-generated ID and save it.
 

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_task_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_task_repository.py
@@ -10,7 +10,6 @@ The repository uses TagResolver to manage tag relationships when saving tasks.
 
 from __future__ import annotations
 
-import warnings
 from datetime import date
 from typing import TYPE_CHECKING, Any
 
@@ -342,27 +341,6 @@ class SqliteTaskRepository(TaskRepository):
             delete_builder = TaskDeleteBuilder(session)
             delete_builder.delete_task(task_id)
             session.commit()
-
-    def generate_next_id(self) -> int:
-        """Generate the next available task ID.
-
-        .. deprecated::
-            This method has a race condition in concurrent scenarios.
-            Use create() which uses database AUTOINCREMENT instead.
-
-        Returns:
-            The next available ID (max_id + 1, or 1 if no tasks exist)
-        """
-        warnings.warn(
-            "generate_next_id() is deprecated due to race conditions. "
-            "Use create() method instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        with self.Session() as session:
-            stmt = select(TaskModel.id).order_by(TaskModel.id.desc()).limit(1)  # type: ignore[attr-defined]
-            result = session.scalar(stmt)
-            return (result + 1) if result is not None else 1
 
     def create(self, name: str, priority: int, **kwargs: Any) -> Task:
         """Create a new task with auto-generated ID and save it.


### PR DESCRIPTION
## Summary
- Remove deprecated `generate_next_id()` from `TaskRepository` interface
- Remove implementation from `SqliteTaskRepository`
- Remove unused `warnings` import

## Context
The method was deprecated due to race conditions in concurrent scenarios. All code has been migrated to use `repository.create()` instead (#462).

## Test plan
- [x] `make test-core` passes (1117 tests)
- [x] Pre-commit hooks pass (ruff, mypy, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)