### PR TITLE
refactor(client): add _request_json helper to reduce boilerplate

### DIFF
--- a/packages/taskdog-client/src/taskdog_client/analytics_client.py
+++ b/packages/taskdog-client/src/taskdog_client/analytics_client.py
@@ -40,13 +40,7 @@ class AnalyticsClient:
         Raises:
             TaskValidationError: If period is invalid
         """
-        response = self._base._safe_request(
-            "get", f"/api/v1/statistics?period={period}"
-        )
-        if not response.is_success:
-            self._base._handle_error(response)
-
-        data = response.json()
+        data = self._base._request_json("get", f"/api/v1/statistics?period={period}")
         return convert_to_statistics_output(data)
 
     def optimize_schedule(
@@ -85,11 +79,7 @@ class AnalyticsClient:
         if task_ids is not None:
             payload["task_ids"] = task_ids
 
-        response = self._base._safe_request("post", "/api/v1/optimize", json=payload)
-        if not response.is_success:
-            self._base._handle_error(response)
-
-        data = response.json()
+        data = self._base._request_json("post", "/api/v1/optimize", json=payload)
         return convert_to_optimization_output(data)
 
     def get_algorithm_metadata(self) -> list[tuple[str, str, str]]:
@@ -98,11 +88,7 @@ class AnalyticsClient:
         Returns:
             List of (name, display_name, description) tuples
         """
-        response = self._base._safe_request("get", "/api/v1/algorithms")
-        if not response.is_success:
-            self._base._handle_error(response)
-
-        data = response.json()
+        data = self._base._request_json("get", "/api/v1/algorithms")
         return [
             (algo["name"], algo["display_name"], algo["description"]) for algo in data
         ]

--- a/packages/taskdog-client/src/taskdog_client/audit_client.py
+++ b/packages/taskdog-client/src/taskdog_client/audit_client.py
@@ -71,11 +71,7 @@ class AuditClient:
         if end_date is not None:
             params["end_date"] = end_date.isoformat()
 
-        response = self._base._safe_request("get", "/api/v1/audit-logs", params=params)
-        if not response.is_success:
-            self._base._handle_error(response)
-
-        data = response.json()
+        data = self._base._request_json("get", "/api/v1/audit-logs", params=params)
         return self._convert_to_list_output(data)
 
     def get_audit_log(self, log_id: int) -> AuditLogOutput | None:

--- a/packages/taskdog-client/src/taskdog_client/base_client.py
+++ b/packages/taskdog-client/src/taskdog_client/base_client.py
@@ -116,6 +116,31 @@ class BaseApiClient:
         else:
             response.raise_for_status()
 
+    def _request_json(self, method: str, *args: Any, **kwargs: Any) -> Any:
+        """Execute HTTP request and return JSON response, handling errors.
+
+        Combines _safe_request + error check + JSON parsing into one call.
+
+        Args:
+            method: HTTP method name ('get', 'post', 'patch', 'delete', 'put')
+            *args: Positional arguments for the request
+            **kwargs: Keyword arguments for the request
+
+        Returns:
+            Parsed JSON response (dict, list, or primitive)
+
+        Raises:
+            ServerConnectionError: If connection to server fails
+            TaskNotFoundException: If status is 404
+            TaskValidationError: If status is 400 or 422
+            AuthenticationError: If status is 401
+            ServerError: If status >= 500
+        """
+        response = self._safe_request(method, *args, **kwargs)
+        if not response.is_success:
+            self._handle_error(response)
+        return response.json()
+
     def _safe_request(self, method: str, *args: Any, **kwargs: Any) -> httpx.Response:
         """Execute HTTP request with connection error handling.
 

--- a/packages/taskdog-client/src/taskdog_client/lifecycle_client.py
+++ b/packages/taskdog-client/src/taskdog_client/lifecycle_client.py
@@ -40,13 +40,7 @@ class LifecycleClient:
             TaskNotFoundException: If task not found
             TaskValidationError: If validation fails
         """
