### PR TITLE
feat(mcp): add planned_start and planned_end parameters to task tools

### DIFF
--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_crud.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_crud.py
@@ -123,11 +123,19 @@ def register_tools(mcp: FastMCP, clients: TaskdogMcpClients) -> None:
         Returns:
             Created task data with ID
         """
-        deadline_dt = datetime.fromisoformat(deadline) if deadline else None
-        planned_start_dt = (
-            datetime.fromisoformat(planned_start) if planned_start else None
-        )
-        planned_end_dt = datetime.fromisoformat(planned_end) if planned_end else None
+        try:
+            deadline_dt = datetime.fromisoformat(deadline) if deadline else None
+            planned_start_dt = (
+                datetime.fromisoformat(planned_start) if planned_start else None
+            )
+            planned_end_dt = (
+                datetime.fromisoformat(planned_end) if planned_end else None
+            )
+        except ValueError as e:
+            raise ValueError(
+                f"Invalid datetime format. Use ISO format "
+                f"(e.g., '2025-12-11T09:00:00'): {e}"
+            ) from e
 
         result = clients.tasks.create_task(
             name=name,
@@ -175,11 +183,19 @@ def register_tools(mcp: FastMCP, clients: TaskdogMcpClients) -> None:
         Returns:
             Updated task data
         """
-        deadline_dt = datetime.fromisoformat(deadline) if deadline else None
-        planned_start_dt = (
-            datetime.fromisoformat(planned_start) if planned_start else None
-        )
-        planned_end_dt = datetime.fromisoformat(planned_end) if planned_end else None
+        try:
+            deadline_dt = datetime.fromisoformat(deadline) if deadline else None
+            planned_start_dt = (
+                datetime.fromisoformat(planned_start) if planned_start else None
+            )
+            planned_end_dt = (
+                datetime.fromisoformat(planned_end) if planned_end else None
+            )
+        except ValueError as e:
+            raise ValueError(
+                f"Invalid datetime format. Use ISO format "
+                f"(e.g., '2025-12-11T09:00:00'): {e}"
+            ) from e
 
         result = clients.tasks.update_task(
             task_id=task_id,

--- a/packages/taskdog-mcp/tests/test_tools.py
+++ b/packages/taskdog-mcp/tests/test_tools.py
@@ -230,6 +230,54 @@ class TestTaskCrudTools:
             assert call_kwargs[key] == expected_value
         assert result["id"] == 1
 
+    @pytest.mark.parametrize(
+        "invalid_datetime",
+        [
+            pytest.param("invalid-date", id="invalid_format"),
+            pytest.param("2025-13-01T00:00:00", id="invalid_month"),
+            pytest.param("not-a-date", id="not_a_date"),
+        ],
+    )
+    def test_create_task_invalid_datetime_raises_error(
+        self, invalid_datetime: str
+    ) -> None:
+        """Test create_task raises ValueError for invalid datetime strings."""
+        from mcp.server.fastmcp import FastMCP
+        from taskdog_mcp.tools import task_crud
+
+        clients = create_mock_clients()
+        mcp = FastMCP("test")
+        task_crud.register_tools(mcp, clients)
+
+        create_task_fn = mcp._tool_manager._tools["create_task"].fn
+
+        with pytest.raises(ValueError, match="Invalid datetime format"):
+            create_task_fn(name="Test Task", deadline=invalid_datetime)
+
+    @pytest.mark.parametrize(
+        "invalid_datetime",
+        [
+            pytest.param("invalid-date", id="invalid_format"),
+            pytest.param("2025-13-01T00:00:00", id="invalid_month"),
+            pytest.param("not-a-date", id="not_a_date"),
+        ],
+    )
+    def test_update_task_invalid_datetime_raises_error(
+        self, invalid_datetime: str
+    ) -> None:
+        """Test update_task raises ValueError for invalid datetime strings."""
+        from mcp.server.fastmcp import FastMCP
+        from taskdog_mcp.tools import task_crud
+
+        clients = create_mock_clients()
+        mcp = FastMCP("test")
+        task_crud.register_tools(mcp, clients)
+
+        update_task_fn = mcp._tool_manager._tools["update_task"].fn
+
+        with pytest.raises(ValueError, match="Invalid datetime format"):
+            update_task_fn(task_id=1, planned_start=invalid_datetime)
+
 
 class TestTaskLifecycleTools:
     """Test task lifecycle MCP tools."""


### PR DESCRIPTION
## Summary
- Add `planned_start` and `planned_end` parameters to `create_task` MCP tool
- Add `planned_start` and `planned_end` parameters to `update_task` MCP tool
- Improve docstrings with ISO format examples (e.g., `'2025-12-11T09:00:00'`)
- Add parametrized tests for datetime conversion

## Usage Example
```python
# Create task with planned times
create_task(
    name="Meeting",
    deadline="2025-12-11T18:00:00",
    planned_start="2025-12-11T14:00:00",
    planned_end="2025-12-11T15:30:00",
    estimated_duration=1.5  # 1 hour 30 minutes
)
```

## Test plan
- [x] Unit tests pass (`make test-mcp`)
- [x] Lint and typecheck pass (`make check`)
- [x] Manual testing with MCP tools confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)