### PR TITLE
refactor(cli): use click.DateTime for date-only options

### DIFF
--- a/packages/taskdog-ui/src/taskdog/cli/commands/common_options.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/common_options.py
@@ -6,8 +6,6 @@ from typing import Any
 
 import click
 
-from taskdog.shared.click_types.datetime_with_default import DateTimeWithDefault
-
 
 def filter_options() -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Add common filter options (--all, --status) to a command.
@@ -97,15 +95,15 @@ def date_range_options() -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         @click.option(
             "--end-date",
             "-e",
-            type=DateTimeWithDefault(),
-            help="End date for filtering (YYYY-MM-DD, MM-DD, or MM/DD). "
+            type=click.DateTime(),
+            help="End date for filtering (YYYY-MM-DD). "
             "Shows tasks with any date field <= end date.",
         )
         @click.option(
             "--start-date",
             "-s",
-            type=DateTimeWithDefault(),
-            help="Start date for filtering (YYYY-MM-DD, MM-DD, or MM/DD). "
+            type=click.DateTime(),
+            help="Start date for filtering (YYYY-MM-DD). "
             "Shows tasks with any date field >= start date.",
         )
         @wraps(f)

--- a/packages/taskdog-ui/src/taskdog/cli/commands/gantt.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/gantt.py
@@ -9,7 +9,6 @@ from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_command_errors
 from taskdog.presenters.gantt_presenter import GanttPresenter
 from taskdog.renderers.rich_gantt_renderer import RichGanttRenderer
-from taskdog.shared.click_types.datetime_with_default import DateTimeWithDefault
 
 
 @click.command(
@@ -48,7 +47,7 @@ EXAMPLE:
   taskdog gantt -a                              # Show all tasks (including archived)
   taskdog gantt --status completed              # Show only completed tasks
   taskdog gantt -t work -t urgent               # Tasks with tag "work" OR "urgent"
-  taskdog gantt --start-date 2025-10-01 --end-date 2025-10-31
+  taskdog gantt --start-date 2025-10-01 --end-date 2025-10-31  # October tasks
 """,
 )
 @click.option(
@@ -61,14 +60,14 @@ EXAMPLE:
 @click.option(
     "--start-date",
     "-s",
-    type=DateTimeWithDefault(),
-    help="Start date for the chart (YYYY-MM-DD, MM-DD, or MM/DD). Defaults to previous Monday.",
+    type=click.DateTime(),
+    help="Start date for the chart (YYYY-MM-DD). Defaults to previous Monday.",
 )
 @click.option(
     "--end-date",
     "-e",
-    type=DateTimeWithDefault(),
-    help="End date for the chart (YYYY-MM-DD, MM-DD, or MM/DD). Defaults to last task date.",
+    type=click.DateTime(),
+    help="End date for the chart (YYYY-MM-DD). Defaults to last task date.",
 )
 @sort_options(default_sort="deadline")
 @filter_options()


### PR DESCRIPTION
## Summary
- Replace `DateTimeWithDefault` with `click.DateTime` for `--start-date` and `--end-date` options
- Affects `gantt`, `table`, and `export` commands (these only use the date portion)
- Removes MM-DD/MM/DD format support (only YYYY-MM-DD now)
- Prepares for #556 which will remove the default time feature from `DateTimeWithDefault`

## Test plan
- [x] `make test-ui` passes (891 tests)
- [x] Manual test: `taskdog gantt --start-date 2025-01-01`
- [x] Manual test: `taskdog table --start-date 2025-01-01 --end-date 2025-12-31`

🤖 Generated with [Claude Code](https://claude.com/claude-code)