### PR TITLE
refactor(cli): move optimize start_date default to server

### DIFF
--- a/packages/taskdog-client/src/taskdog_client/analytics_client.py
+++ b/packages/taskdog-client/src/taskdog_client/analytics_client.py
@@ -46,7 +46,7 @@ class AnalyticsClient:
     def optimize_schedule(
         self,
         algorithm: str | None,
-        start_date: datetime,
+        start_date: datetime | None,
         max_hours_per_day: float | None,
         force_override: bool = True,
         task_ids: list[int] | None = None,
@@ -55,7 +55,7 @@ class AnalyticsClient:
 
         Args:
             algorithm: Algorithm name (None = server default)
-            start_date: Optimization start date
+            start_date: Optimization start date (None = server current time)
             max_hours_per_day: Maximum hours per day (None = server default)
             force_override: Force override existing schedules
             task_ids: Specific task IDs to optimize (None means all schedulable tasks)
@@ -70,7 +70,7 @@ class AnalyticsClient:
         """
         payload: dict[str, str | float | bool | list[int] | None] = {
             "algorithm": algorithm,
-            "start_date": start_date.isoformat(),
+            "start_date": start_date.isoformat() if start_date else None,
             "max_hours_per_day": max_hours_per_day,
             "force_override": force_override,
         }

--- a/packages/taskdog-client/src/taskdog_client/taskdog_api_client.py
+++ b/packages/taskdog-client/src/taskdog_client/taskdog_api_client.py
@@ -257,7 +257,7 @@ class TaskdogApiClient:
     def optimize_schedule(
         self,
         algorithm: str | None,
-        start_date: datetime,
+        start_date: datetime | None,
         max_hours_per_day: float | None,
         force_override: bool = True,
         task_ids: list[int] | None = None,
@@ -266,7 +266,7 @@ class TaskdogApiClient:
 
         Args:
             algorithm: Optimization algorithm (None = server default)
-            start_date: Start date for optimization
+            start_date: Start date for optimization (None = server current time)
             max_hours_per_day: Max hours per day (None = server default)
             force_override: Force override existing schedules
             task_ids: Specific task IDs to optimize

--- a/packages/taskdog-ui/src/taskdog/cli/commands/gantt.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/gantt.py
@@ -98,7 +98,7 @@ def gantt_command(
     # Prepare filter parameters (tags use OR logic by default)
     tags = list(tag) if tag else None
 
-    # Convert datetime to date objects if provided (DateTimeWithDefault returns datetime)
+    # Convert datetime to date objects if provided
     # Default to previous Monday if start_date not provided
     if start_date:
         start_date_obj = start_date.date()

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_optimize_command.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_optimize_command.py
@@ -1,6 +1,6 @@
 """Tests for optimize command."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from click.testing import CliRunner
@@ -21,11 +21,9 @@ class TestOptimizeCommand:
         self.cli_context.console_writer = self.console_writer
         self.cli_context.api_client = self.api_client
 
-    @patch("taskdog.cli.commands.optimize._get_next_weekday_start")
-    def test_basic_optimize(self, mock_get_next_weekday_start):
+    def test_basic_optimize(self):
         """Test basic optimization."""
         # Setup
-        mock_get_next_weekday_start.return_value = MagicMock()
         mock_result = MagicMock()
         mock_result.all_failed.return_value = False
         mock_result.successful_tasks = [MagicMock()]
@@ -40,11 +38,9 @@ class TestOptimizeCommand:
         self.api_client.optimize_schedule.assert_called_once()
         self.console_writer.success.assert_called_once()
 
-    @patch("taskdog.cli.commands.optimize._get_next_weekday_start")
-    def test_optimize_specific_tasks(self, mock_get_next_weekday_start):
+    def test_optimize_specific_tasks(self):
         """Test optimization with specific task IDs."""
         # Setup
-        mock_get_next_weekday_start.return_value = MagicMock()
         mock_result = MagicMock()
         mock_result.all_failed.return_value = False
         mock_result.successful_tasks = [MagicMock(), MagicMock()]
@@ -61,11 +57,9 @@ class TestOptimizeCommand:
         call_kwargs = self.api_client.optimize_schedule.call_args[1]
         assert call_kwargs["task_ids"] == [1, 2, 3]
 
-    @patch("taskdog.cli.commands.optimize._get_next_weekday_start")
-    def test_optimize_with_algorithm(self, mock_get_next_weekday_start):
+    def test_optimize_with_algorithm(self):
         """Test optimization with specific algorithm."""
         # Setup
-        mock_get_next_weekday_start.return_value = MagicMock()
         mock_result = MagicMock()
         mock_result.all_failed.return_value = False
         mock_result.successful_tasks = [MagicMock()]
@@ -82,11 +76,9 @@ class TestOptimizeCommand:
         call_kwargs = self.api_client.optimize_schedule.call_args[1]
         assert call_kwargs["algorithm"] == "balanced"
 
-    @patch("taskdog.cli.commands.optimize._get_next_weekday_start")
-    def test_optimize_with_max_hours(self, mock_get_next_weekday_start):
+    def test_optimize_with_max_hours(self):
         """Test optimization with max hours per day."""
         # Setup
-        mock_get_next_weekday_start.return_value = MagicMock()
         mock_result = MagicMock()
         mock_result.all_failed.return_value = False
         mock_result.successful_tasks = [MagicMock()]
@@ -103,11 +95,9 @@ class TestOptimizeCommand:
         call_kwargs = self.api_client.optimize_schedule.call_args[1]
         assert call_kwargs["max_hours_per_day"] == 8.0
 
-    @patch("taskdog.cli.commands.optimize._get_next_weekday_start")
-    def test_optimize_with_force(self, mock_get_next_weekday_start):
+    def test_optimize_with_force(self):
         """Test optimization with force flag."""
         # Setup
-        mock_get_next_weekday_start.return_value = MagicMock()
         mock_result = MagicMock()
         mock_result.all_failed.return_value = False
         mock_result.successful_tasks = [MagicMock()]
@@ -122,8 +112,7 @@ class TestOptimizeCommand:
         call_kwargs = self.api_client.optimize_schedule.call_args[1]
         assert call_kwargs["force_override"] is True
 
-    @patch("taskdog.cli.commands.optimize._get_next_weekday_start")
-    def test_optimize_with_start_date(self, mock_get_next_weekday_start):
+    def test_optimize_with_start_date(self):
         """Test optimization with specific start date."""
         # Setup
         mock_result = MagicMock()
@@ -142,11 +131,26 @@ class TestOptimizeCommand:
         call_kwargs = self.api_client.optimize_schedule.call_args[1]
         assert call_kwargs["start_date"] is not None
 
-    @patch("taskdog.cli.commands.optimize._get_next_weekday_start")
-    def test_optimize_all_failed(self, mock_get_next_weekday_start):
+    def test_optimize_without_start_date(self):
+        """Test optimization without start date passes None to API."""
+        # Setup
+        mock_result = MagicMock()
+        mock_result.all_failed.return_value = False
+        mock_result.successful_tasks = [MagicMock()]
+        mock_result.has_failures.return_value = False
+        self.api_client.optimize_schedule.return_value = mock_result
+
+        # Execute
+        result = self.runner.invoke(optimize_command, [], obj=self.cli_context)
+
+        # Verify
+        assert result.exit_code == 0
+        call_kwargs = self.api_client.optimize_schedule.call_args[1]
+        assert call_kwargs["start_date"] is None
+
+    def test_optimize_all_failed(self):
         """Test optimization when all tasks fail."""
         # Setup
-        mock_get_next_weekday_start.return_value = MagicMock()
         mock_result = MagicMock()
         mock_result.all_failed.return_value = True
         mock_result.failed_tasks = [MagicMock()]
@@ -159,11 +163,9 @@ class TestOptimizeCommand:
         assert result.exit_code == 0
         self.console_writer.warning.assert_called()
 
-    @patch("taskdog.cli.commands.optimize._get_next_weekday_start")
-    def test_optimize_no_tasks(self, mock_get_next_weekday_start):
+    def test_optimize_no_tasks(self):
         """Test optimization when no tasks to optimize."""
         # Setup
-        mock_get_next_weekday_start.return_value = MagicMock()
         mock_result = MagicMock()
         mock_result.all_failed.return_value = False
         mock_result.successful_tasks = []
@@ -176,11 +178,9 @@ class TestOptimizeCommand:
         assert result.exit_code == 0
         self.console_writer.warning.assert_called()
 
-    @patch("taskdog.cli.commands.optimize._get_next_weekday_start")
-    def test_optimize_partial_success(self, mock_get_next_weekday_start):
+    def test_optimize_partial_success(self):
         """Test optimization with partial success."""
         # Setup
-        mock_get_next_weekday_start.return_value = MagicMock()
         mock_result = MagicMock()
         mock_result.all_failed.return_value = False
         mock_result.successful_tasks = [MagicMock()]


### PR DESCRIPTION
## Summary
- Remove `_get_next_weekday_start()` function from `optimize.py`
- Replace `DateTimeWithDefault` with `click.DateTime()` for `--start-date`
- Make `start_date` optional (`datetime | None`) in `analytics_client.py` and `taskdog_api_client.py`
- Server uses `time_provider.now()` when `start_date` is not provided

This simplifies the CLI layer by moving default logic to the server.

## Related
Prepares for #556

## Test plan
- [x] `make test-ui` passes (892 tests)
- [x] `make test-client` passes (228 tests)
- [x] mypy passes
- [x] Manual test: `taskdog optimize` (without `--start-date`)
- [x] Manual test: `taskdog optimize --start-date 2025-01-15`

🤖 Generated with [Claude Code](https://claude.com/claude-code)