### PR TITLE
chore(server): disable auth by default

### DIFF
--- a/packages/taskdog-server/src/taskdog_server/config/server_config_manager.py
+++ b/packages/taskdog-server/src/taskdog_server/config/server_config_manager.py
@@ -48,13 +48,13 @@ class AuthConfig:
     """Authentication configuration.
 
     Attributes:
-        enabled: Whether authentication is enabled. Default is True.
+        enabled: Whether authentication is enabled. Default is False.
                  When disabled, all requests are allowed without API key.
         api_keys: Tuple of API key entries. When enabled=True and empty,
                   all requests are rejected.
     """
 
-    enabled: bool = True
+    enabled: bool = False
     api_keys: tuple[ApiKeyEntry, ...] = ()
 
 
@@ -80,7 +80,7 @@ class ServerConfigManager:
 
     Example server.toml:
         [auth]
-        enabled = true  # optional, default true
+        enabled = true  # optional, default false
 
         [[auth.api_keys]]
         name = "claude-code"
@@ -111,7 +111,7 @@ class ServerConfigManager:
         auth_data = data.get("auth", {})
 
         # Parse enabled flag with environment variable override
-        enabled_from_file = auth_data.get("enabled", True)
+        enabled_from_file = auth_data.get("enabled", False)
         enabled = ConfigLoader.get_env(
             "AUTH_ENABLED",
             enabled_from_file,

--- a/packages/taskdog-server/tests/config/test_server_config_manager.py
+++ b/packages/taskdog-server/tests/config/test_server_config_manager.py
@@ -21,7 +21,7 @@ class TestServerConfigManager:
         """When config file doesn't exist, return default config."""
         config = ServerConfigManager.load(tmp_path / "nonexistent.toml")
 
-        assert config.auth.enabled is True
+        assert config.auth.enabled is False
         assert config.auth.api_keys == ()
         assert config.cors.origins == tuple(DEFAULT_CORS_ORIGINS)
 
@@ -32,7 +32,7 @@ class TestServerConfigManager:
 
         config = ServerConfigManager.load(config_path)
 
-        assert config.auth.enabled is True
+        assert config.auth.enabled is False
         assert config.auth.api_keys == ()
         assert config.cors.origins == tuple(DEFAULT_CORS_ORIGINS)
 
@@ -176,7 +176,7 @@ class TestAuthConfig:
         """AuthConfig has sensible defaults."""
         config = AuthConfig()
 
-        assert config.enabled is True
+        assert config.enabled is False
         assert config.api_keys == ()
 
     def test_frozen_dataclass(self) -> None:
@@ -194,7 +194,7 @@ class TestServerConfig:
         """ServerConfig has default AuthConfig and CorsConfig."""
         config = ServerConfig()
 
-        assert config.auth.enabled is True
+        assert config.auth.enabled is False
         assert config.auth.api_keys == ()
         assert config.cors.origins == tuple(DEFAULT_CORS_ORIGINS)
 


### PR DESCRIPTION
## Summary
- Change the default value of `auth.enabled` from `True` to `False`
- Update docstrings and comments to reflect the new default
- Update tests to match the new default behavior

## Motivation
This makes the server easier to use out of the box without requiring authentication configuration. Users who want authentication can explicitly enable it in `server.toml`.

## Test plan
- [x] `make test-server` passes (274 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)