### PR TITLE
perf(core): batch holiday checking for Gantt data

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date
 from typing import TYPE_CHECKING, Any
 
 from taskdog_core.application.dto.gantt_output import GanttDateRange, GanttOutput
@@ -454,14 +454,10 @@ class TaskQueryService(QueryService):
             tasks, range_start, range_end
         )
 
-        # Pre-compute holidays in the date range
+        # Pre-compute holidays in the date range (batch operation)
         holidays: set[date] = set()
         if holiday_checker:
-            current = range_start
-            while current <= range_end:
-                if holiday_checker.is_holiday(current):
-                    holidays.add(current)
-                current += timedelta(days=1)
+            holidays = holiday_checker.get_holidays_in_range(range_start, range_end)
 
         # Convert tasks to DTOs
         task_dtos = [GanttTaskDto.from_entity(task) for task in tasks]

--- a/packages/taskdog-core/src/taskdog_core/domain/services/holiday_checker.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/services/holiday_checker.py
@@ -26,3 +26,16 @@ class IHolidayChecker(ABC):
             True if the date is a public holiday, False otherwise
         """
         ...
+
+    @abstractmethod
+    def get_holidays_in_range(self, start_date: date, end_date: date) -> set[date]:
+        """Get all holidays within a date range (inclusive).
+
+        Args:
+            start_date: Start date of the range
+            end_date: End date of the range
+
+        Returns:
+            Set of dates that are public holidays within the range
+        """
+        ...

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/holiday_checker.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/holiday_checker.py
@@ -78,6 +78,37 @@ class HolidayChecker(IHolidayChecker):
 
         return check_date in self._holidays
 
+    def get_holidays_in_range(self, start_date: date, end_date: date) -> set[date]:
+        """Get all holidays within a date range (inclusive).
+
+        Uses year-based batch querying for efficiency instead of checking
+        each date individually.
+
+        Args:
+            start_date: Start date of the range
+            end_date: End date of the range
+
+        Returns:
+            Set of dates that are public holidays within the range
+        """
+        if self._holidays is None:
+            return set()
+
+        if start_date > end_date:
+            return set()
+
+        # Trigger lazy generation for all years in range
+        for year in range(start_date.year, end_date.year + 1):
+            # Accessing a date triggers holiday generation for that year
+            _ = date(year, 1, 1) in self._holidays
+
+        # Now iterate over all generated holidays and filter by date range
+        return {
+            holiday_date
+            for holiday_date in self._holidays
+            if start_date <= holiday_date <= end_date
+        }
+
     def get_holiday_name(self, check_date: date) -> str | None:
         """Get the name of the holiday on a given date.
 

--- a/packages/taskdog-core/tests/infrastructure/test_holiday_checker.py
+++ b/packages/taskdog-core/tests/infrastructure/test_holiday_checker.py
@@ -52,6 +52,52 @@ class TestHolidayCheckerJapan:
         name = self.checker.get_holiday_name(date(2025, 1, 7))
         assert name is None
 
+    def test_get_holidays_in_range_single_month(self):
+        """Test get_holidays_in_range for a single month."""
+        # January 2025 in Japan has: Jan 1 (New Year), Jan 13 (Coming of Age Day)
+        holidays = self.checker.get_holidays_in_range(
+            date(2025, 1, 1), date(2025, 1, 31)
+        )
+
+        assert date(2025, 1, 1) in holidays  # New Year's Day
+        assert date(2025, 1, 13) in holidays  # Coming of Age Day
+        assert date(2025, 1, 7) not in holidays  # Regular day
+
+    def test_get_holidays_in_range_across_years(self):
+        """Test get_holidays_in_range spanning multiple years."""
+        holidays = self.checker.get_holidays_in_range(
+            date(2024, 2, 1), date(2025, 1, 31)
+        )
+
+        # Should include holidays from both years
+        assert date(2024, 2, 23) in holidays  # Emperor's Birthday (2024)
+        assert date(2025, 1, 1) in holidays  # New Year's Day (2025)
+
+    def test_get_holidays_in_range_no_holidays(self):
+        """Test get_holidays_in_range when no holidays in range."""
+        # June typically has no holidays in Japan
+        holidays = self.checker.get_holidays_in_range(
+            date(2025, 6, 2), date(2025, 6, 7)
+        )
+
+        assert len(holidays) == 0
+
+    def test_get_holidays_in_range_single_day(self):
+        """Test get_holidays_in_range with single day range."""
+        holidays = self.checker.get_holidays_in_range(
+            date(2025, 1, 1), date(2025, 1, 1)
+        )
+
+        assert holidays == {date(2025, 1, 1)}
+
+    def test_get_holidays_in_range_invalid_range(self):
+        """Test get_holidays_in_range returns empty set when start > end."""
+        holidays = self.checker.get_holidays_in_range(
+            date(2025, 12, 31), date(2025, 1, 1)
+        )
+
+        assert holidays == set()
+
 
 class TestHolidayCheckerNoCountry:
     """Test cases for HolidayChecker without country specification."""
@@ -72,6 +118,13 @@ class TestHolidayCheckerNoCountry:
         """Test that get_holiday_name returns None without country."""
         name = self.checker.get_holiday_name(date(2025, 1, 1))
         assert name is None
+
+    def test_get_holidays_in_range_no_country(self):
+        """Test that get_holidays_in_range returns empty set without country."""
+        holidays = self.checker.get_holidays_in_range(
+            date(2025, 1, 1), date(2025, 12, 31)
+        )
+        assert holidays == set()
 
 
 class TestHolidayCheckerInvalidCountry:


### PR DESCRIPTION
## Summary
- Add `get_holidays_in_range(start, end)` method to `IHolidayChecker` interface
- Implement batch method in `HolidayChecker` using year-based lookup
- Update `TaskQueryService.get_gantt_data()` to use the new batch method
- Add tests for the new batch method

## Performance
For a 90-day date range, this reduces from **90 `is_holiday()` calls** to a **single batch operation**.

**Before:**
```python
holidays: set[date] = set()
if holiday_checker:
    current = range_start
    while current <= range_end:
        if holiday_checker.is_holiday(current):  # Called N times
            holidays.add(current)
        current += timedelta(days=1)
```

**After:**
```python
holidays: set[date] = set()
if holiday_checker:
    holidays = holiday_checker.get_holidays_in_range(range_start, range_end)  # Single call
```

## Test plan
- [x] All existing tests pass (`make test-core`)
- [x] New tests added for `get_holidays_in_range()`:
  - Single month range
  - Cross-year range
  - No holidays in range
  - Single day range
  - No country configured (returns empty set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)