### PR TITLE
feat(tui): optimize only selected tasks in TUI

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/commands/base.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/base.py
@@ -177,7 +177,22 @@ class TUICommandBase(ABC):  # noqa: B024
             return []
         return self.app.main_screen.task_table.get_selected_task_ids()
 
-    def clear_selection(self) -> None:
+    def get_explicitly_selected_task_ids(self) -> list[int]:
+        """Get only explicitly selected task IDs (no cursor fallback).
+
+        Unlike get_selected_task_ids(), this method does NOT fall back to
+        the cursor position when no tasks are explicitly selected.
+        Use this when you need to distinguish between "no selection" and
+        "single task selected".
+
+        Returns:
+            List of explicitly selected task IDs, or empty list if none selected
+        """
+        if not self.app.main_screen or not self.app.main_screen.task_table:
+            return []
+        return self.app.main_screen.task_table.get_explicitly_selected_task_ids()
+
+    def clear_task_selection(self) -> None:
         """Clear all task selections in the table.
 
         Called after batch operations complete to reset selection state.

--- a/packages/taskdog-ui/src/taskdog/tui/commands/batch_confirmation_base.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/batch_confirmation_base.py
@@ -137,7 +137,7 @@ class BatchConfirmationCommandBase(TUICommandBase):
                     failure_count += 1
 
             # Clear selection and reload tasks
-            self.clear_selection()
+            self.clear_task_selection()
             self.reload_tasks()
 
             # Show result summary (only for failures - success notifications via WebSocket)

--- a/packages/taskdog-ui/src/taskdog/tui/commands/batch_status_change_base.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/batch_status_change_base.py
@@ -58,7 +58,7 @@ class BatchStatusChangeCommandBase(TUICommandBase):
         success_count, failure_count = self._process_tasks(task_ids)
 
         # Clear selection and reload tasks
-        self.clear_selection()
+        self.clear_task_selection()
         self.reload_tasks()
 
         # Show batch summary for multiple tasks

--- a/packages/taskdog-ui/src/taskdog/tui/commands/optimize.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/optimize.py
@@ -60,6 +60,10 @@ class OptimizeCommand(TUICommandBase):
 
     def execute(self) -> None:
         """Execute the optimize command."""
+        # Get explicitly selected task IDs (empty list means optimize all)
+        # Use get_explicitly_selected_task_ids() to avoid cursor fallback
+        selected_ids = self.get_explicitly_selected_task_ids()
+        task_ids = selected_ids if selected_ids else None
 
         def handle_optimization_settings(
             settings: tuple[str, float, datetime, bool] | None,
@@ -81,6 +85,7 @@ class OptimizeCommand(TUICommandBase):
                 start_date=start_date,
                 max_hours_per_day=max_hours,
                 force_override=force_override,
+                task_ids=task_ids,
             )
 
             # Reload tasks to show updated schedules
@@ -104,9 +109,11 @@ class OptimizeCommand(TUICommandBase):
         # Get algorithm metadata from API client
         algorithm_metadata = self.context.api_client.get_algorithm_metadata()
 
-        # Show optimization settings screen
+        # Show optimization settings screen with selected task count
         # Wrap callback with error handling from base class
         self.app.push_screen(
-            AlgorithmSelectionDialog(algorithm_metadata),
+            AlgorithmSelectionDialog(
+                algorithm_metadata, selected_task_count=len(selected_ids)
+            ),
             self.handle_error(handle_optimization_settings),
         )

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/algorithm_selection_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/algorithm_selection_dialog.py
@@ -46,6 +46,7 @@ class AlgorithmSelectionDialog(
     def __init__(
         self,
         algorithm_metadata: list[tuple[str, str, str]],
+        selected_task_count: int = 0,
         *args: Any,
         **kwargs: Any,
     ):
@@ -53,16 +54,23 @@ class AlgorithmSelectionDialog(
 
         Args:
             algorithm_metadata: List of (algorithm_id, display_name, description) tuples
+            selected_task_count: Number of selected tasks (0 means optimize all tasks)
         """
         super().__init__(*args, **kwargs)
         self.algorithms = algorithm_metadata
+        self.selected_task_count = selected_task_count
 
     def compose(self) -> ComposeResult:
         """Compose the screen layout."""
         with Container(
             id="algorithm-dialog", classes="dialog-base dialog-standard"
         ) as container:
