### PR TITLE
refactor(ui): make dialog sizes responsive to terminal size

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/styles/dialogs.tcss
+++ b/packages/taskdog-ui/src/taskdog/tui/styles/dialogs.tcss
@@ -33,11 +33,15 @@ StatsScreen {
 }
 
 .dialog-standard {
-    width: 80;  /* For form-based dialogs and lists */
+    width: 70%;
+    min-width: 60;
+    max-width: 100;
 }
 
 .dialog-wide {
-    width: 100;  /* For detailed information display */
+    width: 80%;
+    min-width: 80;
+    max-width: 120;
 }
 
 /* =============================================================================


### PR DESCRIPTION
## Summary
- TUIダイアログの固定幅をパーセンテージベースに変更
- ターミナルサイズに追従するレスポンシブなデザインに改善

### Changes
| Class | Before | After |
|-------|--------|-------|
| `.dialog-standard` | `width: 80` | `width: 70%; min-width: 60; max-width: 100` |
| `.dialog-wide` | `width: 100` | `width: 80%; min-width: 80; max-width: 120` |

## Test plan
- [x] `make test-ui` passes
- [x] TUIで各ダイアログを開き、ターミナルサイズを変更しても適切に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)