### PR TITLE
fix(types): add type annotations to GanttWidget

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
@@ -74,7 +74,7 @@ class GanttWidget(Vertical, ViNavigationMixin, TUIWidget):
         yield self._title_widget
 
         # GanttDataTable (scrollable via DataTable's built-in scroll)
-        self._gantt_table = GanttDataTable(id="gantt-table")
+        self._gantt_table = GanttDataTable(id="gantt-table")  # type: ignore[no-untyped-call]
         yield self._gantt_table
 
         # Legend at bottom (fixed - not scrollable)
@@ -141,7 +141,7 @@ class GanttWidget(Vertical, ViNavigationMixin, TUIWidget):
         reverse: bool = False,
         all: bool = False,
         keep_scroll_position: bool = False,
-    ):
+    ) -> None:
         """Update the gantt chart with new gantt data.
 
         Args:
@@ -219,7 +219,7 @@ class GanttWidget(Vertical, ViNavigationMixin, TUIWidget):
         """Load and display gantt data from the pre-computed gantt ViewModel."""
         try:
             gantt_view_model = self._get_gantt_from_state()
-            if gantt_view_model:
+            if gantt_view_model and self._gantt_table:
                 self._gantt_table.load_gantt(
                     gantt_view_model, keep_scroll_position=self._keep_scroll_position
                 )
@@ -250,7 +250,7 @@ class GanttWidget(Vertical, ViNavigationMixin, TUIWidget):
 
     def _update_legend(self) -> None:
         """Update legend with gantt chart symbols."""
-        if not self._legend_widget:
+        if not self._legend_widget or not self._gantt_table:
             return
 
         legend_text = self._gantt_table.get_legend_text()
@@ -371,7 +371,7 @@ class GanttWidget(Vertical, ViNavigationMixin, TUIWidget):
         return self.tui_state.sort_by
 
     def update_view_model_and_render(
-        self, gantt_view_model, keep_scroll_position: bool = False
+        self, gantt_view_model: GanttViewModel, keep_scroll_position: bool = False
     ) -> None:
         """Update gantt view model and trigger re-render.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,6 @@ module = [
   "taskdog.tui.app",
   "taskdog.tui.widgets.custom_footer",
   "taskdog.tui.widgets.gantt_data_table",
-  "taskdog.tui.widgets.gantt_widget",
   "taskdog.tui.widgets.task_table",
 ]
 ignore_errors = true


### PR DESCRIPTION
## Summary
- Add `-> None` return type to `update_gantt`
- Add `GanttViewModel` type annotation to `update_view_model_and_render`
- Add None checks for `_gantt_table` access
- Add `# type: ignore[no-untyped-call]` for `GanttDataTable` instantiation
- Remove `gantt_widget` from mypy exclusion list

## Remaining exclusions (4 modules)
| Module | Errors |
|--------|--------|
| app | 6 |
| custom_footer | 6 |
| gantt_data_table | 7 |
| task_table | 14 |

## Test plan
- [x] `make typecheck` passes
- [x] `make test` passes (via pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)