### PR TITLE
refactor(core): remove unused functions and cleanup unused parameters

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_audit_log_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_audit_log_repository.py
@@ -51,7 +51,7 @@ class SqliteAuditLogRepository:
 
         # Configure SQLite pragmas for concurrency
         @event.listens_for(self.engine, "connect")  # type: ignore[no-untyped-call]
-        def set_sqlite_pragma(dbapi_connection: Any, connection_record: Any) -> None:
+        def set_sqlite_pragma(dbapi_connection: Any, _: Any) -> None:
             cursor = dbapi_connection.cursor()
             try:
                 cursor.execute("PRAGMA journal_mode=WAL")

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_task_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_task_repository.py
@@ -81,7 +81,7 @@ class SqliteTaskRepository(TaskRepository):
 
         # Configure SQLite pragmas for concurrency (Issue #226)
         @event.listens_for(self.engine, "connect")  # type: ignore[no-untyped-call]
-        def set_sqlite_pragma(dbapi_connection: Any, connection_record: Any) -> None:
+        def set_sqlite_pragma(dbapi_connection: Any, _: Any) -> None:
             cursor = dbapi_connection.cursor()
             try:
                 # WAL mode enables concurrent readers during writes

--- a/packages/taskdog-core/src/taskdog_core/shared/utils/date_utils.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/utils/date_utils.py
@@ -4,7 +4,6 @@ This module provides utilities for:
 - Parsing datetime strings (parse_date, parse_datetime)
 - Weekday/weekend detection (is_weekday, is_weekend)
 - Workday calculations (count_weekdays, get_previous_monday, calculate_next_workday, get_next_weekday)
-- Date range calculations (get_today_range, get_this_week_range)
 
 Note: Monday=0, Tuesday=1, ..., Friday=4, Saturday=5, Sunday=6
 """
@@ -204,41 +203,3 @@ def get_next_weekday(
 
     # Set time to specified hour for schedule start times
     return next_day.replace(hour=default_start_hour, minute=0, second=0, microsecond=0)
-
-
-def get_today_range(
-    time_provider: ITimeProvider | None = None,
-) -> tuple[date, date]:
-    """Get the date range for today (start and end are the same date).
-
-    This is useful for filtering tasks that are relevant for today.
-
-    Args:
-        time_provider: Provider for current time. Defaults to SystemTimeProvider.
-
-    Returns:
-        Tuple of (start_date, end_date) where both are today's date
-    """
-    provider = _get_time_provider(time_provider)
-    today = provider.today()
-    return today, today
-
-
-def get_this_week_range(
-    time_provider: ITimeProvider | None = None,
-) -> tuple[date, date]:
-    """Get the date range for this week (Monday through Sunday).
-
-    Args:
-        time_provider: Provider for current time. Defaults to SystemTimeProvider.
-
-    Returns:
-        Tuple of (start_date, end_date) where start is Monday and end is Sunday
-    """
-    provider = _get_time_provider(time_provider)
-    today = provider.today()
-    # Get the Monday of this week (weekday() returns 0 for Monday)
-    week_start = today - timedelta(days=today.weekday())
-    # Get the Sunday of this week
-    week_end = week_start + timedelta(days=6)
-    return week_start, week_end


### PR DESCRIPTION
## Summary

- Remove unused functions from `date_utils.py`
- Cleanup unused SQLAlchemy callback parameters (PEP 8 compliance)

## Changes

### Removed Functions (date_utils.py)
| Function | Lines | Reason |
|----------|-------|--------|
| `get_today_range()` | 16 | Never used anywhere in codebase |
| `get_this_week_range()` | 18 | Never used anywhere in codebase |

### Parameter Cleanup
| File | Change |
|------|--------|
| `sqlite_task_repository.py` | Rename `connection_record` → `_` |
| `sqlite_audit_log_repository.py` | Rename `connection_record` → `_` |

The `connection_record` parameter is required by SQLAlchemy's `event.listens_for` callback signature but is not used in the function bodies.

**Net reduction: 39 lines**

## Test plan

- [x] `make test-core` - All 1096 tests pass
- [x] `make check` - Lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)