### PR TITLE
refactor(cli): require full datetime for fix-actual command

### DIFF
--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_fix_actual_command.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_fix_actual_command.py
@@ -117,31 +117,6 @@ class TestFixActualCommand:
                     "clear_duration": False,
                 },
             ),
-            # Date-only input (defaults to specific times)
-            (
-                ["1", "--start", "2025-12-13"],
-                {
-                    "task_id": 1,
-                    "actual_start": datetime(2025, 12, 13, 9, 0, 0),
-                    "actual_end": None,
-                    "actual_duration": None,
-                    "clear_start": False,
-                    "clear_end": False,
-                    "clear_duration": False,
-                },
-            ),
-            (
-                ["1", "--end", "2025-12-13"],
-                {
-                    "task_id": 1,
-                    "actual_start": None,
-                    "actual_end": datetime(2025, 12, 13, 18, 0, 0),
-                    "actual_duration": None,
-                    "clear_start": False,
-                    "clear_end": False,
-                    "clear_duration": False,
-                },
-            ),
         ],
         ids=[
             "start_only",
@@ -150,8 +125,6 @@ class TestFixActualCommand:
             "start_and_end",
             "all_options",
             "short_options",
-            "date_only_start",
-            "date_only_end",
         ],
     )
     def test_fix_actual_success(self, args, expected_kwargs):


### PR DESCRIPTION
## Summary
- Remove `DateTimeWithDefault` usage from `fix-actual` command
- Use `click.DateTime()` directly since actual timestamps require precision
- Update examples in docstring to show full datetime format
- Remove date-only test cases that no longer apply

## Rationale
The `fix-actual` command is used to correct actual timestamps for historical accuracy. Unlike scheduling commands where default times (09:00/18:00) make sense, actual times should be explicitly provided by the user to ensure accuracy.

## Test plan
- [x] All existing tests pass (17 tests)
- [x] Lint and typecheck pass
- [x] Removed date-only test cases as date-only input is no longer supported

🤖 Generated with [Claude Code](https://claude.com/claude-code)