### PR TITLE
refactor: move WebSocketClient to taskdog-client package

### DIFF
--- a/packages/taskdog-client/pyproject.toml
+++ b/packages/taskdog-client/pyproject.toml
@@ -12,6 +12,7 @@ license = { text = "MIT" }
 dependencies = [
     "taskdog-core==0.4.0",
     "httpx>=0.27.0",
+    "websockets>=14.0",
 ]
 
 [project.optional-dependencies]
@@ -31,6 +32,7 @@ build-backend = "setuptools.build_meta"
 packages = [
     "taskdog_client",
     "taskdog_client.converters",
+    "taskdog_client.websocket",
 ]
 package-dir = { "" = "src" }
 

--- a/packages/taskdog-client/src/taskdog_client/__init__.py
+++ b/packages/taskdog-client/src/taskdog_client/__init__.py
@@ -1,6 +1,6 @@
-"""HTTP API client for Taskdog server.
+"""HTTP and WebSocket client for Taskdog server.
 
-This package provides a type-safe HTTP client for communicating with
+This package provides type-safe HTTP and WebSocket clients for communicating with
 the Taskdog API server. It handles authentication, error mapping,
 and response conversion to domain DTOs.
 """
@@ -13,14 +13,17 @@ from taskdog_client.notes_client import NotesClient
 from taskdog_client.query_client import QueryClient
 from taskdog_client.relationship_client import RelationshipClient
 from taskdog_client.task_client import TaskClient
+from taskdog_client.websocket import ConnectionState, WebSocketClient
 
 __all__ = [
     "AnalyticsClient",
     "AuditClient",
     "BaseApiClient",
+    "ConnectionState",
     "LifecycleClient",
     "NotesClient",
     "QueryClient",
     "RelationshipClient",
     "TaskClient",
+    "WebSocketClient",
 ]

--- a/packages/taskdog-client/src/taskdog_client/websocket/__init__.py
+++ b/packages/taskdog-client/src/taskdog_client/websocket/__init__.py
@@ -1,0 +1,8 @@
+"""WebSocket client infrastructure for Taskdog server communication."""
+
+from taskdog_client.websocket.websocket_client import (
+    ConnectionState,
+    WebSocketClient,
+)
+
+__all__ = ["ConnectionState", "WebSocketClient"]

--- a/packages/taskdog-client/tests/websocket/__init__.py
+++ b/packages/taskdog-client/tests/websocket/__init__.py
@@ -1,0 +1,1 @@
+"""WebSocket client tests."""

--- a/packages/taskdog-client/tests/websocket/test_websocket_client.py
+++ b/packages/taskdog-client/tests/websocket/test_websocket_client.py
@@ -4,8 +4,7 @@ import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-from taskdog.infrastructure.websocket.websocket_client import (
+from taskdog_client.websocket.websocket_client import (
     ConnectionState,
     WebSocketClient,
 )
@@ -54,9 +53,7 @@ class TestWebSocketClientConnect:
     """Tests for WebSocketClient.connect()."""
 
     @pytest.mark.asyncio
-    @patch(
-        "taskdog.infrastructure.websocket.websocket_client.WEBSOCKETS_AVAILABLE", True
-    )
+    @patch("taskdog_client.websocket.websocket_client.WEBSOCKETS_AVAILABLE", True)
     async def test_connect_changes_state_to_connecting(self) -> None:
         """Test that connect() changes state to CONNECTING."""
         callback = MagicMock()
@@ -77,9 +74,7 @@ class TestWebSocketClientConnect:
             await client.disconnect()
 
     @pytest.mark.asyncio
-    @patch(
-        "taskdog.infrastructure.websocket.websocket_client.WEBSOCKETS_AVAILABLE", True
-    )
+    @patch("taskdog_client.websocket.websocket_client.WEBSOCKETS_AVAILABLE", True)
     async def test_duplicate_connect_is_no_op(self) -> None:
         """Test that calling connect() twice doesn't create duplicate tasks."""
         callback = MagicMock()
@@ -104,9 +99,7 @@ class TestWebSocketClientConnect:
             await client.disconnect()
 
     @pytest.mark.asyncio
-    @patch(
-        "taskdog.infrastructure.websocket.websocket_client.WEBSOCKETS_AVAILABLE", False
-    )
+    @patch("taskdog_client.websocket.websocket_client.WEBSOCKETS_AVAILABLE", False)
     async def test_connect_without_websockets_library(self) -> None:
         """Test that connect() does nothing when websockets is not available."""
         callback = MagicMock()
@@ -121,9 +114,7 @@ class TestWebSocketClientDisconnect:
     """Tests for WebSocketClient.disconnect()."""
 
     @pytest.mark.asyncio
