### PR TITLE
docs: fix inconsistencies and reduce duplication across documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,9 +39,10 @@ The repository uses UV workspace with three packages:
 
 **Config**: Optional TOML at `$XDG_CONFIG_HOME/taskdog/core.toml` (fallback: `~/.config/taskdog/core.toml`)
 
-- Sections: `[api]`, `[optimization]`, `[task]`, `[time]`, `[region]`, `[storage]`
+- Sections: `[api]`, `[ui]`, `[optimization]`, `[task]`, `[time]`, `[region]`, `[storage]`
 - Settings:
   - API: cors_origins (for future Web UI)
+  - UI: theme (TUI theme)
   - Optimization: max_hours_per_day, default_algorithm
   - Task: default_priority
   - Time: default_start_hour, default_end_hour

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,15 +103,7 @@ CLI/TUI (taskdog-ui) → HTTP API → FastAPI (taskdog-server) → Controllers/R
 
 ### Architecture
 
-Taskdog follows **Clean Architecture** principles with clear separation of concerns:
-
-- **Domain Layer** (taskdog-core): Entities, domain services, exceptions
-- **Application Layer** (taskdog-core): Use cases, queries, DTOs, validators
-- **Infrastructure Layer** (taskdog-core): Repository, persistence, config
-- **Controllers Layer** (taskdog-core): CRUD, Lifecycle, Relationship, Analytics, Query controllers
-- **Presentation Layer** (taskdog-server + taskdog-ui): API routers, CLI commands, TUI
-
-For detailed architecture documentation, see [CLAUDE.md](CLAUDE.md).
+Taskdog follows **Clean Architecture** principles. For detailed architecture documentation, see [CLAUDE.md](CLAUDE.md).
 
 ## Coding Standards
 
@@ -346,22 +338,7 @@ PYTHONPATH=src uv run python -m taskdog_server.main --help
 
 ## Design Philosophy
 
-Before adding new features, please review [DESIGN_PHILOSOPHY.md](docs/DESIGN_PHILOSOPHY.md).
-
-Taskdog is designed for **individual task management**, following GTD principles:
-
-- **Individual over team**: No collaboration features, no cloud sync
-- **Transparent algorithms**: Choose from 9 scheduling strategies you can understand
-- **Privacy-first**: All data stored locally
-- **Simplicity**: Flat task structure with dependencies (no parent-child hierarchy)
-
-When proposing new features, ask:
-
-1. Does this benefit individual users? (Not teams)
-2. Does this maintain simplicity? (Every feature has a cost)
-3. Is this transparent? (No black boxes)
-4. Does this respect privacy? (No cloud requirements)
-5. Can this be achieved with existing features? (Tags, dependencies, notes)
+Before adding new features, please review [DESIGN_PHILOSOPHY.md](docs/DESIGN_PHILOSOPHY.md). This document explains why Taskdog focuses on individual task management with flat task structures, and includes guidelines for evaluating new feature proposals.
 
 ## Questions and Support
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Taskdog supports multiple beautiful themes out of the box. Configure your prefer
 
 ```toml
 [ui]
-theme = "tokyo-night"  # Options: textual-dark, textual-light, tokyo-night, dracula, catppuccin-mocha
+theme = "tokyo-night"  # Options: textual-dark, textual-light, tokyo-night, dracula, catppuccin-mocha, nord, gruvbox, solarized-light
 ```
 
 <table>

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -136,6 +136,9 @@ theme = "textual-dark"        # TUI theme (default: "textual-dark")
   - `tokyo-night` - Tokyo Night color scheme
   - `dracula` - Dracula color scheme
   - `catppuccin-mocha` - Catppuccin Mocha color scheme
+  - `nord` - Nord color scheme
+  - `gruvbox` - Gruvbox color scheme
+  - `solarized-light` - Solarized Light color scheme
 
 ### Optimization Settings
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -186,17 +186,18 @@ taskdog-server --port 8001
 
 ## Environment Variable Alternative
 
