### PR TITLE
fix(tui): improve dialog message alignment and add warning to fix actual dialog

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/fix_actual_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/fix_actual_dialog.py
@@ -82,6 +82,10 @@ class FixActualDialog(FormDialogBase[FixActualFormData | None]):
                 "Tab/Ctrl-j: next | Shift+Tab/Ctrl-k: previous[/dim]",
                 id="dialog-hint",
             )
+            yield Label(
+                "⚠ You are responsible for ensuring data consistency.",
+                id="fix-actual-warning",
+            )
 
             # Error message area
             yield Static("", id="error-message")

--- a/packages/taskdog-ui/src/taskdog/tui/styles/dialogs.tcss
+++ b/packages/taskdog-ui/src/taskdog/tui/styles/dialogs.tcss
@@ -57,6 +57,7 @@ StatsScreen {
 
 /* Message text in confirmation dialogs */
 #dialog-message {
+    width: 100%;
     text-align: center;
     padding: 1 2;
     margin: 1 0;
@@ -128,6 +129,14 @@ StatsScreen {
 #fix-actual-dialog {
     border: round $error;  /* Colored border for emphasis on timestamp correction */
     max-height: 30;  /* 3 fields */
+}
+
+/* Warning message in fix actual dialog */
+#fix-actual-warning {
+    width: 100%;
+    text-align: center;
+    padding: 0 2;
+    margin-bottom: 1;
 }
 
 /* Task Form Dialog (Add/Edit) */


### PR DESCRIPTION
## Summary
- Center-align confirmation dialog messages (archive, reopen, cancel) by adding `width: 100%` to `#dialog-message`
- Add warning message to Fix Actual Time dialog: "⚠ You are responsible for ensuring data consistency."

## Test plan
- [ ] Open TUI and select a task
- [ ] Press `x` (archive), `c` (cancel), or `R` (reopen) to verify messages are centered
- [ ] Open Fix Actual dialog via command palette (`Ctrl+P` → "Fix Actual") to verify warning message is displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)