### PR TITLE
fix(ui): remove duplicate notification on note edit in detail screen

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/commands/show.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/show.py
@@ -67,6 +67,6 @@ class ShowCommand(TUICommandBase):
             task_name: Name of the task
             task_id: ID of the task
         """
-        self.notify_success(f"Note saved for task: {task_name} (ID: {task_id})")
+        # Notification is sent via WebSocket (task_updated event with "notes" field)
         # Re-display detail screen with updated notes
         self.execute()

--- a/packages/taskdog-ui/tests/tui/commands/test_show.py
+++ b/packages/taskdog-ui/tests/tui/commands/test_show.py
@@ -179,21 +179,19 @@ class TestShowCommandOnEditSuccess:
         self.mock_context = MagicMock()
         self.command = ShowCommand(self.mock_app, self.mock_context)
 
-    def test_shows_success_notification(self) -> None:
-        """Test that success notification is shown."""
+    def test_does_not_show_explicit_notification(self) -> None:
+        """Test that no explicit notification is shown (handled via WebSocket)."""
         self.command.notify_success = MagicMock()
         self.command.execute = MagicMock()
 
         self.command._on_edit_success("Test Task", 42)
 
-        self.command.notify_success.assert_called_once()
-        msg = self.command.notify_success.call_args[0][0]
-        assert "Test Task" in msg
-        assert "42" in msg
+        # Notification is handled via WebSocket (task_updated event),
+        # not via explicit notify_success call
+        self.command.notify_success.assert_not_called()
 
     def test_re_displays_detail_screen(self) -> None:
         """Test that execute is called to re-display screen."""
-        self.command.notify_success = MagicMock()
         self.command.execute = MagicMock()
 
         self.command._on_edit_success("Task", 1)


### PR DESCRIPTION
## Summary
- Remove explicit `notify_success()` call from `ShowCommand._on_edit_success()` since the notification is already handled via WebSocket (`task_updated` event with "notes" field)
- This was causing duplicate notifications when editing notes from the TUI detail screen (pressing "v" key)

## Test plan
- [x] Run `make test` - all tests pass
- [x] Run `make typecheck` - no type errors
- [ ] Manual test: Open TUI detail screen, press "v" to edit note, save → verify only one notification appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)