-Instead of editing the config file, you can set an environment variable:
+Instead of editing the config file, you can set environment variables:
 
 ```bash
 # Add to your shell profile (~/.bashrc, ~/.zshrc, etc.)
-export TASKDOG_API_URL=http://127.0.0.1:8000
+export TASKDOG_API_HOST=127.0.0.1
+export TASKDOG_API_PORT=8000
 
-# Or set it temporarily
-TASKDOG_API_URL=http://127.0.0.1:8000 taskdog table
+# Or set them temporarily
+TASKDOG_API_HOST=127.0.0.1 TASKDOG_API_PORT=8000 taskdog table
 ```
 
-Note: Environment variable takes precedence over config file.
+Note: Environment variables take precedence over config file.
 
 ## Uninstall
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,8 @@
 
 This directory contains example configuration files for Taskdog.
 
+For comprehensive configuration documentation, see [docs/CONFIGURATION.md](../docs/CONFIGURATION.md).
+
 ## Configuration Files
 
 Taskdog uses **separate configuration files** for clear separation of concerns:

--- a/packages/taskdog-client/README.md
+++ b/packages/taskdog-client/README.md
@@ -1,0 +1,133 @@
+# taskdog-client
+
+HTTP API client library for Taskdog server.
+
+## Overview
+
+This package provides a type-safe HTTP client for communicating with the Taskdog API server. It handles authentication, error mapping, and response conversion to domain DTOs.
+
+**Use cases:**
+
+- Building custom CLI tools
+- Integrating Taskdog with other systems
+- Creating automated workflows
+- Testing API endpoints
+
+## Installation
+
+```bash
+pip install taskdog-client
+```
+
+For development:
+
+```bash
+pip install -e ".[dev]"
+```
+
+## Client Classes
+
+| Client | Purpose |
+|--------|---------|
+| `TaskClient` | Task CRUD operations (create, update, delete, archive) |
+| `LifecycleClient` | Status changes (start, complete, pause, cancel, reopen) |
+| `RelationshipClient` | Dependencies and tags |
+| `QueryClient` | List tasks, get task details |
+| `AnalyticsClient` | Statistics and Gantt data |
+| `NotesClient` | Task notes (markdown) |
+| `AuditClient` | Audit log access |
+| `BaseApiClient` | Base class with common HTTP logic |
+
+## Usage Example
+
+```python
+from taskdog_client import TaskClient, LifecycleClient, QueryClient
+
+# Create clients
+base_url = "http://127.0.0.1:8000"
+api_key = "your-api-key"  # Optional, for authenticated servers
+
+task_client = TaskClient(base_url, api_key)
+lifecycle_client = LifecycleClient(base_url, api_key)
+query_client = QueryClient(base_url, api_key)
+
+# Create a task
+task = task_client.create_task(
+    name="My Task",
+    priority=100,
+    estimated_duration=8.0,
+    tags=["backend"]
+)
+print(f"Created task: {task.id}")
+
+# List tasks
+tasks = query_client.list_tasks(status="pending")
+for t in tasks:
+    print(f"- {t.name} (ID: {t.id})")
+
+# Start a task
+lifecycle_client.start_task(task.id)
+
+# Complete a task
+lifecycle_client.complete_task(task.id)
+```
+
+## Error Handling
+
+Clients raise exceptions from `taskdog_core.domain.exceptions`:
+
+```python
+from taskdog_core.domain.exceptions import TaskNotFoundException, TaskValidationError
+
+try:
+    task_client.get_task(999)
+except TaskNotFoundException:
+    print("Task not found")
+except TaskValidationError as e:
+    print(f"Validation error: {e}")
+```
+
+## Configuration
+
+Clients accept optional configuration:
+
+```python
+from taskdog_client import TaskClient
+
+# Basic usage (no auth)
+client = TaskClient("http://127.0.0.1:8000")
+
+# With API key authentication
+client = TaskClient(
+    base_url="http://127.0.0.1:8000",
+    api_key="your-secret-key"
+)
+
+# Custom timeout (in seconds)
+client = TaskClient(
+    base_url="http://127.0.0.1:8000",
+    timeout=30.0
+)
+```
+
+## Dependencies
+
+- `taskdog-core`: Domain DTOs and exceptions
+- `httpx`: HTTP client library
+
+## Related Packages
+
+- [taskdog-core](../taskdog-core/): Domain DTOs used by this package
+- [taskdog-server](../taskdog-server/): API server this client connects to
+- [taskdog-ui](../taskdog-ui/): CLI/TUI that uses this client
+- [taskdog-mcp](../taskdog-mcp/): MCP server that uses this client
+
+## Testing
+
+```bash
+pytest tests/
+```
+
+## License
+
+MIT

