### PR TITLE
refactor(config): move CORS settings from core to server package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,17 +37,17 @@ The repository uses UV workspace with three packages:
 
 **Tasks**: Stored in SQLite database `tasks.db` at `$XDG_DATA_HOME/taskdog/tasks.db` (fallback: `~/.local/share/taskdog/tasks.db`)
 
-**Config**: Optional TOML at `$XDG_CONFIG_HOME/taskdog/core.toml` (fallback: `~/.config/taskdog/core.toml`)
+**Config**: Optional TOML files at `$XDG_CONFIG_HOME/taskdog/` (fallback: `~/.config/taskdog/`)
 
-- Sections: `[api]`, `[ui]`, `[optimization]`, `[task]`, `[time]`, `[region]`, `[storage]`
-- Settings:
-  - API: cors_origins (for future Web UI)
-  - UI: theme (TUI theme)
-  - Optimization: max_hours_per_day, default_algorithm
-  - Task: default_priority
-  - Time: default_start_hour, default_end_hour
-  - Region: country (ISO 3166-1 alpha-2: "JP", "US", "GB", "DE", etc.)
-  - Storage: database_url, backend
+- **core.toml** (business logic):
+  - Sections: `[optimization]`, `[task]`, `[time]`, `[region]`, `[storage]`
+  - Settings: max_hours_per_day, default_algorithm, default_priority, default_start_hour, default_end_hour, country, database_url, backend
+- **server.toml** (server-specific):
+  - Sections: `[auth]`, `[cors]`
+  - Settings: enabled, api_keys, origins (CORS for future Web UI)
+- **cli.toml** (CLI/TUI infrastructure):
+  - Sections: `[api]`, `[ui]`, `[notes]`, `[keybindings]`
+  - Settings: host, port, api_key, theme
 - Priority: Environment vars > CLI args > Config file > Defaults
 - Server host/port: CLI arguments (`taskdog-server --host --port`)
 - CLI/TUI connection: `cli.toml` or `TASKDOG_API_HOST`/`TASKDOG_API_PORT` env vars

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -101,24 +101,6 @@ export TASKDOG_API_KEY=your-secret-api-key-1
 
 ## Configuration Sections
 
-### API Settings
-
-The `[api]` section configures API server behavior. Note that connection settings (host/port) are configured separately:
-
-- **Server startup**: Use CLI arguments (`taskdog-server --host 0.0.0.0 --port 3000`)
-- **CLI/TUI connection**: Use `cli.toml` or environment variables (see [CLI Configuration](../packages/taskdog-ui/CLI_CONFIG.md))
-
-```toml
-[api]
-cors_origins = ["http://localhost:3000", "http://localhost:8000"]
-```
-
-**Fields:**
-
-- `cors_origins` (list of strings) - Allowed CORS origins for web browser access. Used for future Web UI support.
-
-**Environment variable:** `TASKDOG_API_CORS_ORIGINS` (comma-separated list)
-
 ### UI Settings
 
 The `[ui]` section configures TUI appearance.
@@ -288,7 +270,7 @@ These variables override core configuration (core.toml):
 | `TASKDOG_REGION_COUNTRY` | string | `None` | ISO 3166-1 alpha-2 country code |
 | `TASKDOG_STORAGE_BACKEND` | string | `"sqlite"` | Storage backend type |
 | `TASKDOG_STORAGE_DATABASE_URL` | string | XDG path | Database file location |
-| `TASKDOG_API_CORS_ORIGINS` | string | localhost | Comma-separated CORS origins |
+| `TASKDOG_CORS_ORIGINS` | string | localhost | Comma-separated CORS origins (server.toml) |
 
 **Example:**
 
@@ -297,7 +279,7 @@ These variables override core configuration (core.toml):
 export TASKDOG_OPTIMIZATION_MAX_HOURS_PER_DAY=8.0
 export TASKDOG_TASK_DEFAULT_PRIORITY=3
 export TASKDOG_REGION_COUNTRY=US
-export TASKDOG_API_CORS_ORIGINS="http://localhost:3000,http://app.example.com"
+export TASKDOG_CORS_ORIGINS="http://localhost:3000,http://app.example.com"
 ```
 
 **Note:** Invalid values are logged as warnings and fall back to defaults.
@@ -368,10 +350,6 @@ Bare minimum to get started (most settings have sensible defaults):
 Complete configuration with all options:
 
 ```toml
