### PR TITLE
refactor(build): use recursive Makefile for per-package targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ lint: $(addprefix lint-,$(PACKAGES)) ## Check code with ruff linter
 
 lint-%: ## Lint a specific package (e.g., make lint-taskdog-core)
 	@echo "Linting $*..."
-	$(MAKE) -C packages/$* lint CONFIG=$(CONFIG)
+	$(MAKE) -C packages/$* lint ROOT_DIR=$(ROOT_DIR)
 
 format: $(addprefix format-,$(PACKAGES)) ## Format code with ruff and apply fixes
 	@echo ""
@@ -210,7 +210,7 @@ format: $(addprefix format-,$(PACKAGES)) ## Format code with ruff and apply fixe
 
 format-%: ## Format a specific package (e.g., make format-taskdog-core)
 	@echo "Formatting $*..."
-	$(MAKE) -C packages/$* format CONFIG=$(CONFIG)
+	$(MAKE) -C packages/$* format ROOT_DIR=$(ROOT_DIR)
 
 typecheck: $(addprefix typecheck-,$(PACKAGES)) ## Run mypy type checker on all packages
 	@echo ""
@@ -219,7 +219,7 @@ typecheck: $(addprefix typecheck-,$(PACKAGES)) ## Run mypy type checker on all p
 
 typecheck-%: ## Type check a specific package (e.g., make typecheck-taskdog-core)
 	@echo "Type checking $*..."
-	$(MAKE) -C packages/$* typecheck CONFIG=$(CONFIG)
+	$(MAKE) -C packages/$* typecheck ROOT_DIR=$(ROOT_DIR)
 
 check: lint typecheck ## Run all code quality checks (lint + typecheck)
 	@echo ""

--- a/packages/taskdog-client/Makefile
+++ b/packages/taskdog-client/Makefile
@@ -2,7 +2,9 @@
 
 PACKAGE_NAME := taskdog_client
 COV_THRESHOLD := 80
-CONFIG ?= ../../pyproject.toml
+ROOT_DIR ?= ../..
+CONFIG ?= $(ROOT_DIR)/pyproject.toml
+PKG_PATH := packages/taskdog-client
 
 test:
 	PYTHONPATH=src uv run python -m pytest tests/ \
@@ -11,11 +13,11 @@ test:
 		--cov-fail-under=$(COV_THRESHOLD)
 
 lint:
-	uv run ruff check --config $(CONFIG) src/ tests/
+	cd $(ROOT_DIR) && uv run ruff check --config pyproject.toml $(PKG_PATH)/src/ $(PKG_PATH)/tests/
 
 format:
-	uv run ruff format --config $(CONFIG) src/ tests/
-	uv run ruff check --fix --config $(CONFIG) src/ tests/
+	cd $(ROOT_DIR) && uv run ruff format --config pyproject.toml $(PKG_PATH)/src/ $(PKG_PATH)/tests/
+	cd $(ROOT_DIR) && uv run ruff check --fix --config pyproject.toml $(PKG_PATH)/src/ $(PKG_PATH)/tests/
 
 typecheck:
-	uv run mypy --config-file $(CONFIG) src/
+	cd $(ROOT_DIR) && uv run mypy --config-file pyproject.toml $(PKG_PATH)/src/

--- a/packages/taskdog-core/Makefile
+++ b/packages/taskdog-core/Makefile
@@ -2,7 +2,9 @@
 
 PACKAGE_NAME := taskdog_core
 COV_THRESHOLD := 90
-CONFIG ?= ../../pyproject.toml
+ROOT_DIR ?= ../..
+CONFIG ?= $(ROOT_DIR)/pyproject.toml
+PKG_PATH := packages/taskdog-core
 
 test:
 	PYTHONPATH=src uv run python -m pytest tests/ \
@@ -11,11 +13,11 @@ test:
 		--cov-fail-under=$(COV_THRESHOLD)
 
 lint:
-	uv run ruff check --config $(CONFIG) src/ tests/
+	cd $(ROOT_DIR) && uv run ruff check --config pyproject.toml $(PKG_PATH)/src/ $(PKG_PATH)/tests/
 
 format:
-	uv run ruff format --config $(CONFIG) src/ tests/
-	uv run ruff check --fix --config $(CONFIG) src/ tests/
+	cd $(ROOT_DIR) && uv run ruff format --config pyproject.toml $(PKG_PATH)/src/ $(PKG_PATH)/tests/
+	cd $(ROOT_DIR) && uv run ruff check --fix --config pyproject.toml $(PKG_PATH)/src/ $(PKG_PATH)/tests/
 
 typecheck:
-	uv run mypy --config-file $(CONFIG) src/
+	cd $(ROOT_DIR) && uv run mypy --config-file pyproject.toml $(PKG_PATH)/src/

--- a/packages/taskdog-mcp/Makefile
+++ b/packages/taskdog-mcp/Makefile
@@ -2,7 +2,9 @@
 
 PACKAGE_NAME := taskdog_mcp
 COV_THRESHOLD := 50
