### PR TITLE
refactor(cli): make --max-hours-per-day option required for optimize

### DIFF
--- a/packages/taskdog-client/src/taskdog_client/analytics_client.py
+++ b/packages/taskdog-client/src/taskdog_client/analytics_client.py
@@ -45,18 +45,18 @@ class AnalyticsClient:
 
     def optimize_schedule(
         self,
-        algorithm: str | None,
+        algorithm: str,
         start_date: datetime | None,
-        max_hours_per_day: float | None,
+        max_hours_per_day: float,
         force_override: bool = True,
         task_ids: list[int] | None = None,
     ) -> OptimizationOutput:
         """Optimize task schedules.
 
         Args:
-            algorithm: Algorithm name (None = server default)
+            algorithm: Algorithm name (required)
             start_date: Optimization start date (None = server current time)
-            max_hours_per_day: Maximum hours per day (None = server default)
+            max_hours_per_day: Maximum hours per day (required)
             force_override: Force override existing schedules
             task_ids: Specific task IDs to optimize (None means all schedulable tasks)
 

--- a/packages/taskdog-client/src/taskdog_client/taskdog_api_client.py
+++ b/packages/taskdog-client/src/taskdog_client/taskdog_api_client.py
@@ -256,18 +256,18 @@ class TaskdogApiClient:
 
     def optimize_schedule(
         self,
-        algorithm: str | None,
+        algorithm: str,
         start_date: datetime | None,
-        max_hours_per_day: float | None,
+        max_hours_per_day: float,
         force_override: bool = True,
         task_ids: list[int] | None = None,
     ) -> OptimizationOutput:
         """Optimize task schedules.
 
         Args:
-            algorithm: Optimization algorithm (None = server default)
+            algorithm: Optimization algorithm (required)
             start_date: Start date for optimization (None = server current time)
-            max_hours_per_day: Max hours per day (None = server default)
+            max_hours_per_day: Max hours per day (required)
             force_override: Force override existing schedules
             task_ids: Specific task IDs to optimize
 

--- a/packages/taskdog-core/src/taskdog_core/controllers/task_analytics_controller.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/task_analytics_controller.py
@@ -81,7 +81,7 @@ class TaskAnalyticsController(BaseTaskController):
         self,
         algorithm: str,
         start_date: datetime,
-        max_hours_per_day: float | None = None,
+        max_hours_per_day: float,
         force_override: bool = True,
         task_ids: list[int] | None = None,
     ) -> OptimizationOutput:
@@ -90,7 +90,7 @@ class TaskAnalyticsController(BaseTaskController):
         Args:
             algorithm: Optimization algorithm name
             start_date: Start date for optimization
-            max_hours_per_day: Maximum hours per day (default: from config)
+            max_hours_per_day: Maximum hours per day (required)
             force_override: Force override existing schedules (default: True)
             task_ids: Specific task IDs to optimize (None means all schedulable tasks)
 
@@ -102,16 +102,9 @@ class TaskAnalyticsController(BaseTaskController):
             TaskNotFoundException: If any specified task_id does not exist
             NoSchedulableTasksError: If no tasks can be scheduled
         """
-        # Apply config default if not specified
-        hours_per_day = (
-            max_hours_per_day
-            if max_hours_per_day is not None
-            else self.config.optimization.max_hours_per_day
-        )
-
         optimize_input = OptimizeScheduleInput(
             start_date=start_date,
-            max_hours_per_day=hours_per_day,
+            max_hours_per_day=max_hours_per_day,
             force_override=force_override,
             algorithm_name=algorithm,
             current_time=datetime.now(),

--- a/packages/taskdog-core/src/taskdog_core/shared/config_manager.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/config_manager.py
@@ -10,22 +10,10 @@ from pathlib import Path
 from taskdog_core.shared.config_loader import ConfigLoader
 from taskdog_core.shared.constants.config_defaults import (
     DEFAULT_END_HOUR,
-    DEFAULT_MAX_HOURS_PER_DAY,
     DEFAULT_PRIORITY,
     DEFAULT_START_HOUR,
 )
 from taskdog_core.shared.xdg_utils import XDGDirectories
-
-
-@dataclass(frozen=True)
-class OptimizationConfig:
-    """Optimization-related configuration.
-
-    Attributes:
-        max_hours_per_day: Maximum work hours per day for schedule optimization
-    """
-
-    max_hours_per_day: float = DEFAULT_MAX_HOURS_PER_DAY
 
 
 @dataclass(frozen=True)
@@ -83,14 +71,12 @@ class Config:
     """Taskdog configuration.
 
     Attributes:
