### PR TITLE
fix(tui): use single-line border for focused elements

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/styles/components.tcss
+++ b/packages/taskdog-ui/src/taskdog/tui/styles/components.tcss
@@ -73,7 +73,7 @@
 }
 
 #footer-search-container:focus-within {
-    border: double $accent;
+    border: round $accent;
 }
 
 #footer-search-input {
@@ -118,7 +118,7 @@ Input {
 }
 
 #filterable-task-table:focus-within {
-    border: double $accent;
+    border: round $accent;
 }
 
 /* Root container for full-width layout */
@@ -149,7 +149,7 @@ Input {
 }
 
 #audit-panel:focus {
-    border: double $accent;
+    border: round $accent;
 }
 
 /* Audit Log Entry Cards */

--- a/packages/taskdog-ui/src/taskdog/tui/styles/main.tcss
+++ b/packages/taskdog-ui/src/taskdog/tui/styles/main.tcss
@@ -26,7 +26,7 @@ MainScreen {
 }
 
 #gantt-widget:focus {
-    border: double $accent;
+    border: round $accent;
 }
 
 /* Gantt title - fixed at top */
@@ -65,5 +65,5 @@ MainScreen {
 }
 
 #task-table:focus {
-    border: double $accent;
+    border: round $accent;
 }


### PR DESCRIPTION
## Summary
- Change TUI focus border style from double to round (single-line)
- Keep the same rounded shape as unfocused state, only using accent color to indicate focus

## Test plan
- [x] Launch TUI and focus on task table/Gantt chart, verify border is single-line
- [ ] Focus on search bar, verify border is single-line

🤖 Generated with [Claude Code](https://claude.com/claude-code)