--- a/packages/taskdog-core/README.md
+++ b/packages/taskdog-core/README.md
@@ -37,11 +37,72 @@ Infrastructure (SQLite, file storage)
 Controllers (orchestration layer)
 ```
 
+### Key Components
+
+**Domain Layer** (`taskdog_core/domain/`):
+
+- `Task` - Core entity with status, priority, deadlines, dependencies
+- `TaskStatus` - PENDING, IN_PROGRESS, COMPLETED, CANCELED
+- `TimeTracker` - Records actual_start/actual_end timestamps
+- `TaskNotFoundException`, `TaskValidationError` - Domain exceptions
+
+**Application Layer** (`taskdog_core/application/`):
+
+- **Use Cases**: CreateTaskUseCase, StartTaskUseCase, OptimizeScheduleUseCase, etc.
+- **Validators**: TaskFieldValidatorRegistry with Status and Dependency validators
+- **Services**: WorkloadAllocator, OptimizationSummaryBuilder, TaskQueryService
+- **Optimization**: 9 scheduling strategies (greedy, balanced, backward, priority_first, earliest_deadline, round_robin, dependency_aware, genetic, monte_carlo)
+
+**Infrastructure Layer** (`taskdog_core/infrastructure/`):
+
+- `SqliteTaskRepository` - SQLite persistence with transactional writes
+- `FileNotesRepository` - Markdown notes storage
+- `ConfigManager` - TOML configuration loading
+
+**Controllers** (`taskdog_core/controllers/`):
+
+- `TaskCrudController` - Create, update, delete operations
+- `TaskLifecycleController` - Start, complete, pause, cancel, reopen
+- `TaskRelationshipController` - Dependencies and tags
+- `TaskAnalyticsController` - Statistics and optimization
+- `QueryController` - Read-only operations
+
+## Usage Example
+
+```python
+from taskdog_core.domain.entities.task import Task, TaskStatus
+from taskdog_core.infrastructure.persistence.database.sqlite_task_repository import SqliteTaskRepository
+from taskdog_core.controllers.task_crud_controller import TaskCrudController
+from taskdog_core.infrastructure.config.config_manager import ConfigManager
+from taskdog_core.shared.utils.logger import StandardLogger
+
+# Setup
+repository = SqliteTaskRepository("sqlite:///tasks.db")
+config = ConfigManager()
+logger = StandardLogger("example")
+
+# Create controller
+crud_controller = TaskCrudController(repository, config, logger)
+
+# Create a task
+from taskdog_core.application.dto.task_request import CreateTaskRequest
+request = CreateTaskRequest(name="My Task", priority=100)
+task = crud_controller.create_task(request)
+```
+
 ## Dependencies
 
 - `holidays`: Holiday checking for scheduling
 - `python-dateutil`: Date/time utilities
 - `sqlalchemy`: Database ORM
+
+## Related Packages
+
+- [taskdog-server](../taskdog-server/): FastAPI REST API server using this package
+- [taskdog-ui](../taskdog-ui/): CLI and TUI interfaces using this package
+- [taskdog-client](../taskdog-client/): HTTP client library for API access
+
+For detailed architecture documentation, see [CLAUDE.md](../../CLAUDE.md).
 
 ## Testing
 

--- a/packages/taskdog-mcp/README.md
+++ b/packages/taskdog-mcp/README.md
@@ -136,3 +136,53 @@ uv pip install -e .
 # Run tests
 PYTHONPATH=src uv run python -m pytest tests/ -v
 ```