-        optimization: Optimization-related settings
         task: Task-related settings
         time: Time-related settings
         region: Region-related settings (holidays, etc.)
         storage: Storage backend settings
     """
 
-    optimization: OptimizationConfig
     task: TaskConfig
     time: TimeConfig
     region: RegionConfig = field(default_factory=RegionConfig)
@@ -123,22 +109,12 @@ class ConfigManager:
         toml_data = ConfigLoader.load_toml(config_path)
 
         # Parse sections with fallback to defaults, then apply env overrides
-        optimization_data = toml_data.get("optimization", {})
         task_data = toml_data.get("task", {})
         time_data = toml_data.get("time", {})
         region_data = toml_data.get("region", {})
         storage_data = toml_data.get("storage", {})
 
         return Config(
-            optimization=OptimizationConfig(
-                max_hours_per_day=ConfigLoader.get_env(
-                    "OPTIMIZATION_MAX_HOURS_PER_DAY",
-                    optimization_data.get(
-                        "max_hours_per_day", DEFAULT_MAX_HOURS_PER_DAY
-                    ),
-                    float,
-                ),
-            ),
             task=TaskConfig(
                 default_priority=ConfigLoader.get_env(
                     "TASK_DEFAULT_PRIORITY",

--- a/packages/taskdog-core/src/taskdog_core/shared/constants/__init__.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/constants/__init__.py
@@ -10,7 +10,6 @@ from taskdog_core.domain.constants import (
 )
 from taskdog_core.shared.constants.config_defaults import (
     DEFAULT_END_HOUR,
-    DEFAULT_MAX_HOURS_PER_DAY,
     DEFAULT_PRIORITY,
     DEFAULT_START_HOUR,
     MAX_ESTIMATED_DURATION_HOURS,
@@ -53,7 +52,6 @@ __all__ = [
     "DATETIME_FORMAT",
     "DAYS_PER_WEEK",
     "DEFAULT_END_HOUR",
-    "DEFAULT_MAX_HOURS_PER_DAY",
     "DEFAULT_PRIORITY",
     "DEFAULT_SCHEDULE_DAYS",
     "DEFAULT_START_HOUR",

--- a/packages/taskdog-core/src/taskdog_core/shared/constants/config_defaults.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/constants/config_defaults.py
@@ -1,8 +1,5 @@
 """Default configuration values for taskdog."""
 
-# === Optimization Defaults ===
-DEFAULT_MAX_HOURS_PER_DAY = 6.0
-
 # === Task Defaults ===
 DEFAULT_PRIORITY = 5
 

--- a/packages/taskdog-server/src/taskdog_server/api/models/requests.py
+++ b/packages/taskdog-server/src/taskdog_server/api/models/requests.py
@@ -150,8 +150,8 @@ class OptimizeScheduleRequest(BaseModel):
         ..., description="Algorithm name (e.g., 'greedy', 'balanced')"
     )
     start_date: datetime | None = Field(None, description="Optimization start date")
-    max_hours_per_day: float | None = Field(
-        None, gt=0, le=24, description="Maximum hours per day"
+    max_hours_per_day: float = Field(
+        ..., gt=0, le=24, description="Maximum hours per day (required)"
     )
     force_override: bool = Field(
         True, description="Whether to override existing schedules for non-fixed tasks"

--- a/packages/taskdog-server/src/taskdog_server/api/routers/analytics.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/analytics.py
@@ -271,7 +271,7 @@ def run_optimization(
     controller: AnalyticsControllerDep,
     algorithm: str,
     start_date: datetime,
-    max_hours_per_day: float | None,
+    max_hours_per_day: float,
     force_override: bool,
     task_ids: list[int] | None = None,
 ) -> None:
@@ -279,9 +279,9 @@ def run_optimization(
 
     Args:
         controller: Analytics controller
-        algorithm: Algorithm name (required, provided by UI)
+        algorithm: Algorithm name (required)
         start_date: Optimization start date
-        max_hours_per_day: Maximum hours per day (None = controller applies default)
+        max_hours_per_day: Maximum hours per day (required)
         force_override: Force override existing schedules
         task_ids: Specific task IDs to optimize
     """

