### PR TITLE
refactor(ui): improve audit log entry styling with theme-aware colors

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/styles/components.tcss
+++ b/packages/taskdog-ui/src/taskdog/tui/styles/components.tcss
@@ -183,3 +183,54 @@ Input {
     margin-bottom: 1;
     border: round $primary;
 }
+
+/* Audit Log Entry Components */
+.log-header {
+    width: 100%;
+    height: auto;
+}
+
+.log-timestamp {
+    color: $text-muted;
+    width: auto;
+    margin-right: 2;
+}
+
+.log-status-ok {
+    color: $success;
+    width: auto;
+}
+
+.log-status-error {
+    color: $error;
+    width: auto;
+}
+
+.log-operation {
+    width: 100%;
+    height: auto;
+}
+
+.log-resource {
+    width: 100%;
+    height: auto;
+    color: $text-muted;
+}
+
+.log-changes {
+    width: 100%;
+    height: auto;
+    color: $text-muted;
+}
+
+.log-error-message {
+    width: 100%;
+    height: auto;
+    color: $error;
+}
+
+.log-client {
+    width: 100%;
+    height: auto;
+    color: $secondary;
+}


### PR DESCRIPTION
## Summary

- Unify audit log entry border color to `$primary` for consistency with other widgets
- Add display of change details (`old_values` → `new_values`) and error messages
- Refactor to use CSS classes for theme-aware styling instead of Rich markup
- Theme variables now used:
  - OK status: `$success` (consistent with footer online indicator)
  - Error status: `$error`
  - Client name: `$secondary`
  - Metadata (timestamp, resource, changes): `$text-muted`

## Test plan

- [ ] Start TUI with `taskdog tui`
- [ ] Toggle audit panel visibility
- [ ] Perform task operations and verify audit log entries display correctly
- [ ] Verify OK status color matches footer online indicator
- [ ] Verify error messages display in red when operations fail
- [ ] Test with different themes to confirm theme-aware colors work

🤖 Generated with [Claude Code](https://claude.com/claude-code)