### PR TITLE
fix(types): add type annotations to TaskTable widget

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,13 +96,6 @@ ignore_missing_imports = true
 module = "alembic.*"
 ignore_missing_imports = true
 
-# Temporarily ignore UI modules with missing type annotations (Tier 4)
-# These require Click decorator type annotations and Rich library compatibility fixes
-[[tool.mypy.overrides]]
-module = [
-  "taskdog.tui.widgets.task_table",
-]
-ignore_errors = true
 
 # Ruff configuration
 [tool.ruff]


### PR DESCRIPTION
## Summary
- Add type annotations to `task_table.py` to enable mypy type checking
- **Remove the entire Tier 4 mypy overrides section** - all TUI modules are now type-checked! 🎉

## Changes
- Add `# type: ignore[type-arg]` to `DataTable` base class
- Add `Any` types to `__init__` `*args` and `**kwargs` parameters
- Import `Coordinate` from `textual.coordinate`
- Replace tuple literals with `Coordinate` for `update_cell_at` and `coordinate_to_cell_key` calls
- Add explicit `float | None` types to `saved_scroll_y/x` with `# type: ignore[has-type]`
- Add `-> None` return type to `setup_columns`, `load_tasks`, `_render_tasks`, `refresh_tasks`, `filter_tasks`, and `clear_filter` methods

## Impact
This is the **final PR** in the TUI type annotation series. After this merge:
- All `taskdog.tui.app` and `taskdog.tui.widgets.*` modules will be fully type-checked
- The "Tier 4" mypy overrides section is completely removed from pyproject.toml

## Test plan
- [x] `make typecheck` passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)