### PR TITLE
chore(docs): remove unused optimization config from docs and examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,8 @@ The repository uses UV workspace with three packages:
 **Config**: Optional TOML files at `$XDG_CONFIG_HOME/taskdog/` (fallback: `~/.config/taskdog/`)
 
 - **core.toml** (business logic):
-  - Sections: `[optimization]`, `[time]`, `[region]`, `[storage]`
-  - Settings: max_hours_per_day, default_start_hour, default_end_hour, country, database_url, backend
+  - Sections: `[time]`, `[region]`, `[storage]`
+  - Settings: default_start_hour, default_end_hour, country, database_url, backend
 - **server.toml** (server-specific):
   - Sections: `[auth]`
   - Settings: enabled, api_keys

--- a/README.md
+++ b/README.md
@@ -227,9 +227,6 @@ theme = "tokyo-night"
 **Core config**: `~/.config/taskdog/core.toml`
 
 ```toml
-[optimization]
-max_hours_per_day = 8.0
-
 [region]
 country = "JP"
 ```

--- a/docs/API.md
+++ b/docs/API.md
@@ -484,12 +484,12 @@ Run schedule optimization
 }
 ```
 
-**All fields optional:**
+**Fields:**
 
-- `start_date` - Optimization start date (default: today)
-- `max_hours_per_day` - Daily hour limit (default: from config or 6.0)
-- `algorithm` - Algorithm to use (default: greedy)
-- `force` - Force re-optimization even if tasks already scheduled
+- `algorithm` - Algorithm to use (required)
+- `max_hours_per_day` - Daily hour limit (required)
+- `start_date` - Optimization start date (optional, default: today)
+- `force` - Force re-optimization even if tasks already scheduled (optional, default: true)
 
 **Available algorithms:**
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -11,8 +11,6 @@ Complete guide to configuring Taskdog.
 - [Configuration Sections](#configuration-sections)
   - [API Settings](#api-settings-required)
   - [UI Settings](#ui-settings)
-  - [Optimization Settings](#optimization-settings)
-  - [Task Settings](#task-settings)
   - [Time Settings](#time-settings)
   - [Region Settings](#region-settings)
   - [Storage Settings](#storage-settings)
@@ -122,39 +120,6 @@ theme = "textual-dark"        # TUI theme (default: "textual-dark")
   - `gruvbox` - Gruvbox color scheme
   - `solarized-light` - Solarized Light color scheme
 
-### Optimization Settings
-
-The `[optimization]` section configures schedule optimization behavior.
-
-```toml
-[optimization]
-max_hours_per_day = 6.0        # Default work hours per day (default: 6.0)
-```
-
-**Fields:**
-
-- `max_hours_per_day` (float) - Maximum hours to schedule per day. Used by optimizer to distribute workload.
-
-**Algorithm Selection:**
-
-The optimization algorithm is specified via CLI `--algorithm` flag (default: "greedy"). Available options:
-
-- `greedy` - Schedule highest priority tasks first
-- `balanced` - Distribute workload evenly across days
-- `backward` - Schedule from deadline backwards
-- `priority_first` - Strict priority ordering
-- `earliest_deadline` - Schedule tasks with earliest deadlines first
-- `round_robin` - Rotate through tasks to minimize context switching
-- `dependency_aware` - Prioritize tasks that unblock others
-- `genetic` - Use genetic algorithm for optimization
-- `monte_carlo` - Use Monte Carlo simulation
-
-**CLI Override:**
-
-```bash
-taskdog optimize --max-hours-per-day 8 --algorithm balanced
-```
-
 ### Time Settings
 
 The `[time]` section configures business hours.
@@ -246,8 +211,6 @@ These variables override core configuration (core.toml):
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `TASKDOG_OPTIMIZATION_MAX_HOURS_PER_DAY` | float | `6.0` | Maximum work hours per day |
-| `TASKDOG_OPTIMIZATION_DEFAULT_ALGORITHM` | string | `"greedy"` | Default scheduling algorithm |
 | `TASKDOG_TIME_DEFAULT_START_HOUR` | int | `9` | Business day start hour |
 | `TASKDOG_TIME_DEFAULT_END_HOUR` | int | `18` | Business day end hour |
 | `TASKDOG_REGION_COUNTRY` | string | `None` | ISO 3166-1 alpha-2 country code |
@@ -258,7 +221,6 @@ These variables override core configuration (core.toml):
 
 ```bash
 # Production settings