-CONFIG ?= ../../pyproject.toml
+ROOT_DIR ?= ../..
+CONFIG ?= $(ROOT_DIR)/pyproject.toml
+PKG_PATH := packages/taskdog-mcp
 
 test:
 	PYTHONPATH=src uv run python -m pytest tests/ \
@@ -11,11 +13,11 @@ test:
 		--cov-fail-under=$(COV_THRESHOLD)
 
 lint:
-	uv run ruff check --config $(CONFIG) src/ tests/
+	cd $(ROOT_DIR) && uv run ruff check --config pyproject.toml $(PKG_PATH)/src/ $(PKG_PATH)/tests/
 
 format:
-	uv run ruff format --config $(CONFIG) src/ tests/
-	uv run ruff check --fix --config $(CONFIG) src/ tests/
+	cd $(ROOT_DIR) && uv run ruff format --config pyproject.toml $(PKG_PATH)/src/ $(PKG_PATH)/tests/
+	cd $(ROOT_DIR) && uv run ruff check --fix --config pyproject.toml $(PKG_PATH)/src/ $(PKG_PATH)/tests/
 
 typecheck:
-	uv run mypy --config-file $(CONFIG) src/
+	cd $(ROOT_DIR) && uv run mypy --config-file pyproject.toml $(PKG_PATH)/src/

--- a/packages/taskdog-server/Makefile
+++ b/packages/taskdog-server/Makefile
@@ -2,7 +2,9 @@
 
 PACKAGE_NAME := taskdog_server
 COV_THRESHOLD := 85
-CONFIG ?= ../../pyproject.toml
+ROOT_DIR ?= ../..
+CONFIG ?= $(ROOT_DIR)/pyproject.toml
+PKG_PATH := packages/taskdog-server
 
 test:
 	PYTHONPATH=src uv run python -m pytest tests/ \
@@ -11,11 +13,11 @@ test:
 		--cov-fail-under=$(COV_THRESHOLD)
 
 lint:
-	uv run ruff check --config $(CONFIG) src/ tests/
+	cd $(ROOT_DIR) && uv run ruff check --config pyproject.toml $(PKG_PATH)/src/ $(PKG_PATH)/tests/
 
 format:
-	uv run ruff format --config $(CONFIG) src/ tests/
-	uv run ruff check --fix --config $(CONFIG) src/ tests/
+	cd $(ROOT_DIR) && uv run ruff format --config pyproject.toml $(PKG_PATH)/src/ $(PKG_PATH)/tests/
+	cd $(ROOT_DIR) && uv run ruff check --fix --config pyproject.toml $(PKG_PATH)/src/ $(PKG_PATH)/tests/
 
 typecheck:
-	uv run mypy --config-file $(CONFIG) src/
+	cd $(ROOT_DIR) && uv run mypy --config-file pyproject.toml $(PKG_PATH)/src/

--- a/packages/taskdog-ui/Makefile
+++ b/packages/taskdog-ui/Makefile
@@ -2,7 +2,9 @@
 
 PACKAGE_NAME := taskdog
 COV_THRESHOLD := 70
-CONFIG ?= ../../pyproject.toml
+ROOT_DIR ?= ../..
+CONFIG ?= $(ROOT_DIR)/pyproject.toml
+PKG_PATH := packages/taskdog-ui
 
 test:
 	PYTHONPATH=src uv run python -m pytest tests/ \
@@ -11,11 +13,11 @@ test:
 		--cov-fail-under=$(COV_THRESHOLD)
 
 lint:
-	uv run ruff check --config $(CONFIG) src/ tests/
+	cd $(ROOT_DIR) && uv run ruff check --config pyproject.toml $(PKG_PATH)/src/ $(PKG_PATH)/tests/
 
 format:
-	uv run ruff format --config $(CONFIG) src/ tests/
-	uv run ruff check --fix --config $(CONFIG) src/ tests/
+	cd $(ROOT_DIR) && uv run ruff format --config pyproject.toml $(PKG_PATH)/src/ $(PKG_PATH)/tests/
+	cd $(ROOT_DIR) && uv run ruff check --fix --config pyproject.toml $(PKG_PATH)/src/ $(PKG_PATH)/tests/
 
 typecheck:
-	uv run mypy --config-file $(CONFIG) src/
+	cd $(ROOT_DIR) && uv run mypy --config-file pyproject.toml $(PKG_PATH)/src/


### PR DESCRIPTION
## Summary

- Add individual Makefiles to each package directory (`packages/*/Makefile`)
- Update root Makefile to use recursive calls with `$(MAKE) -C`
- Unify formatter/linter config via `CONFIG` variable passed from root

## Benefits

- **Independent execution**: `cd packages/taskdog-core && make test`
- **Parallel execution**: `make -j5 test`
- **Unified config**: All packages use the same `pyproject.toml` settings

## Migrated targets

- `test`, `lint`, `format`, `typecheck`

## Test plan

- [x] `make test-taskdog-core` works via recursive call
- [x] `cd packages/taskdog-core && make lint` works with default CONFIG
- [x] `make -j5 test` runs packages in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)