### PR TITLE
refactor(cli): move algorithm default from server to UI

### DIFF
--- a/packages/taskdog-server/src/taskdog_server/api/routers/analytics.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/analytics.py
@@ -269,7 +269,7 @@ async def get_gantt_chart(
 
 def run_optimization(
     controller: AnalyticsControllerDep,
-    algorithm: str | None,
+    algorithm: str,
     start_date: datetime,
     max_hours_per_day: float | None,
     force_override: bool,
@@ -279,7 +279,7 @@ def run_optimization(
 
     Args:
         controller: Analytics controller
-        algorithm: Algorithm name (None = controller applies default)
+        algorithm: Algorithm name (required, provided by UI)
         start_date: Optimization start date
         max_hours_per_day: Maximum hours per day (None = controller applies default)
         force_override: Force override existing schedules
@@ -287,7 +287,7 @@ def run_optimization(
     """
     # This runs in the background
     controller.optimize_schedule(
-        algorithm=algorithm or "greedy",  # Provide default if None
+        algorithm=algorithm,
         start_date=start_date,
         max_hours_per_day=max_hours_per_day,
         force_override=force_override,

--- a/packages/taskdog-ui/src/taskdog/cli/commands/optimize.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/optimize.py
@@ -70,9 +70,9 @@ Examples:
     "--algorithm",
     "-a",
     type=str,
-    default=None,
+    default="greedy",
     help=(
-        "Optimization algorithm (default: from config or greedy): "
+        "Optimization algorithm: "
         "greedy (front-load), "
         "balanced (even distribution), "
         "backward (JIT from deadline), "
@@ -104,9 +104,8 @@ def optimize_command(
     task_ids_list = list(task_ids) if task_ids else None
 
     # Execute optimization via API
-    # Server will apply config defaults for None values
     result = api_client.optimize_schedule(
-        algorithm=algorithm,  # None if not provided, server applies default
+        algorithm=algorithm,
         start_date=start_date,
         max_hours_per_day=max_hours_per_day,  # None if not provided, server applies default
         force_override=force,


### PR DESCRIPTION
## Summary
- Move `algorithm` parameter default from server to CLI
- CLI `--algorithm` now defaults to "greedy" instead of None
- Remove dead code fallback `algorithm or "greedy"` in server

## Test plan
- [x] `make test-ui` passes (890 tests)
- [x] `make test-server` passes (274 tests)
- [x] `taskdog optimize --help` shows updated help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)