### PR TITLE
fix(ui): remove dead code detected by vulture

### DIFF
--- a/packages/taskdog-ui/src/taskdog/cli/commands/add.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/add.py
@@ -68,7 +68,7 @@ from taskdog_core.domain.exceptions.task_exceptions import TaskValidationError
     help="Planned end time (formats: YYYY-MM-DD, MM-DD, YYYY-MM-DD HH:MM:SS)",
 )
 @click.pass_context
-@handle_task_errors("adding task", is_parent=True)
+@handle_task_errors("adding task")
 def add_command(
     ctx: click.Context,
     name: str,

--- a/packages/taskdog-ui/src/taskdog/cli/error_handler.py
+++ b/packages/taskdog-ui/src/taskdog/cli/error_handler.py
@@ -12,17 +12,16 @@ from taskdog_core.domain.exceptions.task_exceptions import TaskNotFoundException
 F = TypeVar("F", bound=Callable[..., Any])
 
 
-def handle_task_errors(action_name: str, is_parent: bool = False) -> Callable[[F], F]:
+def handle_task_errors(action_name: str) -> Callable[[F], F]:
     """Decorator for task-specific error handling in CLI commands.
 
     Use this for commands that operate on specific task IDs (add, update, remove).
 
     Args:
         action_name: Action description for error messages (e.g., "adding task", "starting task")
-        is_parent: Whether this is a parent task error (default: False)
 
     Usage:
-        @handle_task_errors("adding task", is_parent=True)
+        @handle_task_errors("adding task")
         def add_command(ctx, ...):
             # Command logic
 

--- a/packages/taskdog-ui/src/taskdog/renderers/rich_statistics_renderer.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/rich_statistics_renderer.py
@@ -352,6 +352,7 @@ class RichStatisticsRenderer:
         """
         table = Table(
             title=title,
+            title_style=color,
             show_header=True,
             header_style=TABLE_HEADER_STYLE,
             border_style=TABLE_BORDER_STYLE,


### PR DESCRIPTION
## Summary
- Remove unused `is_parent` parameter from `handle_task_errors` decorator in error_handler.py
- Fix unused `color` parameter in `_render_task_examples` by applying it to `title_style` in rich_statistics_renderer.py

## Test plan
- [x] `make typecheck` passes
- [x] `make test-ui` passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)