### PR TITLE
fix(stats): preserve duration fields in statistics task summaries

### DIFF
--- a/packages/taskdog-client/src/taskdog_client/converters/statistics_converters.py
+++ b/packages/taskdog-client/src/taskdog_client/converters/statistics_converters.py
@@ -44,7 +44,12 @@ def _parse_task_summary(data: dict[str, Any] | None) -> TaskSummaryDto | None:
     """
     if data is None:
         return None
-    return TaskSummaryDto(id=data["id"], name=data["name"])
+    return TaskSummaryDto(
+        id=data["id"],
+        name=data["name"],
+        estimated_duration=data.get("estimated_duration"),
+        actual_duration_hours=data.get("actual_duration_hours"),
+    )
 
 
 def _parse_task_summary_list(data: list[dict[str, Any]] | None) -> list[TaskSummaryDto]:
@@ -58,7 +63,15 @@ def _parse_task_summary_list(data: list[dict[str, Any]] | None) -> list[TaskSumm
     """
     if not data:
         return []
-    return [TaskSummaryDto(id=d["id"], name=d["name"]) for d in data]
+    return [
+        TaskSummaryDto(
+            id=d["id"],
+            name=d["name"],
+            estimated_duration=d.get("estimated_duration"),
+            actual_duration_hours=d.get("actual_duration_hours"),
+        )
+        for d in data
+    ]
 
 
 def _parse_time_statistics(time_data: dict[str, Any]) -> TimeStatistics:

--- a/packages/taskdog-core/src/taskdog_core/application/dto/task_dto.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/task_dto.py
@@ -21,10 +21,13 @@ class TaskSummaryDto:
     """Minimal task information for lists and references.
 
     Used when only basic task identification is needed.
+    Includes optional duration fields for statistics display.
     """
 
     id: int
     name: str
+    estimated_duration: float | None = None
+    actual_duration_hours: float | None = None
 
     @classmethod
     def from_entity(cls, task: Task) -> TaskSummaryDto:
@@ -34,14 +37,19 @@ class TaskSummaryDto:
             task: Task entity to convert
 
         Returns:
-            TaskSummaryDto with id and name
+            TaskSummaryDto with id, name, and duration fields
 
         Raises:
             ValueError: If task.id is None
         """
         if task.id is None:
             raise ValueError("Task must have an ID")
-        return cls(id=task.id, name=task.name)
+        return cls(
+            id=task.id,
+            name=task.name,
+            estimated_duration=task.estimated_duration,
+            actual_duration_hours=task.actual_duration_hours,
+        )
 
 
 @dataclass(frozen=True)

--- a/packages/taskdog-server/src/taskdog_server/api/models/responses.py
+++ b/packages/taskdog-server/src/taskdog_server/api/models/responses.py
@@ -274,10 +274,15 @@ class CompletionStatistics(BaseModel):
 
 
 class TaskSummaryResponse(BaseModel):
-    """Minimal task information for references."""
+    """Minimal task information for references.
+
+    Includes optional duration fields for statistics display.
+    """
 
     id: int
     name: str
+    estimated_duration: float | None = None
+    actual_duration_hours: float | None = None
 
 
 class TimeStatistics(BaseModel):

--- a/packages/taskdog-server/src/taskdog_server/api/routers/analytics.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/analytics.py
@@ -80,14 +80,27 @@ async def get_statistics(
         ) -> TaskSummaryResponse | None:
             if dto is None:
                 return None
-            return TaskSummaryResponse(id=dto.id, name=dto.name)
+            return TaskSummaryResponse(
+                id=dto.id,
+                name=dto.name,
+                estimated_duration=dto.estimated_duration,
+                actual_duration_hours=dto.actual_duration_hours,
+            )
 
         def to_task_summary_list(
             dtos: "list[TaskSummaryDto]",
         ) -> list[TaskSummaryResponse]:
             if not dtos:
                 return []
-            return [TaskSummaryResponse(id=d.id, name=d.name) for d in dtos]
+            return [
+                TaskSummaryResponse(
+                    id=d.id,
+                    name=d.name,
+                    estimated_duration=d.estimated_duration,
+                    actual_duration_hours=d.actual_duration_hours,
+                )
+                for d in dtos
+            ]
 
         # Convert DTO to response model
         response = StatisticsResponse(

--- a/packages/taskdog-ui/src/taskdog/mappers/statistics_mapper.py
+++ b/packages/taskdog-ui/src/taskdog/mappers/statistics_mapper.py
@@ -135,10 +135,9 @@ class StatisticsMapper:
         Returns:
             TaskSummaryViewModel with basic task information
         """
-        # TaskSummaryDto only has id and name, so we set optional fields to None
         return TaskSummaryViewModel(
             id=task.id,
             name=task.name,
-            estimated_duration=None,
-            actual_duration_hours=None,
+            estimated_duration=task.estimated_duration,
+            actual_duration_hours=task.actual_duration_hours,
         )


### PR DESCRIPTION
## Summary
- Fix `taskdog stats` command not displaying `estimated_duration` and `actual_duration_hours`
- `TaskSummaryDto` and `TaskSummaryResponse` were only passing `id` and `name`, causing duration information to be lost

## Changes
- Add `estimated_duration` and `actual_duration_hours` fields to `TaskSummaryDto`
- Add same fields to `TaskSummaryResponse`
- Update server-side conversion to include duration fields
- Update client-side converter to parse duration fields
- Update UI mapper to correctly read duration values from DTO

## Test plan
- [x] `make test` - All tests pass
- [x] `make typecheck` - Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)