-        response = self._base._safe_request(
-            "post", f"/api/v1/tasks/{task_id}/{operation}"
-        )
-        if not response.is_success:
-            self._base._handle_error(response)
-
-        data = response.json()
+        data = self._base._request_json("post", f"/api/v1/tasks/{task_id}/{operation}")
         return convert_to_task_operation_output(data)
 
     def start_task(self, task_id: int) -> TaskOperationOutput:
@@ -167,12 +161,9 @@ class LifecycleClient:
         if actual_duration is not None:
             payload["actual_duration"] = actual_duration
 
-        response = self._base._safe_request(
+        data = self._base._request_json(
             "post",
             f"/api/v1/tasks/{task_id}/fix-actual",
             json=payload,
         )
-        if not response.is_success:
-            self._base._handle_error(response)
-
-        return convert_to_task_operation_output(response.json())
+        return convert_to_task_operation_output(data)

--- a/packages/taskdog-client/src/taskdog_client/query_client.py
+++ b/packages/taskdog-client/src/taskdog_client/query_client.py
@@ -91,11 +91,7 @@ class QueryClient:
             if gantt_end_date:
                 params["gantt_end_date"] = gantt_end_date.isoformat()
 
-        response = self._base._safe_request("get", "/api/v1/tasks", params=params)
-        if not response.is_success:
-            self._base._handle_error(response)
-
-        data = response.json()
+        data = self._base._request_json("get", "/api/v1/tasks", params=params)
         return convert_to_task_list_output(data, self._has_notes_cache)
 
     def list_today_tasks(
@@ -130,11 +126,7 @@ class QueryClient:
         if status:
             params["status"] = status.lower()
 
-        response = self._base._safe_request("get", "/api/v1/tasks/today", params=params)
-        if not response.is_success:
-            self._base._handle_error(response)
-
-        data = response.json()
+        data = self._base._request_json("get", "/api/v1/tasks/today", params=params)
         return convert_to_task_list_output(data, self._has_notes_cache)
 
     def list_week_tasks(
@@ -169,11 +161,7 @@ class QueryClient:
         if status:
             params["status"] = status.lower()
 
-        response = self._base._safe_request("get", "/api/v1/tasks/week", params=params)
-        if not response.is_success:
-            self._base._handle_error(response)
-
-        data = response.json()
+        data = self._base._request_json("get", "/api/v1/tasks/week", params=params)
         return convert_to_task_list_output(data, self._has_notes_cache)
 
     def get_task_by_id(self, task_id: int) -> TaskByIdOutput:
@@ -188,11 +176,7 @@ class QueryClient:
         Raises:
             TaskNotFoundException: If task not found
         """
-        response = self._base._safe_request("get", f"/api/v1/tasks/{task_id}")
-        if not response.is_success:
-            self._base._handle_error(response)
-
-        data = response.json()
+        data = self._base._request_json("get", f"/api/v1/tasks/{task_id}")
         return convert_to_get_task_by_id_output(data)
 
     def get_task_detail(self, task_id: int) -> TaskDetailOutput:
@@ -207,11 +191,7 @@ class QueryClient:
         Raises:
             TaskNotFoundException: If task not found
         """
-        response = self._base._safe_request("get", f"/api/v1/tasks/{task_id}")
-        if not response.is_success:
-            self._base._handle_error(response)
-
-        data = response.json()
+        data = self._base._request_json("get", f"/api/v1/tasks/{task_id}")
         return convert_to_get_task_detail_output(data)
 
     def get_gantt_data(
@@ -268,11 +248,7 @@ class QueryClient:
         if end_date:
             params["end_date"] = end_date.isoformat()
 
-        response = self._base._safe_request("get", "/api/v1/gantt", params=params)
-        if not response.is_success:
-            self._base._handle_error(response)
-
-        data = response.json()
+        data = self._base._request_json("get", "/api/v1/gantt", params=params)
         return convert_to_gantt_output(data)
 
     def get_tag_statistics(self) -> TagStatisticsOutput:
@@ -281,9 +257,5 @@ class QueryClient:
         Returns:
             TagStatisticsOutput with tag statistics
         """
-        response = self._base._safe_request("get", "/api/v1/tags/statistics")
-        if not response.is_success:
-            self._base._handle_error(response)
-
-        data = response.json()
+        data = self._base._request_json("get", "/api/v1/tags/statistics")
         return convert_to_tag_statistics_output(data)

--- a/packages/taskdog-client/src/taskdog_client/relationship_client.py
+++ b/packages/taskdog-client/src/taskdog_client/relationship_client.py
@@ -35,15 +35,11 @@ class RelationshipClient:
             TaskNotFoundException: If task not found
             TaskValidationError: If validation fails (e.g., circular dependency)
         """
-        response = self._base._safe_request(
+        data = self._base._request_json(
             "post",
             f"/api/v1/tasks/{task_id}/dependencies",
             json={"depends_on_id": depends_on_id},
         )
-        if not response.is_success:
-            self._base._handle_error(response)
-
-        data = response.json()
         return convert_to_task_operation_output(data)
 
     def remove_dependency(
@@ -62,13 +58,9 @@ class RelationshipClient:
             TaskNotFoundException: If task not found
             TaskValidationError: If validation fails
         """
-        response = self._base._safe_request(
+        data = self._base._request_json(
             "delete", f"/api/v1/tasks/{task_id}/dependencies/{depends_on_id}"
         )
-        if not response.is_success:
-            self._base._handle_error(response)
-
-        data = response.json()
         return convert_to_task_operation_output(data)
 
     def set_task_tags(self, task_id: int, tags: list[str]) -> TaskOperationOutput:
@@ -85,11 +77,7 @@ class RelationshipClient:
             TaskNotFoundException: If task not found
             TaskValidationError: If validation fails
         """
-        response = self._base._safe_request(
+        data = self._base._request_json(
             "put", f"/api/v1/tasks/{task_id}/tags", json={"tags": tags}
         )
-        if not response.is_success:
-            self._base._handle_error(response)
-
-        data = response.json()
         return convert_to_task_operation_output(data)

--- a/packages/taskdog-client/src/taskdog_client/task_client.py
+++ b/packages/taskdog-client/src/taskdog_client/task_client.py
@@ -171,13 +171,9 @@ class TaskClient:
             tags,
         )
 
-        response = self._base._safe_request(
+        data = self._base._request_json(
             "patch", f"/api/v1/tasks/{task_id}", json=payload
         )
-        if not response.is_success:
-            self._base._handle_error(response)
-
-        data = response.json()
         return convert_to_update_task_output(data)
 
     def _lifecycle_operation(self, task_id: int, operation: str) -> TaskOperationOutput:
@@ -197,13 +193,7 @@ class TaskClient:
             TaskNotFoundException: If task not found
             TaskValidationError: If validation fails
         """
-        response = self._base._safe_request(
-            "post", f"/api/v1/tasks/{task_id}/{operation}"
-        )
-        if not response.is_success:
-            self._base._handle_error(response)
-
-        data = response.json()
+        data = self._base._request_json("post", f"/api/v1/tasks/{task_id}/{operation}")
         return convert_to_task_operation_output(data)
 
     def archive_task(self, task_id: int) -> TaskOperationOutput:

--- a/packages/taskdog-client/tests/test_analytics_client.py
+++ b/packages/taskdog-client/tests/test_analytics_client.py
@@ -19,17 +19,14 @@ class TestAnalyticsClient:
     @patch("taskdog_client.analytics_client.convert_to_statistics_output")
     def test_calculate_statistics(self, mock_convert):
         """Test calculate_statistics makes correct API call."""
-        mock_response = Mock()
-        mock_response.is_success = True
-        mock_response.json.return_value = {"completion": {}}
-        self.mock_base._safe_request.return_value = mock_response
+        self.mock_base._request_json.return_value = {"completion": {}}
 
         mock_output = Mock()
         mock_convert.return_value = mock_output
 
         result = self.client.calculate_statistics(period="7d")
 
-        self.mock_base._safe_request.assert_called_once_with(
+        self.mock_base._request_json.assert_called_once_with(
             "get", "/api/v1/statistics?period=7d"
         )
         assert result == mock_output
@@ -37,10 +34,7 @@ class TestAnalyticsClient:
     @patch("taskdog_client.analytics_client.convert_to_optimization_output")
     def test_optimize_schedule(self, mock_convert):
         """Test optimize_schedule makes correct API call."""
-        mock_response = Mock()
-        mock_response.is_success = True
-        mock_response.json.return_value = {"summary": {}}
-        self.mock_base._safe_request.return_value = mock_response
+        self.mock_base._request_json.return_value = {"summary": {}}
 
         mock_output = Mock()
         mock_convert.return_value = mock_output
@@ -53,8 +47,8 @@ class TestAnalyticsClient:
             force_override=True,
         )
 
-        self.mock_base._safe_request.assert_called_once()
-        call_args = self.mock_base._safe_request.call_args
+        self.mock_base._request_json.assert_called_once()
+        call_args = self.mock_base._request_json.call_args
         assert call_args[0][0] == "post"
         assert call_args[0][1] == "/api/v1/optimize"
 
@@ -66,9 +60,7 @@ class TestAnalyticsClient:
 
     def test_get_algorithm_metadata(self):
         """Test get_algorithm_metadata makes correct API call."""
-        mock_response = Mock()
-        mock_response.is_success = True
-        mock_response.json.return_value = [
+        self.mock_base._request_json.return_value = [
             {
                 "name": "greedy",
                 "display_name": "Greedy",
@@ -80,11 +72,10 @@ class TestAnalyticsClient:
                 "description": "Balanced approach",
             },
         ]
-        self.mock_base._safe_request.return_value = mock_response
 
         result = self.client.get_algorithm_metadata()
 
-        self.mock_base._safe_request.assert_called_once_with(
+        self.mock_base._request_json.assert_called_once_with(
             "get", "/api/v1/algorithms"
         )
         assert len(result) == 2

--- a/packages/taskdog-client/tests/test_audit_client.py
+++ b/packages/taskdog-client/tests/test_audit_client.py
@@ -18,20 +18,17 @@ class TestAuditClientListAuditLogs:
 
     def test_list_audit_logs_with_default_params(self) -> None:
         """Test list_audit_logs with only default parameters."""
-        mock_response = Mock()
-        mock_response.is_success = True
-        mock_response.json.return_value = {
+        self.mock_base._request_json.return_value = {
             "logs": [],
             "total_count": 0,
             "limit": 100,
             "offset": 0,
         }
-        self.mock_base._safe_request.return_value = mock_response
 
         result = self.client.list_audit_logs()
 
-        self.mock_base._safe_request.assert_called_once()
-        call_args = self.mock_base._safe_request.call_args
+        self.mock_base._request_json.assert_called_once()
+        call_args = self.mock_base._request_json.call_args
         assert call_args[0][0] == "get"
         assert call_args[0][1] == "/api/v1/audit-logs"
         assert call_args[1]["params"]["limit"] == 100
@@ -40,15 +37,12 @@ class TestAuditClientListAuditLogs:
 
     def test_list_audit_logs_with_all_filters(self) -> None:
         """Test list_audit_logs with all filter parameters."""
-        mock_response = Mock()
-        mock_response.is_success = True
-        mock_response.json.return_value = {
+        self.mock_base._request_json.return_value = {
             "logs": [],
             "total_count": 0,
             "limit": 50,
             "offset": 10,
         }
-        self.mock_base._safe_request.return_value = mock_response
 
         start_date = datetime(2025, 1, 1, 0, 0, 0)
         end_date = datetime(2025, 12, 31, 23, 59, 59)
@@ -65,7 +59,7 @@ class TestAuditClientListAuditLogs:
             offset=10,
         )
 
-        call_args = self.mock_base._safe_request.call_args
+        call_args = self.mock_base._request_json.call_args
         params = call_args[1]["params"]
 
         assert params["client"] == "test-client"
@@ -80,39 +74,29 @@ class TestAuditClientListAuditLogs:
 
     def test_list_audit_logs_success_false_converted_to_lowercase(self) -> None:
         """Test that success=False is converted to 'false' string."""
-        mock_response = Mock()
-        mock_response.is_success = True
-        mock_response.json.return_value = {
+        self.mock_base._request_json.return_value = {
             "logs": [],
             "total_count": 0,
             "limit": 100,
             "offset": 0,
         }
-        self.mock_base._safe_request.return_value = mock_response
 
         self.client.list_audit_logs(success=False)
 
-        call_args = self.mock_base._safe_request.call_args
+        call_args = self.mock_base._request_json.call_args
         params = call_args[1]["params"]
         assert params["success"] == "false"
 
     def test_list_audit_logs_handles_error_response(self) -> None:
         """Test that error responses trigger error handler."""
-        mock_response = Mock()
-        mock_response.is_success = False
-        self.mock_base._safe_request.return_value = mock_response
-        self.mock_base._handle_error.side_effect = Exception("API Error")
+        self.mock_base._request_json.side_effect = Exception("API Error")
 
         with pytest.raises(Exception, match="API Error"):
             self.client.list_audit_logs()
 
-        self.mock_base._handle_error.assert_called_once_with(mock_response)
-
     def test_list_audit_logs_returns_logs(self) -> None:
         """Test that logs are correctly returned."""
-        mock_response = Mock()
-        mock_response.is_success = True
-        mock_response.json.return_value = {
+        self.mock_base._request_json.return_value = {
             "logs": [
                 {
                     "id": 1,
@@ -145,7 +129,6 @@ class TestAuditClientListAuditLogs:
             "limit": 100,
             "offset": 0,
         }
-        self.mock_base._safe_request.return_value = mock_response
 
         result = self.client.list_audit_logs()
 

--- a/packages/taskdog-client/tests/test_query_client.py
+++ b/packages/taskdog-client/tests/test_query_client.py
@@ -20,14 +20,12 @@ class TestQueryClient:
     @patch("taskdog_client.query_client.convert_to_task_list_output")
     def test_list_tasks(self, mock_convert):
         """Test list_tasks makes correct API call."""
-        mock_response = Mock()
-        mock_response.is_success = True
-        mock_response.json.return_value = {
+        mock_json = {
             "tasks": [],
             "total_count": 0,
             "filtered_count": 0,
         }
-        self.mock_base._safe_request.return_value = mock_response
+        self.mock_base._request_json.return_value = mock_json
 
         mock_output = Mock()
         mock_convert.return_value = mock_output
@@ -42,8 +40,8 @@ class TestQueryClient:
             reverse=True,
         )
 
-        self.mock_base._safe_request.assert_called_once()
-        call_args = self.mock_base._safe_request.call_args
+        self.mock_base._request_json.assert_called_once()
+        call_args = self.mock_base._request_json.call_args
         assert call_args[0][0] == "get"
         assert call_args[0][1] == "/api/v1/tasks"
 
@@ -57,7 +55,7 @@ class TestQueryClient:
         assert params["reverse"] == "true"
 
         assert result == mock_output
-        mock_convert.assert_called_once_with(mock_response.json(), self.notes_cache)
+        mock_convert.assert_called_once_with(mock_json, self.notes_cache)
 
     @pytest.mark.parametrize(
         "method_name,converter_name,mock_json",
@@ -74,10 +72,7 @@ class TestQueryClient:
     def test_get_single_task_operations(self, method_name, converter_name, mock_json):
         """Test single task GET operations make correct API calls."""
         with patch(f"taskdog_client.query_client.{converter_name}") as mock_convert:
-            mock_response = Mock()
-            mock_response.is_success = True
-            mock_response.json.return_value = mock_json
-            self.mock_base._safe_request.return_value = mock_response
+            self.mock_base._request_json.return_value = mock_json
 
             mock_output = Mock()
             mock_convert.return_value = mock_output
@@ -85,7 +80,7 @@ class TestQueryClient:
             method = getattr(self.client, method_name)
             result = method(task_id=1)
 
-            self.mock_base._safe_request.assert_called_once_with(
+            self.mock_base._request_json.assert_called_once_with(
                 "get", "/api/v1/tasks/1"
             )
             assert result == mock_output
@@ -93,10 +88,7 @@ class TestQueryClient:
     @patch("taskdog_client.query_client.convert_to_gantt_output")
     def test_get_gantt_data(self, mock_convert):
         """Test get_gantt_data makes correct API call."""
-        mock_response = Mock()
-        mock_response.is_success = True
-        mock_response.json.return_value = {"date_range": {}, "tasks": []}
-        self.mock_base._safe_request.return_value = mock_response
+        self.mock_base._request_json.return_value = {"date_range": {}, "tasks": []}
 
         mock_output = Mock()
         mock_convert.return_value = mock_output
@@ -110,8 +102,8 @@ class TestQueryClient:
             end_date=date(2025, 1, 31),
         )
 
-        self.mock_base._safe_request.assert_called_once()
-        call_args = self.mock_base._safe_request.call_args
+        self.mock_base._request_json.assert_called_once()
+        call_args = self.mock_base._request_json.call_args
         assert call_args[0][0] == "get"
         assert call_args[0][1] == "/api/v1/gantt"
 
@@ -128,17 +120,14 @@ class TestQueryClient:
     @patch("taskdog_client.query_client.convert_to_tag_statistics_output")
     def test_get_tag_statistics(self, mock_convert):
         """Test get_tag_statistics makes correct API call."""
-        mock_response = Mock()
-        mock_response.is_success = True
-        mock_response.json.return_value = {"tags": [], "total_tags": 0}
-        self.mock_base._safe_request.return_value = mock_response
+        self.mock_base._request_json.return_value = {"tags": [], "total_tags": 0}
 
         mock_output = Mock()
         mock_convert.return_value = mock_output
 
         result = self.client.get_tag_statistics()
 
-        self.mock_base._safe_request.assert_called_once_with(
+        self.mock_base._request_json.assert_called_once_with(
             "get", "/api/v1/tags/statistics"
         )
         assert result == mock_output

--- a/packages/taskdog-client/tests/test_relationship_client.py
+++ b/packages/taskdog-client/tests/test_relationship_client.py
@@ -46,10 +46,7 @@ class TestRelationshipClient:
         expected_json,
     ):
         """Test relationship operations with JSON payload make correct API calls."""
-        mock_response = Mock()
-        mock_response.is_success = True
-        mock_response.json.return_value = {"id": 1}
-        self.mock_base._safe_request.return_value = mock_response
+        self.mock_base._request_json.return_value = {"id": 1}
 
         mock_output = Mock()
         mock_convert.return_value = mock_output
@@ -57,8 +54,8 @@ class TestRelationshipClient:
         method = getattr(self.client, method_name)
         result = method(task_id=1, **method_kwargs)
 
-        self.mock_base._safe_request.assert_called_once()
-        call_args = self.mock_base._safe_request.call_args
+        self.mock_base._request_json.assert_called_once()
+        call_args = self.mock_base._request_json.call_args
         assert call_args[0][0] == expected_http_method
         assert call_args[0][1] == expected_endpoint
         assert call_args[1]["json"] == expected_json
@@ -67,17 +64,14 @@ class TestRelationshipClient:
     @patch("taskdog_client.relationship_client.convert_to_task_operation_output")
     def test_remove_dependency(self, mock_convert):
         """Test remove_dependency makes correct API call."""
-        mock_response = Mock()
-        mock_response.is_success = True
-        mock_response.json.return_value = {"id": 1}
-        self.mock_base._safe_request.return_value = mock_response
+        self.mock_base._request_json.return_value = {"id": 1}
 
         mock_output = Mock()
         mock_convert.return_value = mock_output
 
         result = self.client.remove_dependency(task_id=1, depends_on_id=2)
 
-        self.mock_base._safe_request.assert_called_once_with(
+        self.mock_base._request_json.assert_called_once_with(
             "delete", "/api/v1/tasks/1/dependencies/2"
         )
         assert result == mock_output

--- a/packages/taskdog-client/tests/test_task_client.py
+++ b/packages/taskdog-client/tests/test_task_client.py
@@ -109,10 +109,7 @@ class TestTaskClient:
     @patch("taskdog_client.task_client.convert_to_update_task_output")
     def test_update_task(self, mock_convert):
         """Test update_task makes correct API call."""
-        mock_response = Mock()
-        mock_response.is_success = True
-        mock_response.json.return_value = {"id": 1}
-        self.mock_base._safe_request.return_value = mock_response
+        self.mock_base._request_json.return_value = {"id": 1}
 
         mock_output = Mock()
         mock_convert.return_value = mock_output
@@ -122,8 +119,8 @@ class TestTaskClient:
         )
 
         # Verify API call
-        self.mock_base._safe_request.assert_called_once()
-        call_args = self.mock_base._safe_request.call_args
+        self.mock_base._request_json.assert_called_once()
+        call_args = self.mock_base._request_json.call_args
         assert call_args[0][0] == "patch"
         assert call_args[0][1] == "/api/v1/tasks/1"
 
@@ -148,10 +145,7 @@ class TestTaskClient:
         self, mock_convert, method_name, expected_endpoint
     ):
         """Test archive/restore operations make correct API calls."""
-        mock_response = Mock()
-        mock_response.is_success = True
-        mock_response.json.return_value = {"id": 1}
-        self.mock_base._safe_request.return_value = mock_response
+        self.mock_base._request_json.return_value = {"id": 1}
 
         mock_output = Mock()
         mock_convert.return_value = mock_output
@@ -159,7 +153,7 @@ class TestTaskClient:
         method = getattr(self.client, method_name)
         result = method(task_id=1)
 
-        self.mock_base._safe_request.assert_called_once_with("post", expected_endpoint)
+        self.mock_base._request_json.assert_called_once_with("post", expected_endpoint)
         assert result == mock_output
 
     def test_remove_task(self):


### PR DESCRIPTION
## Summary

- Add `_request_json()` helper method to `BaseApiClient` that combines request execution, error handling, and JSON parsing
- Replace repetitive 4-line pattern with 1-line helper calls across all client files
- Net reduction of ~103 lines (194 deleted, 91 added)

## Changes

| File | Pattern Replacements |
|------|---------------------|
| `base_client.py` | +24 lines (new helper) |
| `query_client.py` | 7 replacements |
| `task_client.py` | 2 replacements |
| `relationship_client.py` | 3 replacements |
| `lifecycle_client.py` | 2 replacements |
| `analytics_client.py` | 3 replacements |
| `audit_client.py` | 1 replacement |

## Special Cases Preserved

These methods were NOT converted because they have special handling:
- `create_task`: Uses `status_code != 201` check
- `remove_task`: Returns no JSON (204 response)
- `get_audit_log`: Has special 404 handling

## Test plan

- [x] `make test-client` - All 200 tests pass
- [x] `make check` - Lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)