### PR TITLE
chore(core): remove dead code from shared constants and utils

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/shared/constants/__init__.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/constants/__init__.py
@@ -15,13 +15,11 @@ from taskdog_core.shared.constants.config_defaults import (
     MAX_ESTIMATED_DURATION_HOURS,
 )
 from taskdog_core.shared.constants.file_management import (
-    BACKUP_FILE_SUFFIX,
     CONFIG_FILE_NAME,
     NOTE_FILE_EXTENSION,
     NOTES_DIR_NAME,
-    TASKS_FILE_NAME,
 )
-from taskdog_core.shared.constants.formats import DATETIME_FORMAT, ISO_8601_FORMAT
+from taskdog_core.shared.constants.formats import DATETIME_FORMAT
 from taskdog_core.shared.constants.status_verbs import StatusVerbs
 from taskdog_core.shared.constants.time import (
     DAYS_PER_WEEK,
@@ -47,7 +45,6 @@ WORKLOAD_COMFORTABLE_HOURS = 6.0  # Green zone: comfortable daily load
 WORKLOAD_MODERATE_HOURS = 8.0  # Yellow zone: moderate daily load
 
 __all__ = [
-    "BACKUP_FILE_SUFFIX",
     "CONFIG_FILE_NAME",
     "DATETIME_FORMAT",
     "DAYS_PER_WEEK",
@@ -55,7 +52,6 @@ __all__ = [
     "DEFAULT_PRIORITY",
     "DEFAULT_SCHEDULE_DAYS",
     "DEFAULT_START_HOUR",
-    "ISO_8601_FORMAT",
     "MAX_ESTIMATED_DURATION_HOURS",
     "MAX_HOURS_PER_DAY_LIMIT",
     "MAX_TAGS_PER_TASK",
@@ -69,7 +65,6 @@ __all__ = [
     "SORT_SENTINEL_FUTURE",
     "SORT_SENTINEL_PAST",
     "SUNDAY",
-    "TASKS_FILE_NAME",
     "WEEKDAY_THRESHOLD",
     "WORKLOAD_COMFORTABLE_HOURS",
     "WORKLOAD_MODERATE_HOURS",

--- a/packages/taskdog-core/src/taskdog_core/shared/constants/file_management.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/constants/file_management.py
@@ -1,11 +1,9 @@
 """File and directory management constants."""
 
 # File Extensions
-BACKUP_FILE_SUFFIX = ".json.bak"
 NOTE_FILE_EXTENSION = ".md"
 
 # File Names
-TASKS_FILE_NAME = "tasks.json"
 CONFIG_FILE_NAME = "core.toml"
 
 # Directory Names

--- a/packages/taskdog-core/src/taskdog_core/shared/constants/formats.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/constants/formats.py
@@ -6,6 +6,3 @@ throughout the application. These are technical display concerns, not business l
 
 # Datetime format used throughout the application for internal storage and display
 DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
-
-# ISO 8601 format for API compatibility (future use)
-ISO_8601_FORMAT = "%Y-%m-%dT%H:%M:%S%z"

--- a/packages/taskdog-core/src/taskdog_core/shared/utils/__init__.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/utils/__init__.py
@@ -1,15 +1,11 @@
 """Shared utilities package."""
 
 from taskdog_core.shared.utils.datetime_parser import (
-    format_iso_date,
-    format_iso_datetime,
     parse_iso_date,
     parse_iso_datetime,
 )
 
 __all__ = [
-    "format_iso_date",
-    "format_iso_datetime",
     "parse_iso_date",
     "parse_iso_datetime",
 ]

--- a/packages/taskdog-core/src/taskdog_core/shared/utils/datetime_parser.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/utils/datetime_parser.py
@@ -50,34 +50,6 @@ def parse_iso_datetime(datetime_str: str | None) -> datetime | None:
     return datetime.fromisoformat(datetime_str)
 
 
-def format_iso_datetime(dt: datetime | None) -> str | None:
-    """Format datetime object to ISO 8601 string.
-
-    Args:
-        dt: Datetime object or None
-
-    Returns:
-        ISO format string, or None if input is None
-    """
-    if dt is None:
-        return None
-    return dt.isoformat()
-
-
-def format_iso_date(d: date | None) -> str | None:
-    """Format date object to ISO 8601 string.
-
-    Args:
-        d: Date object or None
-
-    Returns:
-        ISO format string (YYYY-MM-DD), or None if input is None
-    """
-    if d is None:
-        return None
-    return d.isoformat()
-
-
 def parse_date_set(date_strings: Iterable[str]) -> set[date]:
     """Parse iterable of ISO date strings to set of date objects.
 

--- a/packages/taskdog-core/tests/shared/test_iso_datetime_parser.py
+++ b/packages/taskdog-core/tests/shared/test_iso_datetime_parser.py
@@ -6,8 +6,6 @@ import pytest
 
 from taskdog_core.shared.utils.datetime_parser import (
     format_date_dict,
-    format_iso_date,
-    format_iso_datetime,
     parse_date_dict,
     parse_iso_date,
     parse_iso_datetime,
@@ -89,40 +87,6 @@ class TestParseIsoDatetime:
         """Invalid format should raise ValueError."""
         with pytest.raises(ValueError):
             parse_iso_datetime(invalid_input)
-
-
-class TestFormatIsoDatetime:
-    """Test cases for format_iso_datetime."""
-
-    def test_format_datetime(self):
-        """Datetime should format to ISO string."""
-        dt = datetime(2025, 1, 15, 10, 30, 0)
-        result = format_iso_datetime(dt)
-        assert result == "2025-01-15T10:30:00"
-
-    def test_format_datetime_with_micros(self):
-        """Datetime with microseconds should include them."""
-        dt = datetime(2025, 1, 15, 10, 30, 0, 123456)
-        result = format_iso_datetime(dt)
-        assert result == "2025-01-15T10:30:00.123456"
-
-    def test_none_returns_none(self):
-        """None input should return None."""
-        assert format_iso_datetime(None) is None
-
-
-class TestFormatIsoDate:
-    """Test cases for format_iso_date."""
-
-    def test_format_date(self):
-        """Date should format to ISO string."""
-        d = date(2025, 1, 15)
-        result = format_iso_date(d)
-        assert result == "2025-01-15"
-
-    def test_none_returns_none(self):
-        """None input should return None."""
-        assert format_iso_date(None) is None
 
 
 class TestParseDateDict:


### PR DESCRIPTION
## Summary

- Remove unused constants from `file_management.py`: `BACKUP_FILE_SUFFIX`, `TASKS_FILE_NAME` (legacy JSON format, replaced by SQLite)
- Remove unused constant from `formats.py`: `ISO_8601_FORMAT` (marked "future use" but never used)
- Remove test-only functions from `datetime_parser.py`: `format_iso_datetime`, `format_iso_date`
- Update corresponding exports and tests

## Test plan

- [x] All tests pass (1028 passed, 92% coverage)
- [x] Type check passes (mypy)
- [x] Lint passes (ruff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)