### PR TITLE
chore(server): remove unused CORS configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,8 @@ The repository uses UV workspace with three packages:
   - Sections: `[optimization]`, `[task]`, `[time]`, `[region]`, `[storage]`
   - Settings: max_hours_per_day, default_algorithm, default_priority, default_start_hour, default_end_hour, country, database_url, backend
 - **server.toml** (server-specific):
-  - Sections: `[auth]`, `[cors]`
-  - Settings: enabled, api_keys, origins (CORS for future Web UI)
+  - Sections: `[auth]`
+  - Settings: enabled, api_keys
 - **cli.toml** (CLI/TUI infrastructure):
   - Sections: `[api]`, `[ui]`, `[notes]`, `[keybindings]`
   - Settings: host, port, api_key, theme
@@ -214,7 +214,7 @@ Clean Architecture with 5 layers across three packages: **Domain** ← **Applica
 
 **API** (`packages/taskdog-server/src/taskdog_server/api/`):
 
-- `app.py`: FastAPI application setup with CORS, exception handlers
+- `app.py`: FastAPI application setup with exception handlers
 - `routers/`: API route handlers
   - `tasks.py`: Task CRUD operations
   - `lifecycle.py`: Task status changes (start, complete, pause, cancel, reopen)

--- a/docs/API.md
+++ b/docs/API.md
@@ -681,7 +681,3 @@ done
 ## Rate Limiting
 
 Currently, Taskdog API does not implement rate limiting as it's designed for local use. For production deployments, consider adding rate limiting middleware.
-
-## CORS
-
-CORS is enabled by default for all origins in development. For production, configure appropriate CORS origins in the server startup.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -270,7 +270,6 @@ These variables override core configuration (core.toml):
 | `TASKDOG_REGION_COUNTRY` | string | `None` | ISO 3166-1 alpha-2 country code |
 | `TASKDOG_STORAGE_BACKEND` | string | `"sqlite"` | Storage backend type |
 | `TASKDOG_STORAGE_DATABASE_URL` | string | XDG path | Database file location |
-| `TASKDOG_CORS_ORIGINS` | string | localhost | Comma-separated CORS origins (server.toml) |
 
 **Example:**
 
@@ -279,7 +278,6 @@ These variables override core configuration (core.toml):
 export TASKDOG_OPTIMIZATION_MAX_HOURS_PER_DAY=8.0
 export TASKDOG_TASK_DEFAULT_PRIORITY=3
 export TASKDOG_REGION_COUNTRY=US