-# API Server Settings (optional)
-[api]
-cors_origins = ["http://localhost:3000", "http://localhost:8000"]
-
 # UI Settings
 [ui]
 theme = "tokyo-night"

--- a/examples/core.toml
+++ b/examples/core.toml
@@ -5,27 +5,10 @@
 #
 # This config is for CORE BUSINESS LOGIC (task defaults, optimization, storage).
 # For CLI/TUI infrastructure settings (API connection), see cli.toml.
-# For server-specific settings (authentication), see server.toml.
+# For server-specific settings (authentication, CORS), see server.toml.
 #
 # Note: Server host/port are configured via CLI arguments (taskdog-server --host --port),
 # not in this config file.
-
-# =============================================================================
-# API Server Settings
-# =============================================================================
-#
-# Settings that affect API server behavior (not connection settings).
-
-[api]
-# CORS (Cross-Origin Resource Sharing) allowed origins
-# Used when accessing API from web browsers (for future Web UI)
-# Default: localhost:3000, localhost:8000, 127.0.0.1:3000, 127.0.0.1:8000
-cors_origins = [
-    "http://localhost:3000",
-    "http://localhost:8000",
-    "http://127.0.0.1:3000",
-    "http://127.0.0.1:8000",
-]
 
 # =============================================================================
 # Task Defaults

--- a/examples/server.toml
+++ b/examples/server.toml
@@ -35,6 +35,22 @@ key = "sk-change-me-generate-a-secure-key"
 # key = "sk-yet-another-key"
 
 # =============================================================================
+# CORS Configuration
+# =============================================================================
+[cors]
+# CORS (Cross-Origin Resource Sharing) allowed origins
+# Used when accessing API from web browsers (for future Web UI)
+# Default: localhost:3000, localhost:8000, 127.0.0.1:3000, 127.0.0.1:8000
+#
+# Can be overridden with environment variable: TASKDOG_CORS_ORIGINS=http://example.com,http://app.example.com
+origins = [
+    "http://localhost:3000",
+    "http://localhost:8000",
+    "http://127.0.0.1:3000",
+    "http://127.0.0.1:8000",
+]
+
+# =============================================================================
 # Usage Notes
 # =============================================================================
 #

--- a/packages/taskdog-core/src/taskdog_core/shared/config_manager.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/config_manager.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from taskdog_core.shared.config_loader import ConfigLoader
 from taskdog_core.shared.constants.config_defaults import (
     DEFAULT_ALGORITHM,
-    DEFAULT_CORS_ORIGINS,
     DEFAULT_END_HOUR,
     DEFAULT_MAX_HOURS_PER_DAY,
     DEFAULT_PRIORITY,
@@ -83,20 +82,6 @@ class StorageConfig:
 
 
 @dataclass(frozen=True)
-class ApiConfig:
-    """API server configuration.
-
-    Note: host and port are configured via CLI arguments, not here.
-    This config only contains settings that affect server behavior.
-
-    Attributes:
-        cors_origins: List of allowed CORS origins for API requests (for future Web UI)
-    """
-
-    cors_origins: list[str] = field(default_factory=lambda: DEFAULT_CORS_ORIGINS.copy())
-
-
-@dataclass(frozen=True)
 class Config:
     """Taskdog configuration.
 
@@ -106,7 +91,6 @@ class Config:
         time: Time-related settings
         region: Region-related settings (holidays, etc.)
         storage: Storage backend settings
-        api: API server settings
     """
 
     optimization: OptimizationConfig
@@ -114,7 +98,6 @@ class Config:
     time: TimeConfig
     region: RegionConfig = field(default_factory=RegionConfig)
     storage: StorageConfig = field(default_factory=StorageConfig)
-    api: ApiConfig = field(default_factory=ApiConfig)
 
 
 class ConfigManager:
@@ -148,7 +131,6 @@ class ConfigManager:
         time_data = toml_data.get("time", {})
         region_data = toml_data.get("region", {})
         storage_data = toml_data.get("storage", {})
-        api_data = toml_data.get("api", {})
 
         return Config(
             optimization=OptimizationConfig(
@@ -201,12 +183,6 @@ class ConfigManager:
                     "STORAGE_DATABASE_URL",
                     storage_data.get("database_url"),
                     str,
-                ),
-            ),
-            api=ApiConfig(
-                cors_origins=ConfigLoader.get_env_list(
-                    "API_CORS_ORIGINS",
-                    api_data.get("cors_origins", DEFAULT_CORS_ORIGINS),
                 ),
             ),
         )