-            container.border_title = "Optimize Schedule Settings"
+            if self.selected_task_count > 0:
+                container.border_title = (
+                    f"Optimize {self.selected_task_count} Selected Task(s)"
+                )
+            else:
+                container.border_title = "Optimize All Tasks"
             yield Label(
                 "[dim]Ctrl+S: submit | Esc: cancel | Tab/Ctrl-j: next | Shift+Tab/Ctrl-k: previous[/dim]",
                 id="dialog-hint",

--- a/packages/taskdog-ui/src/taskdog/tui/screens/main_screen.py
+++ b/packages/taskdog-ui/src/taskdog/tui/screens/main_screen.py
@@ -214,7 +214,13 @@ class MainScreen(Screen[None]):
             return self.task_table.get_selected_task_ids()
         return []
 
-    def clear_selection(self) -> None:
+    def get_explicitly_selected_task_ids(self) -> list[int]:
+        """Get only explicitly selected task IDs (no cursor fallback)."""
+        if self.task_table:
+            return self.task_table.get_explicitly_selected_task_ids()
+        return []
+
+    def clear_task_selection(self) -> None:
         """Clear all task selections."""
         if self.task_table:
             self.task_table.clear_selection()

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/task_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/task_table.py
@@ -45,7 +45,6 @@ class TaskTable(DataTable, TUIWidget, ViNavigationMixin):  # type: ignore[type-a
         This reactive handler is currently a placeholder for future functionality
         such as updating a selection count display in the footer.
         """
-        # Future: Update footer or status bar with selection count
         pass
 
     # Add Vi-style bindings in addition to DataTable's default bindings
@@ -486,6 +485,19 @@ class TaskTable(DataTable, TUIWidget, ViNavigationMixin):  # type: ignore[type-a
         # Fall back to single selection (cursor position)
         task_id = self.get_selected_task_id()
         return [task_id] if task_id else []
+
+    def get_explicitly_selected_task_ids(self) -> list[int]:
+        """Get only explicitly selected task IDs (no cursor fallback).
+
+        Unlike get_selected_task_ids(), this method does NOT fall back to
+        the cursor position when no tasks are explicitly selected.
+        Use this when you need to distinguish between "no selection" and
+        "single task selected".
+
+        Returns:
+            List of explicitly selected task IDs, or empty list if none selected
+        """
+        return sorted(self._selected_task_ids) if self._selected_task_ids else []
 
     def clear_selection(self) -> None:
         """Clear all selections (called after batch operations)."""

--- a/packages/taskdog-ui/tests/tui/commands/test_batch_confirmation_base.py
+++ b/packages/taskdog-ui/tests/tui/commands/test_batch_confirmation_base.py
@@ -145,7 +145,7 @@ class TestBatchConfirmationCommandConfirmationHandler:
         """Test that action is executed when confirmed."""
         self.command.get_selected_task_ids = MagicMock(return_value=[42])
         self.command.execute_confirmed_action = MagicMock()
-        self.command.clear_selection = MagicMock()
+        self.command.clear_task_selection = MagicMock()
         self.command.reload_tasks = MagicMock()
 
         self.command.execute()
@@ -160,7 +160,7 @@ class TestBatchConfirmationCommandConfirmationHandler:
         """Test that action is executed for all tasks."""
         self.command.get_selected_task_ids = MagicMock(return_value=[1, 2, 3])
         self.command.execute_confirmed_action = MagicMock()
-        self.command.clear_selection = MagicMock()
+        self.command.clear_task_selection = MagicMock()
         self.command.reload_tasks = MagicMock()
 
         self.command.execute()
@@ -177,7 +177,7 @@ class TestBatchConfirmationCommandConfirmationHandler:
         """Test that selection is cleared after execution."""
         self.command.get_selected_task_ids = MagicMock(return_value=[1])
         self.command.execute_confirmed_action = MagicMock()
-        self.command.clear_selection = MagicMock()
+        self.command.clear_task_selection = MagicMock()
         self.command.reload_tasks = MagicMock()
 
         self.command.execute()
@@ -185,7 +185,7 @@ class TestBatchConfirmationCommandConfirmationHandler:
         callback_wrapper = self.mock_app.push_screen.call_args[0][1]
         callback_wrapper(True)
 
-        self.command.clear_selection.assert_called_once()
+        self.command.clear_task_selection.assert_called_once()
         self.command.reload_tasks.assert_called_once()
 
     def test_handles_task_not_found_error(self) -> None:
@@ -195,7 +195,7 @@ class TestBatchConfirmationCommandConfirmationHandler:
             side_effect=TaskNotFoundException(999)
         )
         self.command.notify_error = MagicMock()
-        self.command.clear_selection = MagicMock()
+        self.command.clear_task_selection = MagicMock()
         self.command.reload_tasks = MagicMock()
 
         self.command.execute()
@@ -212,7 +212,7 @@ class TestBatchConfirmationCommandConfirmationHandler:
             side_effect=TaskValidationError("Invalid operation")
         )
         self.command.notify_error = MagicMock()
-        self.command.clear_selection = MagicMock()
+        self.command.clear_task_selection = MagicMock()
         self.command.reload_tasks = MagicMock()
 
         self.command.execute()
@@ -229,7 +229,7 @@ class TestBatchConfirmationCommandConfirmationHandler:
             side_effect=Exception("Generic error")
         )
         self.command.notify_error = MagicMock()
-        self.command.clear_selection = MagicMock()
+        self.command.clear_task_selection = MagicMock()
         self.command.reload_tasks = MagicMock()
 
         self.command.execute()
@@ -247,7 +247,7 @@ class TestBatchConfirmationCommandConfirmationHandler:
         )
         self.command.notify_error = MagicMock()
         self.command.notify_warning = MagicMock()
-        self.command.clear_selection = MagicMock()
+        self.command.clear_task_selection = MagicMock()
         self.command.reload_tasks = MagicMock()
 
         self.command.execute()
@@ -265,7 +265,7 @@ class TestBatchConfirmationCommandConfirmationHandler:
         self.command.get_selected_task_ids = MagicMock(return_value=[1, 2])
         self.command.execute_confirmed_action = MagicMock()
         self.command.notify_warning = MagicMock()
-        self.command.clear_selection = MagicMock()
+        self.command.clear_task_selection = MagicMock()
         self.command.reload_tasks = MagicMock()
 
         self.command.execute()

--- a/packages/taskdog-ui/tests/tui/commands/test_batch_status_change_base.py
+++ b/packages/taskdog-ui/tests/tui/commands/test_batch_status_change_base.py
@@ -59,13 +59,13 @@ class TestBatchStatusChangeCommandBase:
         self.command.execute_single_task = MagicMock(
             return_value=create_mock_output(task_id=42, name="Task 42")
         )
-        self.command.clear_selection = MagicMock()
+        self.command.clear_task_selection = MagicMock()
         self.command.reload_tasks = MagicMock()
 
         self.command.execute()
 
         self.command.execute_single_task.assert_called_once_with(42)
-        self.command.clear_selection.assert_called_once()
+        self.command.clear_task_selection.assert_called_once()
         self.command.reload_tasks.assert_called_once()
 
     def test_execute_processes_multiple_tasks(self) -> None:
@@ -78,7 +78,7 @@ class TestBatchStatusChangeCommandBase:
                 create_mock_output(task_id=3, name="Task 3"),
             ]
         )
-        self.command.clear_selection = MagicMock()
+        self.command.clear_task_selection = MagicMock()
         self.command.reload_tasks = MagicMock()
 
         self.command.execute()
@@ -92,14 +92,14 @@ class TestBatchStatusChangeCommandBase:
             side_effect=Exception("Task failed")
         )
         self.command.notify_error = MagicMock()
-        self.command.clear_selection = MagicMock()
+        self.command.clear_task_selection = MagicMock()
         self.command.reload_tasks = MagicMock()
 
         self.command.execute()
 
         self.command.notify_error.assert_called_once()
         # Should still clear selection and reload
-        self.command.clear_selection.assert_called_once()
+        self.command.clear_task_selection.assert_called_once()
         self.command.reload_tasks.assert_called_once()
 
 

--- a/packages/taskdog-ui/tests/tui/dialogs/test_algorithm_selection_dialog.py
+++ b/packages/taskdog-ui/tests/tui/dialogs/test_algorithm_selection_dialog.py
@@ -32,6 +32,20 @@ class TestAlgorithmSelectionDialogInit:
 
         assert dialog.algorithms == []
 
+    def test_stores_selected_task_count(self) -> None:
+        """Test that selected_task_count is stored correctly."""
+        metadata = create_algorithm_metadata()
+        dialog = AlgorithmSelectionDialog(metadata, selected_task_count=5)
+
+        assert dialog.selected_task_count == 5
+
+    def test_default_selected_task_count_is_zero(self) -> None:
+        """Test that default selected_task_count is zero."""
+        metadata = create_algorithm_metadata()
+        dialog = AlgorithmSelectionDialog(metadata)
+
+        assert dialog.selected_task_count == 0
+
 
 class TestAlgorithmSelectionDialogGetDefaultStartDate:
     """Test cases for _get_default_start_date method."""


### PR DESCRIPTION
## Summary

- Add ability to optimize only explicitly selected tasks (via Space key) in TUI
- When no tasks are selected, optimize all tasks as before
- Show dynamic dialog title based on selection count

## Changes

- Add `selected_task_count` parameter to `AlgorithmSelectionDialog`
- Dialog title shows "Optimize N Selected Task(s)" or "Optimize All Tasks"
- Add `get_explicitly_selected_task_ids()` method (no cursor fallback)
- Fix: Rename `clear_selection()` to `clear_task_selection()` to avoid conflict with Textual's `Screen.clear_selection()` which was causing task selections to be cleared when opening command palette

## Test plan

- [x] Select multiple tasks with Space key
- [x] Open command palette (Ctrl+P) and run optimize
- [x] Verify dialog shows "Optimize N Selected Task(s)"
- [x] Verify only selected tasks are optimized
- [x] Clear selection (Ctrl+N) and run optimize
- [x] Verify dialog shows "Optimize All Tasks"
- [x] Verify all schedulable tasks are optimized

🤖 Generated with [Claude Code](https://claude.ai/code)