+
+## Troubleshooting
+
+### "Cannot connect to API server"
+
+**Problem**: MCP server can't reach taskdog-server
+
+**Solutions**:
+
+1. Check if taskdog-server is running:
+
+   ```bash
+   curl http://127.0.0.1:8000/health
+   ```
+
+2. Verify `~/.config/taskdog/mcp.toml` has correct host/port
+3. Check if authentication is required:
+
+   ```bash
+   curl -H "X-Api-Key: your-key" http://127.0.0.1:8000/health
+   ```
+
+### "Authentication failed"
+
+**Problem**: API key is invalid or missing
+
+**Solutions**:
+
+1. Ensure `api_key` in `mcp.toml` matches a key in `server.toml`
+2. Check that auth is enabled on server (`[auth] enabled = true`)
+
+### Claude Desktop doesn't see taskdog tools
+
+**Problem**: MCP server not properly configured
+
+**Solutions**:
+
+1. Verify `claude_desktop_config.json` has correct path
+2. Restart Claude Desktop after config changes
+3. Check logs: `~/Library/Logs/Claude/mcp*.log` (macOS)
+
+## Related Packages
+
+- [taskdog-server](../taskdog-server/): Required API server
+- [taskdog-core](../taskdog-core/): Core business logic
+- [taskdog-client](../taskdog-client/): HTTP client used internally
+
+## License
+
+MIT

--- a/packages/taskdog-ui/CLI_CONFIG.md
+++ b/packages/taskdog-ui/CLI_CONFIG.md
@@ -54,9 +54,11 @@ theme = "textual-dark"  # TUI theme (default: "textual-dark")
 
 - `textual-dark` (default) - Textual's dark theme
 - `textual-light` - Textual's light theme
+- `tokyo-night` - Tokyo Night color scheme
+- `dracula` - Dracula color scheme
+- `catppuccin-mocha` - Catppuccin Mocha color scheme
 - `nord` - Nord color scheme
 - `gruvbox` - Gruvbox color scheme
-- `tokyo-night` - Tokyo Night color scheme
 - `solarized-light` - Solarized Light color scheme
 
 ### [keybindings] Section (Future Feature)
@@ -146,7 +148,7 @@ host = "192.168.1.100"
 port = 8000
 ```
 
-**Security Note**: The API server does not have authentication. Only use this for trusted networks or localhost.
+**Security Note**: For production use, configure API key authentication in `server.toml`. See [Authentication](../../docs/API.md#authentication) for details.
 
 ## Business Logic Configuration
 

--- a/packages/taskdog-ui/README.md
+++ b/packages/taskdog-ui/README.md
@@ -75,10 +75,11 @@ host = "127.0.0.1"
 port = 8000
 ```
 
-Or set environment variable:
+Or set environment variables:
 
 ```bash
-export TASKDOG_API_URL=http://127.0.0.1:8000
+export TASKDOG_API_HOST=127.0.0.1
+export TASKDOG_API_PORT=8000
 ```
 
 ### 4. Verify Connection


### PR DESCRIPTION
## Summary

- Standardize theme names to all 8 supported themes across all documentation files
- Fix environment variables from `TASKDOG_API_URL` to `TASKDOG_API_HOST` + `TASKDOG_API_PORT`
- Update CLI_CONFIG.md authentication reference to current API docs
- Add `[ui]` section description to CLAUDE.md
- Replace redundant architecture/philosophy sections in CONTRIBUTING.md with links
- Create `packages/taskdog-client/README.md` with client classes, usage examples, and error handling
- Expand package READMEs with key components, usage examples, and troubleshooting

## Test plan

- [ ] Verify all cross-reference links work correctly
- [ ] Confirm theme names are consistent across documentation
- [ ] Check environment variable names match the actual implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)