### PR TITLE
docs: add API key authentication and MCP server setup to Quick Start

### DIFF
--- a/examples/cli.toml
+++ b/examples/cli.toml
@@ -22,6 +22,12 @@ host = "127.0.0.1"
 # Must match the port used by taskdog-server
 port = 8000
 
+# API key for authentication (REQUIRED when auth is enabled on server)
+# This key must match one configured in server.toml's [[auth.api_keys]] section.
+# Generate a key with: python -c "import secrets; print(f'sk-{secrets.token_hex(24)}')"
+# Environment variable: TASKDOG_API_KEY
+api_key = "sk-your-api-key-here"
+
 # Examples:
 # - Default local server: host = "127.0.0.1", port = 8000
 # - Custom local port: host = "127.0.0.1", port = 3000
@@ -105,16 +111,18 @@ theme = "textual-dark"
 #
 # - TASKDOG_API_HOST: API server hostname
 # - TASKDOG_API_PORT: API server port
+# - TASKDOG_API_KEY: API key for authentication
 #
 # Examples:
 #
 #   export TASKDOG_API_HOST=192.168.1.100
 #   export TASKDOG_API_PORT=3000
+#   export TASKDOG_API_KEY=sk-your-api-key
 #   taskdog table
 #
 # Or inline:
 #
-#   TASKDOG_API_HOST=192.168.1.100 taskdog table
+#   TASKDOG_API_KEY=sk-your-key taskdog table
 
 # =============================================================================
 # Notes


### PR DESCRIPTION
## Summary

- Expand Quick Start Step 2 to cover API key generation and configuration for both server and CLI
- Add server.toml and cli.toml setup examples with api_key settings
- Add authentication error (401) troubleshooting section
- Add MCP Server Setup section with installation and Claude Desktop configuration
- Update examples/cli.toml with api_key setting and environment variable documentation

## Test plan

- [ ] Verify QUICKSTART.md renders correctly on GitHub
- [ ] Follow the steps to confirm API key setup works
- [ ] Confirm MCP server installation and configuration instructions are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)