### PR TITLE
fix: add daily_allocations to TaskOperationOutput

### DIFF
--- a/packages/taskdog-client/src/taskdog_client/converters/task_converters.py
+++ b/packages/taskdog-client/src/taskdog_client/converters/task_converters.py
@@ -94,6 +94,7 @@ def convert_to_task_operation_output(data: dict[str, Any]) -> TaskOperationOutpu
         is_archived=data.get("is_archived", False),
         actual_duration_hours=data.get("actual_duration_hours"),
         actual_daily_hours=data.get("actual_daily_hours", {}),
+        daily_allocations=data.get("daily_allocations", {}),
     )
 
 

--- a/packages/taskdog-core/src/taskdog_core/application/dto/task_operation_output.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/task_operation_output.py
@@ -31,6 +31,7 @@ class TaskOperationOutput:
         is_archived: Whether task is archived (soft deleted)
         actual_duration_hours: Computed actual duration (for completed tasks)
         actual_daily_hours: Dictionary mapping dates to logged hours
+        daily_allocations: Dictionary mapping dates to allocated hours (from optimization)
     """
 
     id: int
@@ -49,6 +50,7 @@ class TaskOperationOutput:
     is_archived: bool
     actual_duration_hours: float | None
     actual_daily_hours: dict[str, float]
+    daily_allocations: dict[str, float]
 
     @classmethod
     def from_task(cls, task: Task) -> "TaskOperationOutput":
@@ -86,5 +88,9 @@ class TaskOperationOutput:
             actual_daily_hours={
                 date.isoformat(): hours
                 for date, hours in task.actual_daily_hours.items()
+            },
+            daily_allocations={
+                date.isoformat(): hours
+                for date, hours in task.daily_allocations.items()
             },
         )

--- a/packages/taskdog-core/tests/application/dto/test_task_operation_output.py
+++ b/packages/taskdog-core/tests/application/dto/test_task_operation_output.py
@@ -30,6 +30,7 @@ class TestTaskOperationOutput:
             is_archived=False,
             actual_duration_hours=5.5,
             actual_daily_hours={"2025-01-01": 5.5},
+            daily_allocations={"2025-01-01": 4.0},
         )
 
         assert dto.id == 1
@@ -62,6 +63,7 @@ class TestTaskOperationOutput:
             is_archived=False,
             actual_duration_hours=None,
             actual_daily_hours={},
+            daily_allocations={},
         )
 
         assert dto.id == 1
@@ -174,6 +176,7 @@ class TestTaskOperationOutput:
             is_archived=False,
             actual_duration_hours=None,
             actual_daily_hours={},
+            daily_allocations={},
         )
         dto2 = TaskOperationOutput(
             id=1,
@@ -192,6 +195,7 @@ class TestTaskOperationOutput:
             is_archived=False,
             actual_duration_hours=None,
             actual_daily_hours={},
+            daily_allocations={},
         )
 
         assert dto1 == dto2
@@ -215,6 +219,7 @@ class TestTaskOperationOutput:
             is_archived=False,
             actual_duration_hours=None,
             actual_daily_hours={},
+            daily_allocations={},
         )
         repr_str = repr(dto)
 

--- a/packages/taskdog-mcp/tests/test_tools.py
+++ b/packages/taskdog-mcp/tests/test_tools.py
@@ -68,6 +68,7 @@ def create_mock_task_operation_output(
         is_archived=False,
         actual_duration_hours=None,
         actual_daily_hours={},
+        daily_allocations={},
     )
 
 

--- a/packages/taskdog-server/src/taskdog_server/api/routers/tasks.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/tasks.py
@@ -335,7 +335,7 @@ async def update_task(
     new_values = {}
     if old_task:
         for field in result.updated_fields:
-            if hasattr(old_task, field):
+            if hasattr(old_task, field) and hasattr(result.task, field):
                 old_val = getattr(old_task, field)
                 new_val = getattr(result.task, field)
                 # Handle enum values

--- a/packages/taskdog-server/tests/api/models/test_responses.py
+++ b/packages/taskdog-server/tests/api/models/test_responses.py
@@ -109,6 +109,7 @@ class TestTaskOperationResponse:
             is_archived=False,
             actual_duration_hours=2.5,
             actual_daily_hours={"2024-01-15": 2.5},
+            daily_allocations={},
         )
 
         # Act
@@ -165,6 +166,7 @@ class TestUpdateTaskResponse:
             is_archived=False,
             actual_duration_hours=None,
             actual_daily_hours={},
+            daily_allocations={},
         )
         dto = TaskUpdateOutput(task=task, updated_fields=["name", "priority", "tags"])
 

--- a/packages/taskdog-server/tests/api/test_converters.py
+++ b/packages/taskdog-server/tests/api/test_converters.py
@@ -49,6 +49,7 @@ class TestConvertToUpdateTaskResponse:
             is_archived=False,
             actual_duration_hours=9.5,
             actual_daily_hours={},
+            daily_allocations={},
         )
         dto = TaskUpdateOutput(task=task, updated_fields=["name", "priority", "status"])
 
@@ -82,6 +83,7 @@ class TestConvertToUpdateTaskResponse:
             is_archived=False,
             actual_duration_hours=None,
             actual_daily_hours={},
+            daily_allocations={},
         )
         dto = TaskUpdateOutput(task=task, updated_fields=[])
 

--- a/packages/taskdog-server/tests/websocket/test_event_broadcaster.py
+++ b/packages/taskdog-server/tests/websocket/test_event_broadcaster.py
@@ -48,6 +48,7 @@ class TestWebSocketEventBroadcaster:
             is_archived=False,
             actual_duration_hours=None,
             actual_daily_hours={},
+            daily_allocations={},
         )
 
     def test_task_created_schedules_broadcast(self):


### PR DESCRIPTION
## Summary
- Add missing `daily_allocations` field to `TaskOperationOutput` DTO
- Add defensive `hasattr` check in API router for future-proofing
- Update taskdog-client converter to include `daily_allocations`

## Root Cause
`UpdateTaskUseCase` adds `daily_allocations` to `updated_fields` when clearing schedule (when `planned_start` or `planned_end` is updated), but `TaskOperationOutput` didn't have this field, causing `AttributeError` in the API router's audit logging.

## Test plan
- [x] `make test-core` - 1117 passed
- [x] `make test-server` - 287 passed
- [x] `make test-ui` - 948 passed
- [x] taskdog-client tests - 201 passed
- [x] taskdog-mcp tests - 20 passed

Fixes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)