### PR TITLE
fix(types): add type annotations to TaskdogTUI app

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,6 @@ ignore_missing_imports = true
 # These require Click decorator type annotations and Rich library compatibility fixes
 [[tool.mypy.overrides]]
 module = [
-  "taskdog.tui.app",
   "taskdog.tui.widgets.gantt_data_table",
   "taskdog.tui.widgets.task_table",
 ]


### PR DESCRIPTION
## Summary
- Add type annotations to `app.py` to enable mypy type checking
- Remove `taskdog.tui.app` from mypy exclusion list in pyproject.toml

## Changes
- Add `# type: ignore[type-arg]` to `App` base class (using `App[None]` causes cascade issues with `__getattr__`)
- Add `# type: ignore[assignment]` for `CSS_PATH` (list variance issue: `Path` is subclass of `PurePath` but `list` is invariant)
- Add `Any` types to `__init__` `*args` and `**kwargs` parameters
- Add `Any` return type to `__getattr__` (must be `Any` to avoid false positive errors on `self.notify`, `self.push_screen`, etc.)
- Refactor lambda to named function for `load_tasks` call (fixes `func-returns-value` error)
- Add `Any` type to `_handle_task_change_event` event parameter

## Test plan
- [x] `make typecheck` passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)