### PR TITLE
feat(ui): add dim style to finished tasks for better visual distinction

### DIFF
--- a/packages/taskdog-ui/src/taskdog/presenters/gantt_presenter.py
+++ b/packages/taskdog-ui/src/taskdog/presenters/gantt_presenter.py
@@ -56,10 +56,10 @@ class GanttPresenter:
         Returns:
             TaskGanttRowViewModel with presentation-ready data
         """
-        # Apply strikethrough for finished tasks
+        # Apply strikethrough + dim for finished tasks
         formatted_name = task.name
         if task.is_finished:
-            formatted_name = f"[strike]{task.name}[/strike]"
+            formatted_name = f"[strike dim]{task.name}[/strike dim]"
 
         # Format estimated duration
         formatted_estimated_duration = self._format_estimated_duration(

--- a/packages/taskdog-ui/src/taskdog/renderers/rich_table_renderer.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/rich_table_renderer.py
@@ -246,7 +246,9 @@ class RichTableRenderer(RichRendererBase):
         # Field value extractors mapping
         field_extractors: dict[str, Callable[[TaskRowViewModel], str]] = {
             "id": lambda t: str(t.id),
-            "name": lambda t: f"[strike]{t.name}[/strike]" if t.is_finished else t.name,
+            "name": lambda t: f"[strike dim]{t.name}[/strike dim]"
+            if t.is_finished
+            else t.name,
             "note": lambda t: "📝" if t.has_notes else "",
             "priority": lambda t: str(t.priority),
             "status": lambda t: self._format_status(t),

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/task_table_row_builder.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/task_table_row_builder.py
@@ -52,11 +52,11 @@ class TaskTableRowBuilder:
         return [
             # ID column
             ColumnConfig(formatter=lambda vm: str(vm.id)),
-            # Name column (left-aligned, strikethrough for finished)
+            # Name column (left-aligned, strikethrough + dim for finished)
             ColumnConfig(
                 formatter=lambda vm: self._format_name(vm.name),
                 justification="left",
-                style_func=lambda vm: "strike" if vm.is_finished else None,
+                style_func=lambda vm: "strike dim" if vm.is_finished else None,
             ),
             # Status column (color-coded)
             ColumnConfig(

--- a/packages/taskdog-ui/tests/presentation/renderers/test_rich_gantt_renderer.py
+++ b/packages/taskdog-ui/tests/presentation/renderers/test_rich_gantt_renderer.py
@@ -38,7 +38,7 @@ class TestRichGanttRendererBuildTable:
         self.task2 = TaskGanttRowViewModel(
             id=2,
             name="Task 2",
-            formatted_name="[strike]Task 2[/strike]",
+            formatted_name="[strike dim]Task 2[/strike dim]",
             estimated_duration=4.0,
             formatted_estimated_duration="4.0",
             status=TaskStatus.COMPLETED,

--- a/packages/taskdog-ui/tests/presentation/renderers/test_rich_table_renderer.py
+++ b/packages/taskdog-ui/tests/presentation/renderers/test_rich_table_renderer.py
@@ -124,7 +124,7 @@ class TestRichTableRenderer:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "is_finished,expected_text,has_strikethrough",
+        "is_finished,expected_text,has_strikethrough_dim",
         [
             (False, "Test Task 1", False),
             (True, "Completed Task", True),
@@ -132,17 +132,17 @@ class TestRichTableRenderer:
         ids=["unfinished_task", "finished_task"],
     )
     def test_get_field_value_name_field(
-        self, is_finished, expected_text, has_strikethrough
+        self, is_finished, expected_text, has_strikethrough_dim
     ):
-        """Test _get_field_value returns name with optional strikethrough for finished tasks."""
+        """Test _get_field_value returns name with optional strikethrough+dim for finished tasks."""
         task = self.task2 if is_finished else self.task1
         result = self.renderer._get_field_value(task, "name")
 
-        if has_strikethrough:
-            assert result == f"[strike]{expected_text}[/strike]"
+        if has_strikethrough_dim:
+            assert result == f"[strike dim]{expected_text}[/strike dim]"
         else:
             assert result == expected_text
-            assert "[strike]" not in result
+            assert "[strike dim]" not in result
 
     @pytest.mark.parametrize(
         "has_notes,expected",

--- a/packages/taskdog-ui/tests/presentation/tui/widgets/test_task_table_row_builder.py
+++ b/packages/taskdog-ui/tests/presentation/tui/widgets/test_task_table_row_builder.py
@@ -39,8 +39,8 @@ class TestTaskTableRowBuilder:
         assert str(row[1]) == "Test task"  # Name
         assert str(row[3]) == "2"  # Priority
 
-    def test_build_row_completed_task_has_strikethrough(self):
-        """Test that completed tasks have strikethrough style on name."""
+    def test_build_row_completed_task_has_strikethrough_and_dim(self):
+        """Test that completed tasks have strikethrough and dim style on name."""
         task = Task(
             id=1,
             name="Completed task",
@@ -50,9 +50,9 @@ class TestTaskTableRowBuilder:
 
         row = self.builder.build_row(task)
 
-        # Name column should have strikethrough style
+        # Name column should have strikethrough + dim style
         name_text = row[1]
-        assert name_text.style == "strike"
+        assert name_text.style == "strike dim"
 
     def test_build_row_pending_task_no_strikethrough(self):
         """Test that non-completed tasks don't have strikethrough."""


### PR DESCRIPTION
## Summary
- Add dim styling in addition to strikethrough for completed/canceled tasks
- Applied to the name column across all views:
  - CLI `table` command
  - CLI `gantt` command
  - TUI task table
  - TUI Gantt view

This improves visual distinction between active and finished tasks.

## Test plan
- [x] Run `make test-ui` - all 891 tests pass
- [x] Manual verification: run `taskdog tui` and check completed tasks display with strikethrough + dim
- [x] Manual verification: run `taskdog table` and check completed tasks display with strikethrough + dim
- [x] Manual verification: run `taskdog gantt` and check completed tasks display with strikethrough + dim

🤖 Generated with [Claude Code](https://claude.com/claude-code)