--- a/packages/taskdog-server/tests/api/models/test_requests.py
+++ b/packages/taskdog-server/tests/api/models/test_requests.py
@@ -201,12 +201,12 @@ class TestOptimizeScheduleRequest:
     def test_valid_minimal_request(self):
         """Test creating request with minimal required fields."""
         # Act
-        request = OptimizeScheduleRequest(algorithm="greedy")
+        request = OptimizeScheduleRequest(algorithm="greedy", max_hours_per_day=6.0)
 
         # Assert
         assert request.algorithm == "greedy"
         assert request.start_date is None
-        assert request.max_hours_per_day is None
+        assert request.max_hours_per_day == 6.0
         assert request.force_override is True
 
     def test_valid_full_request(self):

--- a/packages/taskdog-server/tests/api/routers/test_analytics.py
+++ b/packages/taskdog-server/tests/api/routers/test_analytics.py
@@ -303,8 +303,8 @@ class TestAnalyticsRouter:
         data = response.json()
         assert "background" in data["message"].lower()
 
-    def test_optimize_schedule_with_defaults(self, client, task_factory):
-        """Test schedule optimization with default parameters."""
+    def test_optimize_schedule_with_required_fields(self, client, task_factory):
+        """Test schedule optimization with required parameters."""
         # Arrange - create task
         task_factory.create(
             name="Task",
@@ -313,7 +313,7 @@ class TestAnalyticsRouter:
             status=TaskStatus.PENDING,
         )
 
-        request_data = {"algorithm": "greedy"}
+        request_data = {"algorithm": "greedy", "max_hours_per_day": 6.0}
 
         # Act
         response = client.post("/api/v1/optimize", json=request_data)

--- a/packages/taskdog-server/tests/api/test_app.py
+++ b/packages/taskdog-server/tests/api/test_app.py
@@ -33,7 +33,6 @@ class TestApp:
         self.mock_audit_log_controller = Mock(spec=AuditLogController)
         self.mock_config = MagicMock()
         self.mock_config.task.default_priority = 3
-        self.mock_config.optimization.max_hours_per_day = 8.0
         self.mock_config.region.country = None
 
         # Create mock logger for controllers

--- a/packages/taskdog-server/tests/api/test_dependencies.py
+++ b/packages/taskdog-server/tests/api/test_dependencies.py
@@ -63,7 +63,6 @@ class TestDependencyInjection:
             config_path = f.name
             # Write minimal config
             f.write("[task]\ndefault_priority = 3\n")
-            f.write("[optimization]\nmax_hours_per_day = 8.0\n")
             f.write('[storage]\nbackend = "sqlite"\n')
             f.write('database_url = "sqlite:///:memory:"\n')
 
@@ -276,7 +275,6 @@ class TestInitializeApiContext:
         with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".toml") as f:
             config_path = f.name
             f.write("[task]\ndefault_priority = 3\n")
-            f.write("[optimization]\nmax_hours_per_day = 8.0\n")
             f.write('[storage]\nbackend = "sqlite"\n')
             f.write('database_url = "sqlite:///:memory:"\n')
 
@@ -314,7 +312,6 @@ class TestInitializeApiContext:
         with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".toml") as f:
             config_path = f.name
             f.write("[task]\ndefault_priority = 3\n")
