### PR TITLE
fix(types): remove obsolete mypy exclusions for infrastructure module

### DIFF
--- a/packages/taskdog-ui/pyproject.toml
+++ b/packages/taskdog-ui/pyproject.toml
@@ -87,13 +87,6 @@ warn_unused_ignores = false
 module = "taskdog_client"
 ignore_missing_imports = true
 
-# Ignore modules that depend on taskdog_client (external package)
-[[tool.mypy.overrides]]
-module = [
-    "taskdog.infrastructure",
-]
-ignore_errors = true
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,11 +71,6 @@ disallow_any_generics = false
 disallow_untyped_calls = false
 check_untyped_defs = false
 
-# Ignore modules that depend on taskdog_client (external package in monorepo)
-[[tool.mypy.overrides]]
-module = ["taskdog.infrastructure.api_client", "taskdog.infrastructure"]
-ignore_errors = true
-
 # Ignore third-party library without type stubs
 [[tool.mypy.overrides]]
 module = "textual.*"
@@ -108,10 +103,8 @@ module = [
   "taskdog.renderers.rich_renderer_base",
   "taskdog.renderers.rich_table_renderer",
   "taskdog.renderers.rich_gantt_renderer",
-  # "taskdog.cli.commands.*",  # Temporarily enabled for Tier 4 work
   "taskdog.tui.app",
   "taskdog.tui.widgets.*",
-  "taskdog.tui.screens.algorithm_selection_screen",
 ]
 ignore_errors = true
 


### PR DESCRIPTION
## Summary

- Remove `ignore_errors = true` for `taskdog.infrastructure` module (now fully type-safe)
- Remove `ignore_errors = true` for `taskdog.infrastructure.api_client` (module no longer exists - moved to `taskdog_client` package)
- Remove `taskdog.tui.screens.algorithm_selection_screen` from exclusions (file doesn't exist)
- Clean up commented-out exclusion entry

## Test plan

- [x] `make typecheck` passes for all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)