-    @patch(
-        "taskdog.infrastructure.websocket.websocket_client.WEBSOCKETS_AVAILABLE", True
-    )
+    @patch("taskdog_client.websocket.websocket_client.WEBSOCKETS_AVAILABLE", True)
     async def test_disconnect_changes_state_to_disconnected(self) -> None:
         """Test that disconnect() changes state to DISCONNECTED."""
         callback = MagicMock()
@@ -139,9 +130,7 @@ class TestWebSocketClientDisconnect:
             assert client._state == ConnectionState.DISCONNECTED
 
     @pytest.mark.asyncio
-    @patch(
-        "taskdog.infrastructure.websocket.websocket_client.WEBSOCKETS_AVAILABLE", True
-    )
+    @patch("taskdog_client.websocket.websocket_client.WEBSOCKETS_AVAILABLE", True)
     async def test_disconnect_when_already_disconnected_is_no_op(self) -> None:
         """Test that disconnect() on disconnected client is a no-op."""
         callback = MagicMock()
@@ -152,9 +141,7 @@ class TestWebSocketClientDisconnect:
         assert client._state == ConnectionState.DISCONNECTED
 
     @pytest.mark.asyncio
-    @patch(
-        "taskdog.infrastructure.websocket.websocket_client.WEBSOCKETS_AVAILABLE", True
-    )
+    @patch("taskdog_client.websocket.websocket_client.WEBSOCKETS_AVAILABLE", True)
     async def test_disconnect_cancels_task(self) -> None:
         """Test that disconnect() cancels the background task."""
         callback = MagicMock()
@@ -197,9 +184,7 @@ class TestWebSocketClientConcurrency:
     """Tests for WebSocketClient concurrent access."""
 
     @pytest.mark.asyncio
-    @patch(
-        "taskdog.infrastructure.websocket.websocket_client.WEBSOCKETS_AVAILABLE", True
-    )
+    @patch("taskdog_client.websocket.websocket_client.WEBSOCKETS_AVAILABLE", True)
     async def test_concurrent_connect_disconnect(self) -> None:
         """Test that concurrent connect/disconnect calls are properly serialized."""
         callback = MagicMock()

--- a/packages/taskdog-ui/pyproject.toml
+++ b/packages/taskdog-ui/pyproject.toml
@@ -84,11 +84,17 @@ strict = true
 # Disable unused-ignore warnings (environment-dependent)
 warn_unused_ignores = false
 
+# Ignore missing imports for taskdog_client (installed separately)
+[[tool.mypy.overrides]]
+module = "taskdog_client"
+ignore_missing_imports = true
+
 # Ignore modules that depend on taskdog_client (external package)
 [[tool.mypy.overrides]]
 module = [
     "taskdog.infrastructure.api_client",
     "taskdog.infrastructure",
+    "taskdog.infrastructure.websocket",
 ]
 ignore_errors = true
 

--- a/packages/taskdog-ui/src/taskdog/infrastructure/websocket/__init__.py
+++ b/packages/taskdog-ui/src/taskdog/infrastructure/websocket/__init__.py
@@ -1,6 +1,10 @@
-"""WebSocket client infrastructure."""
+"""WebSocket client infrastructure.
 
-from taskdog.infrastructure.websocket.websocket_client import (
+This module re-exports WebSocket classes from taskdog_client
+for backward compatibility.
+"""
+
+from taskdog_client import (  # type: ignore[import-not-found]
     ConnectionState,
     WebSocketClient,
 )

--- a/packages/taskdog-ui/tests/infrastructure/websocket/__init__.py
+++ b/packages/taskdog-ui/tests/infrastructure/websocket/__init__.py
@@ -1,1 +1,0 @@
-"""WebSocket infrastructure tests."""

--- a/uv.lock
+++ b/uv.lock
@@ -1054,6 +1054,7 @@ source = { editable = "packages/taskdog-client" }
 dependencies = [
     { name = "httpx" },
     { name = "taskdog-core" },
+    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
@@ -1074,6 +1075,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "taskdog-core", editable = "packages/taskdog-core" },
+    { name = "websockets", specifier = ">=14.0" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
## Summary

- Move `WebSocketClient` from `taskdog-ui` to `taskdog-client` to unify communication layer (HTTP + WebSocket) in a single package
- Replace `textual.log` with standard `logging` module for reusability outside TUI context
- Add `websockets>=14.0` dependency to `taskdog-client`
- Update `taskdog-ui` to re-export from `taskdog_client` for backward compatibility

## Test plan

- [x] `make test-client` passes (201 tests, 83% coverage)
- [x] `make test-ui` passes (948 tests, 78% coverage)
- [x] `make test` passes all tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)