### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/packages/taskdog-client/pyproject.toml
+++ b/packages/taskdog-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "taskdog-client"
-version = "0.7.0"
+version = "0.7.1"
 description = "HTTP API client for Taskdog server"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -10,7 +10,7 @@ authors = [
 license = { text = "MIT" }
 
 dependencies = [
-    "taskdog-core==0.7.0",
+    "taskdog-core==0.7.1",
     "httpx>=0.27.0",
     "websockets>=14.0",
 ]

--- a/packages/taskdog-core/pyproject.toml
+++ b/packages/taskdog-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "taskdog-core"
-version = "0.7.0"
+version = "0.7.1"
 description = "Core business logic and infrastructure for Taskdog"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/taskdog-mcp/pyproject.toml
+++ b/packages/taskdog-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "taskdog-mcp"
-version = "0.7.0"
+version = "0.7.1"
 description = "MCP server for Taskdog - enables Claude Desktop integration"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -10,8 +10,8 @@ authors = [
 license = { text = "MIT" }
 
 dependencies = [
-    "taskdog-client==0.7.0",
-    "taskdog-core==0.7.0",
+    "taskdog-client==0.7.1",
+    "taskdog-core==0.7.1",
     "mcp>=1.2.0",
 ]
 

--- a/packages/taskdog-server/pyproject.toml
+++ b/packages/taskdog-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "taskdog-server"
-version = "0.7.0"
+version = "0.7.1"
 description = "FastAPI server for Taskdog task management system"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -10,7 +10,7 @@ authors = [
 license = { text = "MIT" }
 
 dependencies = [
-    "taskdog-core==0.7.0",
+    "taskdog-core==0.7.1",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",
     "pydantic>=2.10.0",

--- a/packages/taskdog-ui/pyproject.toml
+++ b/packages/taskdog-ui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "taskdog-ui"
-version = "0.7.0"
+version = "0.7.1"
 description = "CLI and TUI for Taskdog task management system"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -10,8 +10,8 @@ authors = [
 license = { text = "MIT" }
 
 dependencies = [
-    "taskdog-core==0.7.0",
-    "taskdog-client==0.7.0",
+    "taskdog-core==0.7.1",
+    "taskdog-client==0.7.1",
     "click>=8.3.0",
     "rich>=14.2.0",
     "textual>=0.88.0",
@@ -27,7 +27,7 @@ dev = [
     "ruff>=0.7.0",
 ]
 server = [
-    "taskdog-server==0.7.0",
+    "taskdog-server==0.7.1",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "taskdog-workspace"
-version = "0.7.0"
+version = "0.7.1"
 description = "Taskdog monorepo workspace"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1049,7 +1049,7 @@ wheels = [
 
 [[package]]
 name = "taskdog-client"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "packages/taskdog-client" }
 dependencies = [
     { name = "httpx" },
@@ -1081,7 +1081,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-core"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "packages/taskdog-core" }
 dependencies = [
     { name = "holidays" },
@@ -1113,7 +1113,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-mcp"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "packages/taskdog-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -1145,7 +1145,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-server"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "packages/taskdog-server" }
 dependencies = [
     { name = "fastapi" },
@@ -1181,7 +1181,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-ui"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "packages/taskdog-ui" }
 dependencies = [
     { name = "click" },
@@ -1223,7 +1223,7 @@ provides-extras = ["dev", "server"]
 
 [[package]]
 name = "taskdog-workspace"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Bump version from 0.7.0 to 0.7.1
- Updated using `scripts/bump_version.py` from #524

## Changes
- 13 version references updated across 6 pyproject.toml files

## Dependencies
- Requires #524 to be merged first (adds the bump_version.py script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)