### PR TITLE
refactor(server): remove unused Pydantic models and test-only functions

### DIFF
--- a/packages/taskdog-server/src/taskdog_server/api/dependencies.py
+++ b/packages/taskdog-server/src/taskdog_server/api/dependencies.py
@@ -4,7 +4,7 @@ import secrets
 from contextlib import suppress
 from typing import Annotated
 
-from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Request, WebSocket
+from fastapi import BackgroundTasks, Depends, HTTPException, Request, WebSocket
 from fastapi.security import APIKeyHeader
 
 from taskdog_core.controllers.audit_log_controller import AuditLogController
@@ -149,30 +149,6 @@ def get_api_context(request: Request) -> ApiContext:
     return context
 
 
-def set_api_context(app: FastAPI, context: ApiContext) -> None:
-    """Set the API context on app.state.
-
-    This is primarily used for testing to inject mock contexts.
-
-    Args:
-        app: FastAPI application instance
-        context: ApiContext instance to store in app.state
-    """
-    app.state.api_context = context
-
-
-def reset_app_state(app: FastAPI) -> None:
-    """Reset app.state for testing.
-
-    Args:
-        app: FastAPI application instance
-    """
-    if hasattr(app.state, "api_context"):
-        delattr(app.state, "api_context")
-    if hasattr(app.state, "connection_manager"):
-        delattr(app.state, "connection_manager")
-
-
 # Dependency type aliases for cleaner endpoint signatures
 ApiContextDep = Annotated[ApiContext, Depends(get_api_context)]
 
@@ -291,7 +267,6 @@ AnalyticsControllerDep = Annotated[
 CrudControllerDep = Annotated[TaskCrudController, Depends(get_crud_controller)]
 RepositoryDep = Annotated[TaskRepository, Depends(get_repository)]
 NotesRepositoryDep = Annotated[NotesRepository, Depends(get_notes_repository)]
-ConfigDep = Annotated[Config, Depends(get_config)]
 HolidayCheckerDep = Annotated[IHolidayChecker | None, Depends(get_holiday_checker)]
 TimeProviderDep = Annotated[ITimeProvider, Depends(get_time_provider)]
 AuditLogControllerDep = Annotated[AuditLogController, Depends(get_audit_log_controller)]

--- a/packages/taskdog-server/src/taskdog_server/api/models/requests.py
+++ b/packages/taskdog-server/src/taskdog_server/api/models/requests.py
@@ -1,6 +1,5 @@
 """Pydantic request models for FastAPI endpoints."""
 
-from datetime import date as date_type
 from datetime import datetime
 
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -161,29 +160,6 @@ class OptimizeScheduleRequest(BaseModel):
         None,
         description="Specific task IDs to optimize (None means all schedulable tasks)",
     )
-
-
-class TaskFilterParams(BaseModel):
-    """Query parameters for filtering tasks."""
-
-    all: bool = Field(False, description="Include archived tasks")
-    status: TaskStatus | None = Field(None, description="Filter by status")
-    tags: list[str] | None = Field(None, description="Filter by tags (OR logic)")
-    start_date: date_type | None = Field(
-        None, description="Filter by start date (tasks on or after)"
-    )
-    end_date: date_type | None = Field(
-        None, description="Filter by end date (tasks on or before)"
-    )
-
-
-class TaskSortParams(BaseModel):
-    """Query parameters for sorting tasks."""
-
-    sort: str = Field(
-        "id", description="Sort field (id, name, priority, deadline, etc.)"
-    )
-    reverse: bool = Field(False, description="Reverse sort order")
 
 
 class UpdateNotesRequest(BaseModel):

--- a/packages/taskdog-server/tests/api/models/test_requests.py
+++ b/packages/taskdog-server/tests/api/models/test_requests.py
@@ -1,6 +1,6 @@
 """Tests for Pydantic request models."""
 
-from datetime import date, datetime
+from datetime import datetime
 
 import pytest
 from pydantic import ValidationError
@@ -11,8 +11,6 @@ from taskdog_server.api.models.requests import (
     CreateTaskRequest,
     OptimizeScheduleRequest,
     SetTaskTagsRequest,
-    TaskFilterParams,
-    TaskSortParams,
     UpdateNotesRequest,
     UpdateTaskRequest,
 )
@@ -258,73 +256,6 @@ class TestOptimizeScheduleRequest:
         # Act & Assert
         with pytest.raises(ValidationError):
             OptimizeScheduleRequest()
-
-
-class TestTaskFilterParams:
-    """Test cases for TaskFilterParams model."""
-
-    def test_valid_default_params(self):
-        """Test creating filter params with defaults."""
-        # Act
-        params = TaskFilterParams()
-
-        # Assert
-        assert params.all is False
-        assert params.status is None
-        assert params.tags is None
-        assert params.start_date is None
-        assert params.end_date is None
-
-    def test_valid_full_params(self):
-        """Test creating filter params with all fields."""
-        # Arrange
-        today = date.today()
-
-        # Act
-        params = TaskFilterParams(
-            all=True,
-            status=TaskStatus.PENDING,
-            tags=["backend", "api"],
-            start_date=today,
-            end_date=today,
-        )
-
-        # Assert
-        assert params.all is True
-        assert params.status == TaskStatus.PENDING
-        assert params.tags == ["backend", "api"]
-        assert params.start_date == today
-        assert params.end_date == today
-
-    def test_valid_status_filter(self):
-        """Test filtering by status."""
-        # Act
-        params = TaskFilterParams(status=TaskStatus.COMPLETED)
-
-        # Assert
-        assert params.status == TaskStatus.COMPLETED
-
-
-class TestTaskSortParams:
-    """Test cases for TaskSortParams model."""
-
-    def test_valid_default_params(self):
-        """Test creating sort params with defaults."""
-        # Act
-        params = TaskSortParams()
-
-        # Assert
-        assert params.sort == "id"
-        assert params.reverse is False
-
-    def test_valid_custom_sort(self):
-        """Test creating sort params with custom field."""
-        # Act
-        params = TaskSortParams(sort="deadline", reverse=True)
-
-        # Assert
-        assert params.sort == "deadline"
-        assert params.reverse is True
 
 
 class TestUpdateNotesRequest:


### PR DESCRIPTION
## Summary
- Remove unused `TaskFilterParams` and `TaskSortParams` Pydantic models from requests.py
- Remove test-only functions `set_api_context` and `reset_app_state` from dependencies.py
- Remove unused `ConfigDep` type alias from dependencies.py
- Clean up unused imports

## Changes
- `requests.py`: Removed unused Pydantic models and `date` import
- `dependencies.py`: Removed test-only functions, unused type alias, and `FastAPI` import
- `test_requests.py`: Removed tests for deleted models and unused `date` import
- `test_dependencies.py`: Updated to use direct `app.state` assignment instead of removed helpers

~156 lines removed.

## Test plan
- [x] All server tests pass (270 passed)
- [x] Code coverage maintained (86.72%)
- [x] Lint checks pass
- [x] Type checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)