### PR TITLE
perf(cli): remove redundant health check on startup

### DIFF
--- a/packages/taskdog-ui/src/taskdog/cli_main.py
+++ b/packages/taskdog-ui/src/taskdog/cli_main.py
@@ -102,25 +102,13 @@ def cli(
     effective_api_key = api_key if api_key is not None else config.api.api_key
 
     # Initialize API client (required for all CLI commands)
+    # Health check is deferred to actual API calls for better performance
     from taskdog_client import TaskdogApiClient
 
-    try:
-        api_client = TaskdogApiClient(
-            base_url=f"http://{api_host}:{api_port}",
-            api_key=effective_api_key,
-        )
-        # Test connection (uses _safe_request which includes API key header)
-        if not api_client.check_health():
-            raise Exception("Health check failed")
-    except Exception as e:
-        console_writer.error(
-            "connecting to API server",
-            Exception(
-                f"Cannot connect to API server at {api_host}:{api_port}. "
-                f"Please start the server first with 'taskdog-server'. Error: {e}"
-            ),
-        )
-        ctx.exit(1)
+    api_client = TaskdogApiClient(
+        base_url=f"http://{api_host}:{api_port}",
+        api_key=effective_api_key,
+    )
 
     # Store in CliContext for type-safe access
     ctx.ensure_object(dict)

--- a/packages/taskdog-ui/tests/presentation/cli/test_cli_main.py
+++ b/packages/taskdog-ui/tests/presentation/cli/test_cli_main.py
@@ -119,32 +119,6 @@ class TestCliGlobalOptions:
         assert "API server host" in result.output
         assert "API server port" in result.output
 
-    @patch("taskdog_client.TaskdogApiClient")
-    @patch("taskdog.cli_main.load_cli_config")
-    def test_connection_error_shows_overridden_host_port(
-        self, mock_load_config, mock_api_client
-    ):
-        """Test connection error message uses overridden host/port."""
-        # Setup
-        mock_config = MagicMock()
-        mock_config.api.host = "127.0.0.1"
-        mock_config.api.port = 8000
-        mock_load_config.return_value = mock_config
-
-        mock_client_instance = MagicMock()
-        # check_health() raises Exception on connection failure
-        mock_client_instance.check_health.side_effect = Exception("Connection refused")
-        mock_api_client.return_value = mock_client_instance
-
-        # Execute
-        result = self.runner.invoke(
-            cli, ["--host", "192.168.1.100", "--port", "3000", "table"]
-        )
-
-        # Verify - error message should show overridden values
-        assert result.exit_code == 1
-        assert "192.168.1.100:3000" in result.output
-
     def test_port_validation_too_low(self):
         """Test that port 0 is rejected."""
         # Execute


### PR DESCRIPTION
## Summary

- Remove the health check performed on every CLI invocation
- Eliminates ~50-200ms of network latency per command
- Connection errors are still properly handled by individual API calls

## Motivation

The health check was redundant because:
- The API client already raises `ServerConnectionError` on connection failure
- Each command's API call will fail with a clear error message if the server is unavailable
- The health check added unnecessary latency to every CLI command, even when the server was running normally

## Changes

- `cli_main.py`: Remove `check_health()` call and try-except block (17 lines → 4 lines)
- `test_cli_main.py`: Remove obsolete test for health check error handling

## Test plan

- [x] All existing tests pass (890 passed)
- [x] Pre-commit hooks pass (ruff, mypy, unit tests)
- [x] Manual verification: CLI commands work correctly with server running
- [x] Manual verification: CLI shows appropriate error when server is down (via API call failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)