-            f.write("[optimization]\nmax_hours_per_day = 8.0\n")
             f.write('[storage]\nbackend = "sqlite"\n')
             f.write('database_url = "sqlite:///:memory:"\n')
             f.write('[region]\ncountry = "US"\n')
@@ -349,7 +346,6 @@ class TestInitializeApiContext:
         with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".toml") as f:
             config_path = f.name
             f.write("[task]\ndefault_priority = 3\n")
-            f.write("[optimization]\nmax_hours_per_day = 8.0\n")
             f.write('[storage]\nbackend = "sqlite"\n')
             f.write('database_url = "sqlite:///:memory:"\n')
             f.write('[region]\ncountry = "XX"\n')  # Invalid country code

--- a/packages/taskdog-ui/src/taskdog/cli/commands/optimize.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/optimize.py
@@ -63,8 +63,8 @@ Examples:
     "--max-hours-per-day",
     "-m",
     type=click.FloatRange(min=0, min_open=True, max=24.0),
-    default=None,
-    help="Max work hours per day (default: from config or 6.0)",
+    required=True,
+    help="Max work hours per day (required, e.g., 6.0 or 8.0)",
 )
 @click.option(
     "--algorithm",
@@ -91,8 +91,8 @@ def optimize_command(
     ctx: click.Context,
     task_ids: tuple[int, ...],
     start_date: datetime | None,
-    max_hours_per_day: float | None,
-    algorithm: str | None,
+    max_hours_per_day: float,
+    algorithm: str,
     force: bool,
 ) -> None:
     """Auto-generate optimal schedules for tasks."""
@@ -107,7 +107,7 @@ def optimize_command(
     result = api_client.optimize_schedule(
         algorithm=algorithm,
         start_date=start_date,
-        max_hours_per_day=max_hours_per_day,  # None if not provided, server applies default
+        max_hours_per_day=max_hours_per_day,
         force_override=force,
         task_ids=task_ids_list,
     )

--- a/packages/taskdog-ui/src/taskdog/tui/commands/optimize.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/optimize.py
@@ -62,14 +62,13 @@ class OptimizeCommand(TUICommandBase):
         """Execute the optimize command."""
 
         def handle_optimization_settings(
-            settings: tuple[str, float | None, datetime, bool] | None,
+            settings: tuple[str, float, datetime, bool] | None,
         ) -> None:
             """Handle the optimization settings from the dialog.
 
             Args:
                 settings: Tuple of (algorithm_name, max_hours_per_day, start_date, force_override),
                          or None if cancelled.
-                         max_hours_per_day can be None (server will apply config default)
             """
             if settings is None:
                 return  # User cancelled
@@ -77,7 +76,6 @@ class OptimizeCommand(TUICommandBase):
             algorithm, max_hours, start_date, force_override = settings
 
             # Use API client to optimize schedules
-            # max_hours can be None - server will apply config default
             result = self.context.api_client.optimize_schedule(
                 algorithm=algorithm,
                 start_date=start_date,

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/algorithm_selection_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/algorithm_selection_dialog.py
@@ -16,7 +16,7 @@ from taskdog.tui.widgets.vi_select import ViSelect
 
 
 class AlgorithmSelectionDialog(
-    BaseModalDialog[tuple[str, float | None, datetime, bool] | None]
+    BaseModalDialog[tuple[str, float, datetime, bool] | None]
 ):
     """Modal screen for selecting optimization algorithm, max hours, and start date."""
 
@@ -79,12 +79,16 @@ class AlgorithmSelectionDialog(
                 ]
                 yield ViSelect(options, id="algorithm-select", allow_blank=False)
 
-                yield Label("Max Hours per Day:", classes="field-label")
+                yield Label(
+                    "Max Hours per Day [red]*[/red]:",
+                    classes="field-label",
+                    markup=True,
+                )
                 yield Input(
-                    placeholder="Enter max hours per day (typically 6-8)",
+                    placeholder="Enter max hours per day (required, e.g., 6 or 8)",
                     id="max-hours-input",
                     value="",
-                    valid_empty=True,
+                    valid_empty=False,
                     validators=[Number(minimum=0.1, maximum=24)],
                 )
 
@@ -153,6 +157,14 @@ class AlgorithmSelectionDialog(
             return
         selected_algo = str(algorithm_select.value)
 
+        # Validate max hours (required)
+        max_hours_str = max_hours_input.value.strip()
+        if not max_hours_str:
+            self._show_validation_error(
+                "Max hours per day is required", max_hours_input
+            )
+            return
+
         # Validate start date (required)
         start_date_str = start_date_input.value.strip()
         if not start_date_str:
@@ -169,8 +181,7 @@ class AlgorithmSelectionDialog(
             return
 
         # Parse values
-        max_hours_str = max_hours_input.value.strip()
-        max_hours = float(max_hours_str) if max_hours_str else None
+        max_hours = float(max_hours_str)
 
         start_date_validator = StartDateTextualValidator()
         start_date = start_date_validator.parse(start_date_str)

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_optimize_command.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_optimize_command.py
@@ -32,7 +32,7 @@ class TestOptimizeCommand:
 
         # Execute
         result = self.runner.invoke(
-            optimize_command, ["-a", "greedy"], obj=self.cli_context
+            optimize_command, ["-a", "greedy", "-m", "6.0"], obj=self.cli_context
         )
 
         # Verify
@@ -51,7 +51,9 @@ class TestOptimizeCommand:
 
         # Execute
         result = self.runner.invoke(
-            optimize_command, ["-a", "greedy", "1", "2", "3"], obj=self.cli_context
+            optimize_command,
+            ["-a", "greedy", "-m", "6.0", "1", "2", "3"],
+            obj=self.cli_context,
         )
 
         # Verify
@@ -70,7 +72,9 @@ class TestOptimizeCommand:
 
         # Execute
         result = self.runner.invoke(
-            optimize_command, ["--algorithm", "balanced"], obj=self.cli_context
+            optimize_command,
+            ["--algorithm", "balanced", "-m", "6.0"],
+            obj=self.cli_context,
         )
 
         # Verify
@@ -110,7 +114,9 @@ class TestOptimizeCommand:
 
         # Execute
         result = self.runner.invoke(
-            optimize_command, ["-a", "greedy", "--force"], obj=self.cli_context
+            optimize_command,
+            ["-a", "greedy", "-m", "6.0", "--force"],
+            obj=self.cli_context,
         )
 
         # Verify
@@ -130,7 +136,7 @@ class TestOptimizeCommand:
         # Execute
         result = self.runner.invoke(
             optimize_command,
-            ["-a", "greedy", "--start-date", "2025-10-15"],
+            ["-a", "greedy", "-m", "6.0", "--start-date", "2025-10-15"],
             obj=self.cli_context,
         )
 
@@ -150,7 +156,7 @@ class TestOptimizeCommand:
 
         # Execute
         result = self.runner.invoke(
-            optimize_command, ["-a", "greedy"], obj=self.cli_context
+            optimize_command, ["-a", "greedy", "-m", "6.0"], obj=self.cli_context
         )
 
         # Verify
@@ -168,7 +174,7 @@ class TestOptimizeCommand:
 
         # Execute
         result = self.runner.invoke(
-            optimize_command, ["-a", "greedy"], obj=self.cli_context
+            optimize_command, ["-a", "greedy", "-m", "6.0"], obj=self.cli_context
         )
 
         # Verify
@@ -185,7 +191,7 @@ class TestOptimizeCommand:
 
         # Execute
         result = self.runner.invoke(
-            optimize_command, ["-a", "greedy"], obj=self.cli_context
+            optimize_command, ["-a", "greedy", "-m", "6.0"], obj=self.cli_context
         )
 
         # Verify
@@ -204,7 +210,7 @@ class TestOptimizeCommand:
 
         # Execute
         result = self.runner.invoke(
-            optimize_command, ["-a", "greedy"], obj=self.cli_context
+            optimize_command, ["-a", "greedy", "-m", "6.0"], obj=self.cli_context
         )
 
         # Verify
@@ -219,7 +225,7 @@ class TestOptimizeCommand:
 
         # Execute
         result = self.runner.invoke(
-            optimize_command, ["-a", "greedy"], obj=self.cli_context
+            optimize_command, ["-a", "greedy", "-m", "6.0"], obj=self.cli_context
         )
 
         # Verify
@@ -228,8 +234,21 @@ class TestOptimizeCommand:
 
     def test_missing_algorithm_fails(self):
         """Test that missing algorithm option causes error."""
-        # Execute without -a option
-        result = self.runner.invoke(optimize_command, [], obj=self.cli_context)
+        # Execute without -a option (but with -m)
+        result = self.runner.invoke(
+            optimize_command, ["-m", "6.0"], obj=self.cli_context
+        )
+
+        # Verify - should fail with missing required option
+        assert result.exit_code != 0
+        assert "Missing option" in result.output or "required" in result.output.lower()
+
+    def test_missing_max_hours_fails(self):
+        """Test that missing --max-hours-per-day option causes error."""
+        # Execute without -m option (but with -a)
+        result = self.runner.invoke(
+            optimize_command, ["-a", "greedy"], obj=self.cli_context
+        )
 
         # Verify - should fail with missing required option
         assert result.exit_code != 0

--- a/packages/taskdog-ui/tests/tui/commands/test_optimize.py
+++ b/packages/taskdog-ui/tests/tui/commands/test_optimize.py
@@ -202,7 +202,7 @@ class TestOptimizeCommandExecute:
         self.command.execute()
 
         callback = self.mock_app.push_screen.call_args[0][1]
-        callback(("greedy", None, datetime.now(), False))
+        callback(("greedy", 6.0, datetime.now(), False))
 
         self.command.reload_tasks.assert_called_once()
 
@@ -256,7 +256,7 @@ class TestOptimizeCommandExecute:
         self.command.execute()
 
         callback = self.mock_app.push_screen.call_args[0][1]
-        callback(("greedy", None, datetime.now(), False))
+        callback(("greedy", 6.0, datetime.now(), False))
 
         self.command.notify_warning.assert_called_once()
         message = self.command.notify_warning.call_args[0][0]
@@ -277,19 +277,3 @@ class TestOptimizeCommandExecute:
         callback(("greedy", 8.0, datetime.now(), False))
 
         self.command.notify_warning.assert_not_called()
-
-    def test_passes_none_max_hours_to_api(self) -> None:
-        """Test that None max_hours is passed correctly to API."""
-        self.mock_context.api_client.get_algorithm_metadata.return_value = []
-        result = create_mock_optimization_output(successful_count=1)
-        self.mock_context.api_client.optimize_schedule.return_value = result
-        self.command.reload_tasks = MagicMock()
-
-        self.command.execute()
-
-        callback = self.mock_app.push_screen.call_args[0][1]
-        start_date = datetime(2025, 1, 6)
-        callback(("greedy", None, start_date, False))  # max_hours is None
-
-        call_kwargs = self.mock_context.api_client.optimize_schedule.call_args
-        assert call_kwargs[1]["max_hours_per_day"] is None


### PR DESCRIPTION
## Summary
- Remove the config-based default for `max_hours_per_day` and make it a required option for the optimize command
- This follows the same pattern as the recent `--algorithm` change (#566)

## Changes
- **CLI**: Make `--max-hours-per-day` required instead of optional with default
- **Server**: Make `max_hours_per_day` required in `OptimizeScheduleRequest`
- **Controller**: Remove fallback to config default
- **Config**: Remove `OptimizationConfig` class and `DEFAULT_MAX_HOURS_PER_DAY`
- **TUI**: Make max hours required in `AlgorithmSelectionDialog`
- **API Client**: Update type signatures to require `max_hours_per_day`

## Test plan
- [x] All existing tests pass with updates
- [x] Linter passes
- [x] Type checker passes
- [ ] Manual test: `taskdog optimize -a greedy` should fail with missing `--max-hours-per-day`
- [ ] Manual test: `taskdog optimize -a greedy -m 6.0` should succeed

🤖 Generated with [Claude Code](https://claude.ai/code)