-export TASKDOG_CORS_ORIGINS="http://localhost:3000,http://app.example.com"
 ```
 
 **Note:** Invalid values are logged as warnings and fall back to defaults.

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,7 +23,6 @@ Taskdog uses **separate configuration files** for clear separation of concerns:
 - Time settings (default start/end hours)
 - Region settings (holiday calendar)
 - Storage settings (database location)
-- API settings (CORS)
 
 **When to use**: Configure business logic behavior
 

--- a/examples/core.toml
+++ b/examples/core.toml
@@ -5,7 +5,7 @@
 #
 # This config is for CORE BUSINESS LOGIC (task defaults, optimization, storage).
 # For CLI/TUI infrastructure settings (API connection), see cli.toml.
-# For server-specific settings (authentication, CORS), see server.toml.
+# For server-specific settings (authentication), see server.toml.
 #
 # Note: Server host/port are configured via CLI arguments (taskdog-server --host --port),
 # not in this config file.

--- a/examples/server.toml
+++ b/examples/server.toml
@@ -35,22 +35,6 @@ key = "sk-change-me-generate-a-secure-key"
 # key = "sk-yet-another-key"
 
 # =============================================================================
-# CORS Configuration
-# =============================================================================
-[cors]
-# CORS (Cross-Origin Resource Sharing) allowed origins
-# Used when accessing API from web browsers (for future Web UI)
-# Default: localhost:3000, localhost:8000, 127.0.0.1:3000, 127.0.0.1:8000
-#
-# Can be overridden with environment variable: TASKDOG_CORS_ORIGINS=http://example.com,http://app.example.com
-origins = [
-    "http://localhost:3000",
-    "http://localhost:8000",
-    "http://127.0.0.1:3000",
-    "http://127.0.0.1:8000",
-]
-
-# =============================================================================
 # Usage Notes
 # =============================================================================
 #

--- a/packages/taskdog-server/src/taskdog_server/api/app.py
+++ b/packages/taskdog-server/src/taskdog_server/api/app.py
@@ -4,7 +4,6 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
 
 from taskdog_core.shared.config_manager import ConfigManager
 from taskdog_server import __version__
@@ -68,17 +67,6 @@ def create_app() -> FastAPI:
 
     # Add logging middleware (should be first to log all requests)
     app.add_middleware(LoggingMiddleware)
-
-    # Configure CORS with settings from config file or defaults
-    # Default origins: localhost:3000, localhost:8000, 127.0.0.1:3000, 127.0.0.1:8000
-    # Can be overridden in server.toml under [cors] section with origins = [...]
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=list(server_config.cors.origins),
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
 
     # Register routers
     app.include_router(tasks_router, prefix="/api/v1/tasks", tags=["tasks"])

--- a/packages/taskdog-server/src/taskdog_server/config/server_config_manager.py
+++ b/packages/taskdog-server/src/taskdog_server/config/server_config_manager.py
@@ -11,24 +11,6 @@ from taskdog_core.shared.xdg_utils import XDGDirectories
 
 SERVER_CONFIG_FILENAME = "server.toml"
 
-DEFAULT_CORS_ORIGINS = [
-    "http://localhost:3000",
-    "http://localhost:8000",
-    "http://127.0.0.1:3000",
-    "http://127.0.0.1:8000",
-]
-
-
-@dataclass(frozen=True)
-class CorsConfig:
-    """CORS (Cross-Origin Resource Sharing) configuration.
-
-    Attributes:
-        origins: List of allowed CORS origins for API requests (for future Web UI)
-    """
-
-    origins: tuple[str, ...] = tuple(DEFAULT_CORS_ORIGINS)
-
 
 @dataclass(frozen=True)
 class ApiKeyEntry:
@@ -64,11 +46,9 @@ class ServerConfig:
 
     Attributes:
         auth: Authentication configuration
-        cors: CORS configuration
     """
 
     auth: AuthConfig = field(default_factory=AuthConfig)
-    cors: CorsConfig = field(default_factory=CorsConfig)
 
 
 class ServerConfigManager:
@@ -126,15 +106,6 @@ class ServerConfigManager:
             if isinstance(entry, dict) and "name" in entry and "key" in entry
         )
 
-        # Parse CORS configuration
-        cors_data = data.get("cors", {})
-        cors_origins_from_file = cors_data.get("origins", DEFAULT_CORS_ORIGINS)
-        cors_origins = ConfigLoader.get_env_list(
-            "CORS_ORIGINS",
-            cors_origins_from_file,
-        )
-
         return ServerConfig(
             auth=AuthConfig(enabled=enabled, api_keys=api_keys),
-            cors=CorsConfig(origins=tuple(cors_origins)),
         )

--- a/packages/taskdog-server/tests/api/test_app.py
+++ b/packages/taskdog-server/tests/api/test_app.py
@@ -114,15 +114,6 @@ class TestApp:
         data = response.json()
         assert data["status"] == "ok"
 
-    def test_cors_middleware_configured(self):
-        """Test that CORS middleware is configured."""
-        # The app should have CORS middleware
-        # We can verify by checking if OPTIONS requests are handled
-        response = self.client.options("/")
-
-        # Assert - OPTIONS should be allowed
-        assert response.status_code in [200, 405]  # Either OK or Method Not Allowed
-
     def test_routers_registered(self):
         """Test that all routers are registered with correct prefixes."""
         # Check that routes exist for each router


### PR DESCRIPTION
## Summary
- Remove CORS configuration that was added for "future Web UI"
- CLI/TUI use HTTP client directly (not browser), no CORS needed
- MCP uses server-to-server communication, no CORS needed

## Changes
- Remove `CorsConfig` and `DEFAULT_CORS_ORIGINS` from server_config_manager.py
- Remove CORS middleware from app.py
- Remove `[cors]` section from server.toml example
- Remove CORS-related tests and documentation

## Test plan
- [x] `make test-server` passes (268 tests, 86.45% coverage)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)