### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/packages/taskdog-client/pyproject.toml
+++ b/packages/taskdog-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "taskdog-client"
-version = "0.6.0"
+version = "0.7.0"
 description = "HTTP API client for Taskdog server"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/taskdog-core/pyproject.toml
+++ b/packages/taskdog-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "taskdog-core"
-version = "0.6.0"
+version = "0.7.0"
 description = "Core business logic and infrastructure for Taskdog"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/taskdog-mcp/pyproject.toml
+++ b/packages/taskdog-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "taskdog-mcp"
-version = "0.6.0"
+version = "0.7.0"
 description = "MCP server for Taskdog - enables Claude Desktop integration"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/taskdog-mcp/src/taskdog_mcp/__init__.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/__init__.py
@@ -4,4 +4,4 @@ This package provides a Model Context Protocol (MCP) server that enables
 Claude Desktop and other MCP-compatible AI clients to interact with Taskdog.
 """
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/packages/taskdog-server/pyproject.toml
+++ b/packages/taskdog-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "taskdog-server"
-version = "0.6.0"
+version = "0.7.0"
 description = "FastAPI server for Taskdog task management system"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/taskdog-server/src/taskdog_server/__init__.py
+++ b/packages/taskdog-server/src/taskdog_server/__init__.py
@@ -3,4 +3,4 @@
 FastAPI-based REST API server for task management.
 """
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/packages/taskdog-ui/pyproject.toml
+++ b/packages/taskdog-ui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "taskdog-ui"
-version = "0.6.0"
+version = "0.7.0"
 description = "CLI and TUI for Taskdog task management system"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/taskdog-ui/src/taskdog/__init__.py
+++ b/packages/taskdog-ui/src/taskdog/__init__.py
@@ -1,3 +1,3 @@
 """taskdog - CLI task management tool"""
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "taskdog-workspace"
-version = "0.6.0"
+version = "0.7.0"
 description = "Taskdog monorepo workspace"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1049,7 +1049,7 @@ wheels = [
 
 [[package]]
 name = "taskdog-client"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "packages/taskdog-client" }
 dependencies = [
     { name = "httpx" },
@@ -1081,7 +1081,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-core"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "packages/taskdog-core" }
 dependencies = [
     { name = "holidays" },
@@ -1113,7 +1113,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-mcp"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "packages/taskdog-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -1145,7 +1145,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-server"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "packages/taskdog-server" }
 dependencies = [
     { name = "fastapi" },
@@ -1181,7 +1181,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-ui"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "packages/taskdog-ui" }
 dependencies = [
     { name = "click" },
@@ -1223,7 +1223,7 @@ provides-extras = ["dev", "server"]
 
 [[package]]
 name = "taskdog-workspace"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Bump version from 0.6.0 to 0.7.0 across all packages

## Changes
- Updated `pyproject.toml` in all packages (workspace, core, server, ui, mcp, client)
- Updated `__version__` in `__init__.py` files (mcp, server, ui)
- Updated `uv.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)