### PR TITLE
fix(types): add type annotations to ConnectionStatusWidget

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/widgets/connection_status.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/connection_status.py
@@ -1,6 +1,6 @@
 """Connection status indicator widget for TUI header."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from textual.reactive import reactive
 from textual.widgets import Static
@@ -24,7 +24,7 @@ class ConnectionStatusWidget(Static):
     is_api_connected: reactive[bool] = reactive(False)
     is_websocket_connected: reactive[bool] = reactive(False)
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the connection status widget."""
         super().__init__(*args, **kwargs)
         self.add_class("connection-status")
@@ -32,10 +32,12 @@ class ConnectionStatusWidget(Static):
     def on_mount(self) -> None:
         """Called when widget is mounted to the DOM."""
         # Subscribe to connection status changes via observer pattern
-        self.app.connection_manager.subscribe(self._on_connection_status_changed)
+        self.app.connection_manager.subscribe(  # type: ignore[attr-defined]
+            self._on_connection_status_changed
+        )
 
         # Initialize from current status
-        status = self.app.connection_manager.status
+        status = self.app.connection_manager.status  # type: ignore[attr-defined]
         self.is_api_connected = status.is_api_connected
         self.is_websocket_connected = status.is_websocket_connected
         self._update_display()
@@ -43,7 +45,9 @@ class ConnectionStatusWidget(Static):
     def on_unmount(self) -> None:
         """Called when widget is unmounted from the DOM."""
         # Unsubscribe to prevent memory leaks
-        self.app.connection_manager.unsubscribe(self._on_connection_status_changed)
+        self.app.connection_manager.unsubscribe(  # type: ignore[attr-defined]
+            self._on_connection_status_changed
+        )
 
     def _on_connection_status_changed(self, status: "ConnectionStatusData") -> None:
         """Handle connection status change from ConnectionStatusManager.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,6 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = [
   "taskdog.tui.app",
-  "taskdog.tui.widgets.connection_status",
   "taskdog.tui.widgets.custom_footer",
   "taskdog.tui.widgets.gantt_data_table",
   "taskdog.tui.widgets.gantt_widget",


### PR DESCRIPTION
## Summary
- Add `Any` types to `*args` and `**kwargs` in `__init__`
- Add `# type: ignore[attr-defined]` for `app.connection_manager` access
- Remove `connection_status` from mypy exclusion list

## Remaining exclusions (5 modules)
| Module | Errors |
|--------|--------|
| gantt_widget | 5 |
| app | 6 |
| custom_footer | 6 |
| gantt_data_table | 7 |
| task_table | 14 |

## Test plan
- [x] `make typecheck` passes
- [x] `make test` passes (via pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)