### PR TITLE
refactor(ui): remove unused api_client from GanttPresenter

### DIFF
--- a/packages/taskdog-ui/src/taskdog/presenters/gantt_presenter.py
+++ b/packages/taskdog-ui/src/taskdog/presenters/gantt_presenter.py
@@ -5,14 +5,9 @@ presentation logic (formatting, strikethrough) to create presentation-ready
 view models.
 """
 
-from typing import TYPE_CHECKING
-
 from taskdog.view_models.gantt_view_model import GanttViewModel, TaskGanttRowViewModel
 from taskdog_core.application.dto.gantt_output import GanttOutput
 from taskdog_core.application.dto.task_dto import GanttTaskDto
-
-if TYPE_CHECKING:
-    from taskdog_client import TaskdogApiClient
 
 
 class GanttPresenter:
@@ -23,14 +18,6 @@ class GanttPresenter:
     2. Applying presentation logic (strikethrough, formatting)
     3. Converting domain data to presentation-ready ViewModels
     """
-
-    def __init__(self, api_client: "TaskdogApiClient | None" = None):
-        """Initialize the GanttPresenter.
-
-        Args:
-            api_client: API client (kept for compatibility, currently unused)
-        """
-        self.api_client = api_client
 
     def present(self, gantt_result: GanttOutput) -> GanttViewModel:
         """Convert GanttOutput DTO to GanttViewModel.

--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -247,9 +247,9 @@ class TaskdogTUI(App):
             config=self._cli_config,
         )
 
-        # Initialize presenters for view models (will be updated to not use notes_repository)
+        # Initialize presenters for view models
         self.table_presenter = TablePresenter(api_client)
-        self.gantt_presenter = GanttPresenter(api_client)
+        self.gantt_presenter = GanttPresenter()
 
         # Initialize TaskDataLoader for data fetching
         self.task_data_loader = TaskDataLoader(


### PR DESCRIPTION
## Summary
- Remove unused `api_client` parameter from `GanttPresenter.__init__`
- Presenter's responsibility is to create ViewModels from DTOs, not to access API

## Test plan
- [x] `make test-ui` - 900 passed
- [x] `make typecheck` - Success

🤖 Generated with [Claude Code](https://claude.com/claude-code)