--- a/packages/taskdog-core/src/taskdog_core/shared/constants/config_defaults.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/constants/config_defaults.py
@@ -13,11 +13,3 @@ MAX_ESTIMATED_DURATION_HOURS = 999  # Maximum estimated duration in hours
 # === Time Defaults ===
 DEFAULT_START_HOUR = 9  # Business day start hour
 DEFAULT_END_HOUR = 18  # Business day end hour (used for deadlines)
-
-# === API Server Defaults ===
-DEFAULT_CORS_ORIGINS = [
-    "http://localhost:3000",
-    "http://localhost:8000",
-    "http://127.0.0.1:3000",
-    "http://127.0.0.1:8000",
-]

--- a/packages/taskdog-core/tests/shared/test_config_manager.py
+++ b/packages/taskdog-core/tests/shared/test_config_manager.py
@@ -146,35 +146,6 @@ default_algorithm = "balanced"
         finally:
             config_path.unlink()
 
-    def test_env_var_list_parsing(self):
-        """Test comma-separated list parsing for environment variables."""
-        env_vars = {
-            "TASKDOG_API_CORS_ORIGINS": "http://localhost:3000, http://example.com, http://test.com",
-        }
-
-        with patch.dict(os.environ, env_vars, clear=False):
-            config = ConfigManager.load(Path("/nonexistent/config.toml"))
-
-        assert config.api.cors_origins == [
-            "http://localhost:3000",
-            "http://example.com",
-            "http://test.com",
-        ]
-
-    def test_env_var_list_with_empty_items(self):
-        """Test that empty items are filtered out from list parsing."""
-        env_vars = {
-            "TASKDOG_API_CORS_ORIGINS": "http://localhost:3000, , http://example.com, ",
-        }
-
-        with patch.dict(os.environ, env_vars, clear=False):
-            config = ConfigManager.load(Path("/nonexistent/config.toml"))
-
-        assert config.api.cors_origins == [
-            "http://localhost:3000",
-            "http://example.com",
-        ]
-
     @pytest.mark.parametrize(
         "env_key,env_value,section,field,expected",
         [

--- a/packages/taskdog-server/src/taskdog_server/api/app.py
+++ b/packages/taskdog-server/src/taskdog_server/api/app.py
@@ -71,10 +71,10 @@ def create_app() -> FastAPI:
 
     # Configure CORS with settings from config file or defaults
     # Default origins: localhost:3000, localhost:8000, 127.0.0.1:3000, 127.0.0.1:8000
-    # Can be overridden in core.toml under [api] section with cors_origins = [...]
+    # Can be overridden in server.toml under [cors] section with origins = [...]
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=config.api.cors_origins,
+        allow_origins=list(server_config.cors.origins),
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/packages/taskdog-server/tests/config/test_server_config_manager.py
+++ b/packages/taskdog-server/tests/config/test_server_config_manager.py
@@ -5,8 +5,10 @@ from pathlib import Path
 import pytest
 
 from taskdog_server.config.server_config_manager import (
+    DEFAULT_CORS_ORIGINS,
     ApiKeyEntry,
     AuthConfig,
+    CorsConfig,
     ServerConfig,
     ServerConfigManager,
 )
@@ -21,6 +23,7 @@ class TestServerConfigManager:
 
         assert config.auth.enabled is True
         assert config.auth.api_keys == ()
+        assert config.cors.origins == tuple(DEFAULT_CORS_ORIGINS)
 
     def test_load_empty_file_returns_defaults(self, tmp_path: Path) -> None:
         """When config file is empty, return default config."""
@@ -31,6 +34,7 @@ class TestServerConfigManager:
 
         assert config.auth.enabled is True
         assert config.auth.api_keys == ()
+        assert config.cors.origins == tuple(DEFAULT_CORS_ORIGINS)
 
     def test_load_with_single_api_key(self, tmp_path: Path) -> None:
         """Load config with a single API key."""
@@ -187,11 +191,12 @@ class TestServerConfig:
     """Tests for ServerConfig dataclass."""
 
     def test_default_values(self) -> None:
-        """ServerConfig has default AuthConfig."""
+        """ServerConfig has default AuthConfig and CorsConfig."""
         config = ServerConfig()
 
         assert config.auth.enabled is True
         assert config.auth.api_keys == ()
+        assert config.cors.origins == tuple(DEFAULT_CORS_ORIGINS)
 
     def test_frozen_dataclass(self) -> None:
         """ServerConfig is immutable."""
@@ -199,3 +204,67 @@ class TestServerConfig:
 
         with pytest.raises(AttributeError):
             config.auth = AuthConfig(enabled=False)  # type: ignore[misc]
+
+
+class TestCorsConfig:
+    """Tests for CorsConfig dataclass."""
+
+    def test_default_values(self) -> None:
+        """CorsConfig has sensible defaults."""
+        config = CorsConfig()
+
+        assert config.origins == tuple(DEFAULT_CORS_ORIGINS)
+
+    def test_frozen_dataclass(self) -> None:
+        """CorsConfig is immutable."""
+        config = CorsConfig()
+
+        with pytest.raises(AttributeError):
+            config.origins = ("http://example.com",)  # type: ignore[misc]
+
+
+class TestCorsConfiguration:
+    """Tests for CORS configuration loading."""
+
+    def test_load_custom_cors_origins(self, tmp_path: Path) -> None:
+        """Load config with custom CORS origins."""
+        config_path = tmp_path / "server.toml"
+        config_path.write_text("""
+[cors]
+origins = ["http://example.com", "https://app.example.com"]
+""")
+
+        config = ServerConfigManager.load(config_path)
+
+        assert config.cors.origins == ("http://example.com", "https://app.example.com")
+
+    def test_environment_variable_override_cors(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """TASKDOG_CORS_ORIGINS env var overrides config file."""
+        config_path = tmp_path / "server.toml"
+        config_path.write_text("""
+[cors]
+origins = ["http://from-file.com"]
+""")
+
+        # Override with environment variable (comma-separated)
+        monkeypatch.setenv(
+            "TASKDOG_CORS_ORIGINS", "http://from-env.com,https://another.com"
+        )
+
+        config = ServerConfigManager.load(config_path)
+
+        assert config.cors.origins == ("http://from-env.com", "https://another.com")
+
+    def test_cors_empty_origins_list(self, tmp_path: Path) -> None:
+        """Empty CORS origins list is preserved."""
+        config_path = tmp_path / "server.toml"
+        config_path.write_text("""
+[cors]
+origins = []
+""")
+
+        config = ServerConfigManager.load(config_path)
+
+        assert config.cors.origins == ()


### PR DESCRIPTION
## Summary

- Move `cors_origins` configuration from `taskdog-core` to `taskdog-server` to follow Clean Architecture principles
- CORS is a server-specific concern and should not be defined in the core business logic layer
- Add `CorsConfig` dataclass and `[cors]` section support in `server.toml`
- Update environment variable from `TASKDOG_API_CORS_ORIGINS` to `TASKDOG_CORS_ORIGINS`

## Changes

### taskdog-server (Added)
- `server_config_manager.py`: Add `CorsConfig` dataclass and `[cors]` section loading
- `app.py`: Change `config.api.cors_origins` → `server_config.cors.origins`
- Add CORS configuration tests

### taskdog-core (Removed)
- `config_manager.py`: Remove `ApiConfig` dataclass and `api` section loading
- `config_defaults.py`: Remove `DEFAULT_CORS_ORIGINS`
- Remove CORS-related tests

### Documentation
- `examples/core.toml`: Remove `[api]` section
- `examples/server.toml`: Add `[cors]` section
- `docs/CONFIGURATION.md`: Update CORS settings description
- `CLAUDE.md`: Clarify the roles of three config files (core.toml, server.toml, cli.toml)

## Test plan

- [x] `make test-core` - All tests pass
- [x] `make test-server` - All tests pass (including new CORS tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)