### PR TITLE
refactor(core): remove deprecated actual_daily_hours column

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,7 +270,7 @@ Clean Architecture with 5 layers across three packages: **Domain** ← **Applica
 
 **Task Entity** (`packages/taskdog-core/src/taskdog_core/domain/entities/task.py`)
 
-- Fields: id, name, priority, status, planned_start/end, deadline, actual_start/end, estimated_duration, daily_allocations, is_fixed, depends_on, actual_daily_hours, tags, is_archived
+- Fields: id, name, priority, status, planned_start/end, deadline, actual_start/end, estimated_duration, daily_allocations, is_fixed, depends_on, tags, is_archived
 - Statuses: PENDING, IN_PROGRESS, COMPLETED, CANCELED
 - Always-Valid Entity: validates invariants in `__post_init__` (name non-empty, priority > 0, estimated_duration > 0 if set, tags non-empty and unique)
 - Properties: actual_duration_hours, is_active, is_finished, can_be_modified, is_schedulable

--- a/docs/API.md
+++ b/docs/API.md
@@ -198,7 +198,6 @@ List tasks with filtering
     "is_fixed": false,
     "depends_on": [],
     "daily_allocations": {},
-    "actual_daily_hours": {},
     "tags": ["backend", "api"],
     "is_archived": false
   }

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/migrations/versions/002_remove_actual_daily_hours.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/migrations/versions/002_remove_actual_daily_hours.py
@@ -1,0 +1,47 @@
+"""Remove deprecated actual_daily_hours column.
+
+Revision ID: 002_remove_actual_daily_hours
+Revises: 001_initial
+Create Date: 2025-12-27
+
+This migration removes the actual_daily_hours column which was deprecated
+and is no longer used by the application. The column was originally used
+for tracking daily work hours but this functionality has been removed.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "002_remove_actual_daily_hours"
+down_revision: str | None = "001_initial"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Remove the deprecated actual_daily_hours column from tasks table.
+
+    Uses batch mode for SQLite compatibility since SQLite doesn't support
+    DROP COLUMN directly. Checks if column exists first to handle databases
+    created with newer model that never had this column.
+    """
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    columns = {col["name"] for col in inspector.get_columns("tasks")}
+
+    if "actual_daily_hours" in columns:
+        with op.batch_alter_table("tasks") as batch_op:
+            batch_op.drop_column("actual_daily_hours")
+
+
+def downgrade() -> None:
+    """Restore actual_daily_hours column for rollback."""
+    with op.batch_alter_table("tasks") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "actual_daily_hours", sa.Text(), nullable=False, server_default="{}"
+            )
+        )

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/models/task_model.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/models/task_model.py
@@ -65,11 +65,6 @@ class TaskModel(Base):
     # Format: {"2025-01-15": 2.0, "2025-01-16": 3.0}
     daily_allocations: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
 
-    # DEPRECATED: Kept for database backwards compatibility only.
-    # This field is no longer used by the application but the column must exist
-    # in the database schema because it has NOT NULL constraint.
-    actual_daily_hours: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
-
     # Format: [2, 3, 5]
     depends_on: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
 

--- a/packages/taskdog-core/tests/infrastructure/persistence/database/test_migration_runner.py
+++ b/packages/taskdog-core/tests/infrastructure/persistence/database/test_migration_runner.py
@@ -84,7 +84,7 @@ class TestRunMigrations:
             # Should now have alembic_version stamped
             inspector = inspect(engine)
             assert "alembic_version" in inspector.get_table_names()
-            assert get_current_revision(engine) == "001_initial"
+            assert get_current_revision(engine) == "002_remove_actual_daily_hours"
         finally:
             engine.dispose()
 
@@ -98,7 +98,7 @@ class TestRunMigrations:
             run_migrations(engine)
 
             # Should still work and have correct revision
-            assert get_current_revision(engine) == "001_initial"
+            assert get_current_revision(engine) == "002_remove_actual_daily_hours"
         finally:
             engine.dispose()
 
@@ -127,7 +127,6 @@ class TestRunMigrations:
                 "estimated_duration",
                 "is_fixed",
                 "daily_allocations",
-                "actual_daily_hours",
                 "depends_on",
                 "is_archived",
             }
@@ -227,7 +226,7 @@ class TestGetCurrentRevision:
         try:
             run_migrations(engine)
 
-            assert get_current_revision(engine) == "001_initial"
+            assert get_current_revision(engine) == "002_remove_actual_daily_hours"
         finally:
             engine.dispose()
 


### PR DESCRIPTION
## Summary

- Remove the deprecated `actual_daily_hours` column from the tasks table using Alembic migration
- This column was marked as DEPRECATED and no longer used by the application
- Add migration `002_remove_actual_daily_hours` with SQLite batch mode support for column existence check

## Test plan

- [x] Run `make test-core` - 1036 tests passed
- [x] Verify migration works on fresh database
- [x] Verify migration works on existing database (stamps + applies)
- [x] Verify idempotent migration execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)