### PR TITLE
fix(types): add return type annotations to TUI widget init methods

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/widgets/task_search_filter.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/task_search_filter.py
@@ -18,7 +18,7 @@ class TaskSearchFilter:
     Formatters are cached at instance level to avoid repeated instantiation.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize with cached formatters for efficient reuse."""
         self._duration_formatter = DurationFormatter()
         self._date_formatter = DateTimeFormatter()

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/task_table_row_builder.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/task_table_row_builder.py
@@ -37,7 +37,7 @@ class TaskTableRowBuilder:
     and DurationFormatter for formatting logic.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the TaskTableRowBuilder with formatter dependencies."""
         self.date_formatter = DateTimeFormatter()
         self.duration_formatter = DurationFormatter()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,11 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = [
   "taskdog.tui.app",
-  "taskdog.tui.widgets.*",
+  "taskdog.tui.widgets.connection_status",
+  "taskdog.tui.widgets.custom_footer",
+  "taskdog.tui.widgets.gantt_data_table",
+  "taskdog.tui.widgets.gantt_widget",
+  "taskdog.tui.widgets.task_table",
 ]
 ignore_errors = true
 


### PR DESCRIPTION
## Summary
- Add `-> None` return type to `TaskSearchFilter.__init__`
- Add `-> None` return type to `TaskTableRowBuilder.__init__`
- Update mypy exclusions from wildcard to explicit module list

## Changes to pyproject.toml
Changed from:
```toml
module = [
  "taskdog.tui.app",
  "taskdog.tui.widgets.*",
]
```

To explicit list (excluding fixed modules):
```toml
module = [
  "taskdog.tui.app",
  "taskdog.tui.widgets.connection_status",
  "taskdog.tui.widgets.custom_footer",
  "taskdog.tui.widgets.gantt_data_table",
  "taskdog.tui.widgets.gantt_widget",
  "taskdog.tui.widgets.task_table",
]
```

## Remaining exclusions (6 modules, 42 errors)
| Module | Errors |
|--------|--------|
| connection_status | 4 |
| gantt_widget | 5 |
| app | 6 |
| custom_footer | 6 |
| gantt_data_table | 7 |
| task_table | 14 |

## Test plan
- [x] `make typecheck` passes
- [x] `make test` passes (via pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)