### PR TITLE
refactor(core): remove unused parse_date_keyed_dict and get_previous_monday

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/shared/utils/date_utils.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/utils/date_utils.py
@@ -3,7 +3,7 @@
 This module provides utilities for:
 - Parsing datetime strings (parse_date, parse_datetime)
 - Weekday/weekend detection (is_weekday, is_weekend)
-- Workday calculations (count_weekdays, get_previous_monday, calculate_next_workday, get_next_weekday)
+- Workday calculations (count_weekdays, calculate_next_workday, get_next_weekday)
 
 Note: Monday=0, Tuesday=1, ..., Friday=4, Saturday=5, Sunday=6
 """
@@ -126,27 +126,6 @@ def count_weekdays(start: datetime | date, end: datetime | date) -> int:
             weekday_count += 1
         current_date += timedelta(days=1)
     return weekday_count
-
-
-def get_previous_monday(
-    from_date: date | None = None,
-    time_provider: ITimeProvider | None = None,
-) -> date:
-    """Get the previous Monday (or today if today is Monday).
-
-    Args:
-        from_date: Optional date to calculate from (defaults to today)
-        time_provider: Provider for current time. Defaults to SystemTimeProvider.
-
-    Returns:
-        date object representing the previous Monday
-    """
-    if from_date is None:
-        provider = _get_time_provider(time_provider)
-        from_date = provider.today()
-    # weekday(): Monday=0, Sunday=6
-    days_since_monday = from_date.weekday()
-    return from_date - timedelta(days=days_since_monday)
 
 
 def calculate_next_workday(

--- a/packages/taskdog-core/src/taskdog_core/shared/utils/datetime_parser.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/utils/datetime_parser.py
@@ -78,26 +78,6 @@ def format_iso_date(d: date | None) -> str | None:
     return d.isoformat()
 
 
-def parse_date_keyed_dict[T](str_dict: dict[str, T]) -> dict[date, T]:
-    """Parse dict with ISO date string keys to date object keys.
-
-    Args:
-        str_dict: Dictionary with ISO date string keys
-
-    Returns:
-        Dictionary with date object keys and original values
-
-    Raises:
-        ValueError: If any date key is malformed or empty
-    """
-    result: dict[date, T] = {}
-    for date_str, value in str_dict.items():
-        if not date_str:
-            raise ValueError("Empty date key")
-        result[datetime.fromisoformat(date_str).date()] = value
-    return result
-
-
 def parse_date_set(date_strings: Iterable[str]) -> set[date]:
     """Parse iterable of ISO date strings to set of date objects.
 

--- a/packages/taskdog-core/tests/shared/test_date_utils.py
+++ b/packages/taskdog-core/tests/shared/test_date_utils.py
@@ -6,7 +6,6 @@ import pytest
 
 from taskdog_core.shared.utils.date_utils import (
     calculate_next_workday,
-    get_previous_monday,
     is_weekday,
     is_weekend,
 )
@@ -30,42 +29,6 @@ class TestDateUtils:
         result = calculate_next_workday(input_date)
         assert result.weekday() == expected_weekday
         assert result.date() == expected_date.date()
-
-
-class TestGetPreviousMonday:
-    """Test cases for get_previous_monday function."""
-
-    @pytest.mark.parametrize(
-        "input_date,expected_monday",
-        [
-            (date(2025, 1, 6), date(2025, 1, 6)),
-            (date(2025, 1, 7), date(2025, 1, 6)),
-            (date(2025, 1, 8), date(2025, 1, 6)),
-            (date(2025, 1, 12), date(2025, 1, 6)),
-        ],
-        ids=["monday", "tuesday", "wednesday", "sunday"],
-    )
-    def test_get_previous_monday_for_weekday(self, input_date, expected_monday):
-        """Test that various days return the correct previous Monday."""
-        result = get_previous_monday(input_date)
-        assert result == expected_monday
-        assert result.weekday() == 0
-
-    def test_get_previous_monday_default_none(self):
-        """Test that None uses today's date."""
-        result = get_previous_monday(None)
-        # Should return a Monday
-        assert result.weekday() == 0
-        # Should be <= today
-        assert result <= date.today()
-
-    def test_get_previous_monday_no_argument(self):
-        """Test that no argument uses today's date."""
-        result = get_previous_monday()
-        # Should return a Monday
-        assert result.weekday() == 0
-        # Should be <= today
-        assert result <= date.today()
 
 
 class TestWeekdayHelpers:


### PR DESCRIPTION
## Summary
- Remove `parse_date_keyed_dict` from datetime_parser.py (completely unused)
- Remove `get_previous_monday` from date_utils.py (replaced by inline pattern)

## Details
`parse_date_keyed_dict` was never called anywhere in the codebase.

`get_previous_monday` was only used in tests, not in production code. The codebase uses the inline pattern directly:
```python
# In this_week_filter.py:55
week_start = today - timedelta(days=today.weekday())
```

## Test plan
- [x] All existing tests pass (`make test-core`: 1066 passed)
- [x] Code quality checks pass (`make check`)

## Impact
Net reduction: ~79 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)