### PR TITLE
fix(types): add proper BINDINGS type annotations to TUI widgets

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/widgets/audit_log_widget.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/audit_log_widget.py
@@ -7,6 +7,7 @@ status, and client info.
 
 from typing import Any, ClassVar
 
+from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.widgets import Static
 
@@ -27,7 +28,9 @@ class AuditLogWidget(VerticalScroll, ViNavigationMixin, TUIWidget):
     """
 
     MAX_LOGS: ClassVar[int] = 50
-    BINDINGS: ClassVar = ViNavigationMixin.VI_SCROLL_BINDINGS
+    BINDINGS: ClassVar[list[Binding | tuple[str, str] | tuple[str, str, str]]] = list(
+        ViNavigationMixin.VI_SCROLL_BINDINGS
+    )
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the audit log widget."""

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     pass
 
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import Vertical
 from textual.events import Resize
 from textual.widgets import Static
@@ -45,7 +46,9 @@ class GanttWidget(Vertical, ViNavigationMixin, TUIWidget):
     allow_maximize = True
 
     # Vi-style bindings for scrolling (delegated to gantt table)
-    BINDINGS: ClassVar = ViNavigationMixin.VI_SCROLL_ALL_BINDINGS
+    BINDINGS: ClassVar[list[Binding | tuple[str, str] | tuple[str, str, str]]] = list(
+        ViNavigationMixin.VI_SCROLL_ALL_BINDINGS
+    )
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the gantt widget."""

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/vi_option_list.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/vi_option_list.py
@@ -1,6 +1,5 @@
 """ViOptionList widget with Vi-style key bindings."""
 
-from collections.abc import Sequence
 from typing import ClassVar
 
 from textual.binding import Binding
@@ -24,7 +23,7 @@ class ViOptionList(OptionList, ViNavigationMixin):
     """
 
     # Use Vi vertical navigation bindings from mixin
-    BINDINGS: ClassVar[Sequence[Binding | tuple[str, str] | tuple[str, str, str]]] = (
+    BINDINGS: ClassVar[list[Binding | tuple[str, str] | tuple[str, str, str]]] = list(
         ViNavigationMixin.VI_VERTICAL_BINDINGS
     )
 

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/vi_select.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/vi_select.py
@@ -1,6 +1,5 @@
 """ViSelect widget with Vi-style key bindings."""
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from textual.binding import Binding
@@ -23,7 +22,7 @@ class ViSelectOverlay(SelectOverlay, ViNavigationMixin):
     - G: Jump to bottom
     """
 
-    BINDINGS: ClassVar[Sequence[Binding | tuple[str, str] | tuple[str, str, str]]] = [
+    BINDINGS: ClassVar[list[Binding | tuple[str, str] | tuple[str, str, str]]] = [
         *SelectOverlay.BINDINGS,
         *ViNavigationMixin.VI_VERTICAL_BINDINGS,
     ]


### PR DESCRIPTION
## Summary
- Use `list` type instead of `Sequence` for BINDINGS class variables
- Add explicit `Binding` import where needed
- Convert tuple assignments to `list()` for type compatibility

## Files changed
- `audit_log_widget.py`
- `gantt_widget.py`
- `vi_option_list.py`
- `vi_select.py`

## Context
This is preparation for removing mypy `ignore_errors = true` exclusions from TUI modules.
44 errors remain in `app.py` and `widgets/` - those will be addressed in follow-up PRs.

## Test plan
- [x] `make typecheck` passes
- [x] `make test` passes (via pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)