-export TASKDOG_OPTIMIZATION_MAX_HOURS_PER_DAY=8.0
 export TASKDOG_REGION_COUNTRY=US
 ```
 
@@ -333,10 +295,6 @@ Complete configuration with all options:
 # UI Settings
 [ui]
 theme = "tokyo-night"
-
-# Optimization Settings
-[optimization]
-max_hours_per_day = 8.0
 
 # Time Settings
 [time]
@@ -421,12 +379,9 @@ enabled = false
 
 ### Work Schedule Configuration
 
-Configure for 8-hour work days with strict 9-18 schedule:
+Configure for strict 9-18 schedule with US holidays:
 
 ```toml
-[optimization]
-max_hours_per_day = 8.0
-
 [time]
 default_start_hour = 9
 default_end_hour = 18
@@ -435,7 +390,11 @@ default_end_hour = 18
 country = "US"  # Avoid US holidays
 ```
 
-Use `--algorithm balanced` when running the optimize command to distribute workload evenly.
+Use `--max-hours-per-day` and `--algorithm` options when running the optimize command:
+
+```bash
+taskdog optimize --max-hours-per-day 8 --algorithm balanced
+```
 
 ### Custom Theme
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -201,17 +201,15 @@ port = 8000
 **Only edit core.toml**:
 
 ```toml
-[task]
-default_priority = 7  # Higher default priority
-
-[optimization]
-max_hours_per_day = 8.0  # Longer work days
-
 [region]
 country = "US"  # Use US holidays
 ```
 
-CLI needs no changes - it automatically uses server's settings. Use `--algorithm balanced` when running the optimize command if needed.
+CLI needs no changes - it automatically uses server's settings. Use `--max-hours-per-day` and `--algorithm` options when running the optimize command:
+
+```bash
+taskdog optimize --max-hours-per-day 8 --algorithm balanced
+```
 
 ## Environment Variables
 

--- a/examples/core.toml
+++ b/examples/core.toml
@@ -26,21 +26,6 @@ default_start_hour = 9
 default_end_hour = 18
 
 # =============================================================================
-# Schedule Optimization Settings
-# =============================================================================
-#
-# Settings for the schedule optimizer.
-
-[optimization]
-# Maximum work hours per day for optimization (default: 6.0)
-# Used when auto-scheduling tasks to distribute workload
-max_hours_per_day = 6.0
-
-# Algorithm is specified via CLI --algorithm flag (default: "greedy")
-# Available algorithms: greedy, balanced, backward, priority_first,
-# earliest_deadline, round_robin, dependency_aware, genetic, monte_carlo
-
-# =============================================================================
 # Region Settings
 # =============================================================================
 #

--- a/packages/taskdog-server/README.md
+++ b/packages/taskdog-server/README.md
@@ -119,9 +119,6 @@ enabled = false
 Core configuration: `~/.config/taskdog/core.toml`
 
 ```toml
-[optimization]
-max_hours_per_day = 6.0
-
 [region]
 country = "JP"
 ```


### PR DESCRIPTION
## Summary

- Remove `[optimization]` section and `max_hours_per_day` default value references from documentation and example files
- These settings were never loaded by ConfigManager - the `--max-hours-per-day` and `--algorithm` options are required CLI arguments with no config file defaults
- Update API documentation to correctly mark `algorithm` and `max_hours_per_day` as required fields

## Test plan

- [x] All tests pass (`make test`)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)