### PR TITLE
chore: sync internal package dependencies to 0.7.0

### DIFF
--- a/packages/taskdog-client/pyproject.toml
+++ b/packages/taskdog-client/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 license = { text = "MIT" }
 
 dependencies = [
-    "taskdog-core==0.6.0",
+    "taskdog-core==0.7.0",
     "httpx>=0.27.0",
     "websockets>=14.0",
 ]

--- a/packages/taskdog-mcp/pyproject.toml
+++ b/packages/taskdog-mcp/pyproject.toml
@@ -10,8 +10,8 @@ authors = [
 license = { text = "MIT" }
 
 dependencies = [
-    "taskdog-client==0.6.0",
-    "taskdog-core==0.6.0",
+    "taskdog-client==0.7.0",
+    "taskdog-core==0.7.0",
     "mcp>=1.2.0",
 ]
 

--- a/packages/taskdog-server/pyproject.toml
+++ b/packages/taskdog-server/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 license = { text = "MIT" }
 
 dependencies = [
-    "taskdog-core==0.6.0",
+    "taskdog-core==0.7.0",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",
     "pydantic>=2.10.0",

--- a/packages/taskdog-ui/pyproject.toml
+++ b/packages/taskdog-ui/pyproject.toml
@@ -10,8 +10,8 @@ authors = [
 license = { text = "MIT" }
 
 dependencies = [
-    "taskdog-core==0.6.0",
-    "taskdog-client==0.6.0",
+    "taskdog-core==0.7.0",
+    "taskdog-client==0.7.0",
     "click>=8.3.0",
     "rich>=14.2.0",
     "textual>=0.88.0",
@@ -27,7 +27,7 @@ dev = [
     "ruff>=0.7.0",
 ]
 server = [
-    "taskdog-server==0.6.0",
+    "taskdog-server==0.7.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- Update internal package version references from 0.6.0 to 0.7.0
- Ensures all package dependencies are consistent with the recent version bump

## Changes
| Package | Updated Dependencies |
|---------|---------------------|
| taskdog-client | `taskdog-core==0.7.0` |
| taskdog-server | `taskdog-core==0.7.0` |
| taskdog-ui | `taskdog-core==0.7.0`, `taskdog-client==0.7.0`, `taskdog-server==0.7.0` |
| taskdog-mcp | `taskdog-client==0.7.0`, `taskdog-core==0.7.0` |

## Test plan
- [x] `make check` passes (lint + typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)