### PR TITLE
refactor(server,ui): remove unused methods

### DIFF
--- a/packages/taskdog-server/tests/conftest.py
+++ b/packages/taskdog-server/tests/conftest.py
@@ -386,22 +386,6 @@ class TaskFactory:
             **create_kwargs,
         )
 
-    def create_batch(self, count: int, **kwargs) -> list[Task]:
-        """Create multiple tasks with shared properties.
-
-        Args:
-            count: Number of tasks to create
-            **kwargs: Shared task attributes
-
-        Returns:
-            List of created tasks
-        """
-        return [self.create(**kwargs) for _ in range(count)]
-
-    def reset_counter(self):
-        """Reset the task counter to 1."""
-        self._task_counter = 1
-
 
 @pytest.fixture
 def task_factory(repository) -> TaskFactory:

--- a/packages/taskdog-ui/src/taskdog/services/task_data_loader.py
+++ b/packages/taskdog-ui/src/taskdog/services/task_data_loader.py
@@ -124,35 +124,6 @@ class TaskDataLoader:
             filtered_gantt_view_model=filtered_gantt_view_model,
         )
 
-    def load_gantt_data(
-        self,
-        all: bool = False,
-        sort_by: str = "deadline",
-        reverse: bool = False,
-        start_date: date | None = None,
-        end_date: date | None = None,
-    ) -> GanttViewModel:
-        """Load gantt data from API.
-
-        Args:
-            all: Include archived tasks (default: False)
-            sort_by: Sort field name
-            reverse: Sort direction (default: False for ascending)
-            start_date: Start date for gantt
-            end_date: End date for gantt
-
-        Returns:
-            GanttViewModel from presenter
-        """
-        gantt_output = self.api_client.get_gantt_data(
-            all=all,
-            sort_by=sort_by,
-            reverse=reverse,
-            start_date=start_date,
-            end_date=end_date,
-        )
-        return self.gantt_presenter.present(gantt_output)
-
     def apply_display_filter(
         self, tasks: list[TaskRowDto], hide_completed: bool
     ) -> list[TaskRowDto]:


### PR DESCRIPTION
## Summary

- Remove unused methods from server tests and ui package
- Net reduction: ~45 lines of code

### Removed

| Package | File | Method |
|---------|------|--------|
| server | `tests/conftest.py` | `TaskFactory.create_batch` |
| server | `tests/conftest.py` | `TaskFactory.reset_counter` |
| ui | `task_data_loader.py` | `load_gantt_data` |

## Test plan

- [x] `make check` passes (lint + typecheck)
- [x] `make test` passes (all packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)