### PR TITLE
feat(cli): add timeline command for daily work visualization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -407,6 +407,7 @@ Commands in `packages/taskdog-ui/src/taskdog/cli/commands/`, registered in `cli_
 **Visualization**
 
 - `gantt [--sort] [--reverse] [--all] [--status] [--tag] [--start-date] [--end-date]`: Gantt chart with workload summary (default sort: deadline, shows non-archived tasks by default)
+- `timeline [--date YYYY-MM-DD]`: Daily timeline showing actual work times (horizontal axis is hours, vertical is tasks)
 - `table [--sort] [--reverse] [--all] [--fields] [--status] [--tag] [--start-date] [--end-date]`: Task table with filtering (shows non-archived tasks by default)
 - `today`: Today's tasks (deadline today, planned includes today, or IN_PROGRESS)
 - `week`: This week's tasks

--- a/packages/taskdog-ui/src/taskdog/cli/commands/timeline.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/timeline.py
@@ -1,0 +1,85 @@
+"""Timeline command - Display actual work times for a day."""
+
+from datetime import date, datetime
+
+import click
+
+from taskdog.cli.context import CliContext
+from taskdog.cli.error_handler import handle_command_errors
+from taskdog.presenters.timeline_presenter import TimelinePresenter
+from taskdog.renderers.rich_timeline_renderer import RichTimelineRenderer
+
+
+@click.command(
+    name="timeline",
+    help="""Display actual work times for a specific day.
+
+Shows when tasks were actually worked on during the day, based on
+actual_start and actual_end timestamps. This is a "daily Gantt" view
+where the horizontal axis is time-of-day instead of calendar days.
+
+\b
+DISPLAY:
+  - Horizontal axis: Hours of the day (e.g., 08, 09, 10, ...)
+  - Vertical axis: Tasks (sorted by start time)
+  - Bars: Show actual work periods with status-based colors
+  - Duration: Work time for each task on that day
+
+\b
+INCLUDED TASKS:
+  - Tasks with actual_start on the target date
+  - IN_PROGRESS tasks (uses current time as end)
+  - Tasks spanning multiple days (clipped to target date)
+
+\b
+COLOR CODING:
+  - Blue bars: IN_PROGRESS
+  - Green bars: COMPLETED
+  - Red bars: CANCELED
+
+\b
+EXAMPLE:
+  taskdog timeline                    # Show today's work times
+  taskdog timeline -d 2026-01-29      # Show specific date
+  taskdog timeline --date 2026-01-15  # Show specific date (long form)
+""",
+)
+@click.option(
+    "--date",
+    "-d",
+    "target_date",
+    type=click.DateTime(formats=["%Y-%m-%d"]),
+    default=None,
+    help="Date to show timeline for (YYYY-MM-DD). Defaults to today.",
+)
+@click.pass_context
+@handle_command_errors("displaying timeline")
+def timeline_command(
+    ctx: click.Context,
+    target_date: datetime | None,
+) -> None:
+    """Display actual work times for a specific day.
+
+    Shows a horizontal timeline of when tasks were worked on during the day,
+    based on actual_start and actual_end timestamps.
+    """
+    ctx_obj: CliContext = ctx.obj
+
+    # Default to today if no date specified
+    date_to_show = date.today() if target_date is None else target_date.date()
+
+    # Get all tasks (we'll filter by actual_start/end in the presenter)
+    # Include all statuses since we want to show completed work too
+    task_list = ctx_obj.api_client.list_tasks(
+        all=True,  # Include archived to show historical work
+        sort_by="id",
+        reverse=False,
+    )
+
+    # Convert to ViewModel (Presenter filters and prepares data)
+    presenter = TimelinePresenter()
+    timeline_vm = presenter.present(task_list, date_to_show)
+
+    # Render using Presentation layer
+    renderer = RichTimelineRenderer(ctx_obj.console_writer)
+    renderer.render(timeline_vm)

--- a/packages/taskdog-ui/src/taskdog/cli_main.py
+++ b/packages/taskdog-ui/src/taskdog/cli_main.py
@@ -25,6 +25,7 @@ from taskdog.cli.commands.start import start_command
 from taskdog.cli.commands.stats import stats_command
 from taskdog.cli.commands.table import table_command
 from taskdog.cli.commands.tags import tags_command
+from taskdog.cli.commands.timeline import timeline_command
 from taskdog.cli.commands.today import today_command
 from taskdog.cli.commands.update import update_command
 from taskdog.cli.commands.week import week_command
@@ -183,6 +184,7 @@ cli.add_command(fix_actual_command)
 cli.add_command(optimize_command)
 cli.add_command(stats_command)
 cli.add_command(tags_command)
+cli.add_command(timeline_command)
 # Note: tui_command is lazy-loaded via LAZY_SUBCOMMANDS for performance
 
 if __name__ == "__main__":

--- a/packages/taskdog-ui/src/taskdog/presenters/timeline_presenter.py
+++ b/packages/taskdog-ui/src/taskdog/presenters/timeline_presenter.py
@@ -1,0 +1,197 @@
+"""Presenter for converting TaskListOutput to TimelineViewModel.
+
+This presenter filters tasks that have actual_start/actual_end on the target date
+and creates presentation-ready view models for the Timeline chart.
+"""
+
+from datetime import date, datetime, time
+
+from taskdog.view_models.timeline_view_model import (
+    TimelineTaskRowViewModel,
+    TimelineViewModel,
+)
+from taskdog_core.application.dto.task_dto import TaskRowDto
+from taskdog_core.application.dto.task_list_output import TaskListOutput
+
+# Default display hours
+DEFAULT_START_HOUR = 8
+DEFAULT_END_HOUR = 18
+MIN_DISPLAY_HOURS = 2  # Minimum hours to show in timeline
+
+
+class TimelinePresenter:
+    """Presenter for converting TaskListOutput to TimelineViewModel.
+
+    This class is responsible for:
+    1. Filtering tasks that have actual work on the target date
+    2. Calculating display time range
+    3. Converting task data to presentation-ready ViewModels
+    """
+
+    def present(
+        self, task_list: TaskListOutput, target_date: date
+    ) -> TimelineViewModel:
+        """Convert TaskListOutput to TimelineViewModel for a specific date.
+
+        Args:
+            task_list: Task list from the API
+            target_date: The date to show timeline for
+
+        Returns:
+            TimelineViewModel with presentation-ready data
+        """
+        # Filter and convert tasks that have work on the target date
+        rows: list[TimelineTaskRowViewModel] = []
+        min_hour = DEFAULT_END_HOUR
+        max_hour = DEFAULT_START_HOUR
+
+        for task_row in task_list.tasks:
+            row = self._try_convert_task(task_row, target_date)
+            if row is not None:
+                rows.append(row)
+                # Track time range
+                min_hour = min(min_hour, row.actual_start.hour)
+                max_hour = max(max_hour, row.actual_end.hour)
+
+        # Sort by actual_start (ascending)
+        rows.sort(key=lambda r: (r.actual_start.hour, r.actual_start.minute))
+
+        # Calculate display range
+        if rows:
+            start_hour = max(0, min_hour)
+            end_hour = min(23, max_hour + 1)  # Include the end hour
+        else:
+            start_hour = DEFAULT_START_HOUR
+            end_hour = DEFAULT_END_HOUR
+
+        # Ensure minimum display width
+        if end_hour - start_hour < MIN_DISPLAY_HOURS:
+            end_hour = start_hour + MIN_DISPLAY_HOURS
+
+        # Calculate totals
+        total_work_hours = sum(row.duration_hours for row in rows)
+
+        return TimelineViewModel(
+            target_date=target_date,
+            rows=rows,
+            start_hour=start_hour,
+            end_hour=end_hour,
+            total_work_hours=total_work_hours,
+            task_count=len(rows),
+        )
+
+    def _try_convert_task(
+        self, task_row: TaskRowDto, target_date: date
+    ) -> TimelineTaskRowViewModel | None:
+        """Try to convert a TaskRowDto to TimelineTaskRowViewModel.
+
+        Returns None if the task has no work on the target date.
+
+        Args:
+            task_row: Task row DTO from the API
+            target_date: The date to check for work
+
+        Returns:
+            TimelineTaskRowViewModel if task has work on target_date, None otherwise
+        """
+        # Check if task has actual start/end on the target date
+        actual_start = task_row.actual_start
+        actual_end = task_row.actual_end
+
+        if actual_start is None:
+            return None
+
+        # For IN_PROGRESS tasks, use "now" as end time if on target date
+        if actual_end is None:
+            if actual_start.date() == target_date:
+                # Task started today and still in progress
+                now = datetime.now()
+                if now.date() == target_date:
+                    actual_end = now
+                else:
+                    # Started today but we're looking at a past date?
+                    # Use end of day
+                    actual_end = datetime.combine(target_date, time(23, 59, 59))
+            else:
+                return None
+
+        # Calculate the overlap with the target date
+        start_time, end_time = self._get_work_times_on_date(
+            actual_start, actual_end, target_date
+        )
+
+        if start_time is None or end_time is None:
+            return None
+
+        # Calculate duration on this date
+        duration_hours = self._calculate_duration_hours(start_time, end_time)
+
+        if duration_hours <= 0:
+            return None
+
+        # Use is_finished from DTO (consistent with other presenters)
+        is_finished = task_row.is_finished
+
+        # Apply strikethrough for finished tasks
+        formatted_name = task_row.name
+        if is_finished:
+            formatted_name = f"[strike dim]{task_row.name}[/strike dim]"
+
+        return TimelineTaskRowViewModel(
+            task_id=task_row.id,
+            name=task_row.name,
+            formatted_name=formatted_name,
+            actual_start=start_time,
+            actual_end=end_time,
+            duration_hours=duration_hours,
+            status=task_row.status,
+            is_finished=is_finished,
+        )
+
+    def _get_work_times_on_date(
+        self, actual_start: datetime, actual_end: datetime, target_date: date
+    ) -> tuple[time | None, time | None]:
+        """Get the work start and end times for a specific date.
+
+        Handles cases where work spans multiple days by clipping to the target date.
+
+        Args:
+            actual_start: Task actual start datetime
+            actual_end: Task actual end datetime
+            target_date: The date to get times for
+
+        Returns:
+            Tuple of (start_time, end_time) on target_date, or (None, None) if no overlap
+        """
+        start_date = actual_start.date()
+        end_date = actual_end.date()
+
+        # Check if target_date is within the work period
+        if target_date < start_date or target_date > end_date:
+            return None, None
+
+        # Determine start time on target date
+        # (Work continued from previous day uses midnight)
+        start_time = actual_start.time() if target_date == start_date else time(0, 0)
+
+        # Determine end time on target date
+        # (Work continued to next day uses end of day)
+        end_time = actual_end.time() if target_date == end_date else time(23, 59, 59)
+
+        return start_time, end_time
+
+    def _calculate_duration_hours(self, start_time: time, end_time: time) -> float:
+        """Calculate duration in hours between two times.
+
+        Args:
+            start_time: Start time
+            end_time: End time
+
+        Returns:
+            Duration in hours
+        """
+        start_minutes = start_time.hour * 60 + start_time.minute
+        end_minutes = end_time.hour * 60 + end_time.minute
+
+        duration_minutes = end_minutes - start_minutes
+        return max(0, duration_minutes / 60.0)

--- a/packages/taskdog-ui/src/taskdog/renderers/rich_timeline_renderer.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/rich_timeline_renderer.py
@@ -1,0 +1,247 @@
+"""Rich-based renderer for Timeline chart.
+
+This module renders the Timeline chart as a Rich Table, showing
+actual work times on a horizontal time axis for a specific day.
+"""
+
+from rich.table import Table
+from rich.text import Text
+
+from taskdog.console.console_writer import ConsoleWriter
+from taskdog.constants.table_dimensions import (
+    GANTT_TABLE_ID_WIDTH,
+    GANTT_TABLE_TASK_MIN_WIDTH,
+)
+from taskdog.constants.table_styles import (
+    COLUMN_ID_STYLE,
+    COLUMN_NAME_STYLE,
+    TABLE_BORDER_STYLE,
+    TABLE_HEADER_STYLE,
+    TABLE_PADDING,
+    format_table_title,
+)
+from taskdog.renderers.rich_renderer_base import RichRendererBase
+from taskdog.renderers.timeline_cell_formatter import (
+    CHARS_PER_HOUR,
+    TimelineCellFormatter,
+)
+from taskdog.view_models.timeline_view_model import (
+    TimelineTaskRowViewModel,
+    TimelineViewModel,
+)
+
+# Column width for duration display
+TIMELINE_TABLE_DURATION_WIDTH = 6
+
+
+class RichTimelineRenderer(RichRendererBase):
+    """Renders TimelineViewModel as a Rich table.
+
+    This renderer displays actual work times on a horizontal time axis,
+    showing when tasks were worked on during a specific day.
+    """
+
+    def __init__(self, console_writer: ConsoleWriter):
+        """Initialize the renderer.
+
+        Args:
+            console_writer: Console writer for output
+        """
+        self.console_writer = console_writer
+
+    def build_table(self, timeline_vm: TimelineViewModel) -> Table | None:
+        """Build and return a Timeline chart Table object.
+
+        Args:
+            timeline_vm: Presentation-ready Timeline data
+
+        Returns:
+            Rich Table object or None if no tasks
+        """
+        if timeline_vm.is_empty():
+            return None
+
+        table = self._create_table(timeline_vm)
+        self._add_columns(table)
+        self._add_hour_header_row(table, timeline_vm)
+        self._add_task_rows(table, timeline_vm)
+        self._add_summary_section(table, timeline_vm)
+
+        return table
+
+    def _create_table(self, timeline_vm: TimelineViewModel) -> Table:
+        """Create and configure the base Table object.
+
+        Args:
+            timeline_vm: Timeline data for title generation
+
+        Returns:
+            Configured Rich Table object
+        """
+        # Format date with day of week
+        date_str = timeline_vm.target_date.strftime("%Y-%m-%d (%a)")
+
+        return Table(
+            title=format_table_title(f"Timeline - {date_str}"),
+            show_header=True,
+            header_style=TABLE_HEADER_STYLE,
+            border_style=TABLE_BORDER_STYLE,
+            padding=TABLE_PADDING,
+        )
+
+    def _add_columns(self, table: Table) -> None:
+        """Add column definitions to the table.
+
+        Args:
+            table: Rich Table object to add columns to
+        """
+        table.add_column(
+            "ID",
+            justify="right",
+            style=COLUMN_ID_STYLE,
+            no_wrap=True,
+            width=GANTT_TABLE_ID_WIDTH,
+        )
+        table.add_column(
+            "Task", style=COLUMN_NAME_STYLE, min_width=GANTT_TABLE_TASK_MIN_WIDTH
+        )
+        table.add_column("Timeline", style=COLUMN_NAME_STYLE)
+        table.add_column(
+            "Time",
+            justify="right",
+            style="cyan",
+            no_wrap=True,
+            width=TIMELINE_TABLE_DURATION_WIDTH,
+        )
+
+    def _add_hour_header_row(
+        self, table: Table, timeline_vm: TimelineViewModel
+    ) -> None:
+        """Add the hour header row to the table.
+
+        Args:
+            table: Rich Table object
+            timeline_vm: Timeline data containing time range
+        """
+        hour_header = TimelineCellFormatter.build_hour_header(
+            timeline_vm.start_hour, timeline_vm.end_hour
+        )
+        table.add_row("", "[dim]Hour[/dim]", hour_header, "")
+
+    def _add_task_rows(self, table: Table, timeline_vm: TimelineViewModel) -> None:
+        """Add all task rows to the table.
+
+        Args:
+            table: Rich Table object
+            timeline_vm: Timeline data containing tasks
+        """
+        for row_vm in timeline_vm.rows:
+            self._add_task_row(
+                table,
+                row_vm,
+                timeline_vm.start_hour,
+                timeline_vm.end_hour,
+            )
+
+    def _add_task_row(
+        self,
+        table: Table,
+        row_vm: TimelineTaskRowViewModel,
+        start_hour: int,
+        end_hour: int,
+    ) -> None:
+        """Add a single task row to the table.
+
+        Args:
+            table: Rich Table object
+            row_vm: Task row ViewModel
+            start_hour: Display start hour
+            end_hour: Display end hour
+        """
+        # Build timeline bar
+        timeline_bar = TimelineCellFormatter.build_timeline_bar(
+            row_vm.actual_start,
+            row_vm.actual_end,
+            start_hour,
+            end_hour,
+            row_vm.status,
+        )
+
+        # Format duration
+        duration_str = TimelineCellFormatter.format_duration(row_vm.duration_hours)
+
+        table.add_row(
+            str(row_vm.task_id),
+            row_vm.formatted_name,
+            timeline_bar,
+            duration_str,
+        )
+
+    def _add_summary_section(
+        self, table: Table, timeline_vm: TimelineViewModel
+    ) -> None:
+        """Add section divider and summary row.
+
+        Args:
+            table: Rich Table object
+            timeline_vm: Timeline data containing totals
+        """
+        table.add_section()
+
+        # Build summary text
+        summary_text = (
+            f"[bold yellow]{timeline_vm.task_count} tasks | "
+            f"{timeline_vm.total_work_hours:.1f}h worked[/bold yellow]"
+        )
+
+        # Calculate timeline width for centering
+        timeline_width = (
+            timeline_vm.end_hour - timeline_vm.start_hour + 1
+        ) * CHARS_PER_HOUR
+
+        # Create centered summary in timeline column
+        summary_timeline = Text()
+        padding = max(
+            0,
+            (
+                timeline_width
+                - len(
+                    f"{timeline_vm.task_count} tasks | {timeline_vm.total_work_hours:.1f}h worked"
+                )
+            )
+            // 2,
+        )
+        summary_timeline.append(" " * padding)
+
+        table.add_row(
+            "",
+            "[bold yellow]Summary[/bold yellow]",
+            summary_text,
+            "",
+        )
+
+        # Add legend
+        legend_text = TimelineCellFormatter.build_legend()
+        table.caption = legend_text
+        table.caption_justify = "center"
+
+    def render(self, timeline_vm: TimelineViewModel) -> None:
+        """Render and print Timeline chart from TimelineViewModel.
+
+        Args:
+            timeline_vm: Presentation-ready Timeline data
+        """
+        if timeline_vm.is_empty():
+            date_str = timeline_vm.target_date.strftime("%Y-%m-%d (%a)")
+            self.console_writer.warning(
+                f"No tasks with actual work times found for {date_str}."
+            )
+            return
+
+        table = self.build_table(timeline_vm)
+
+        if table is None:
+            self.console_writer.warning("No tasks found.")
+            return
+
+        self.console_writer.print(table)

--- a/packages/taskdog-ui/src/taskdog/renderers/timeline_cell_formatter.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/timeline_cell_formatter.py
@@ -1,0 +1,131 @@
+"""Formatting logic for Timeline chart rendering.
+
+This module provides formatting utilities for the Timeline chart,
+which displays actual work times on a horizontal time axis.
+"""
+
+from datetime import time
+
+from rich.text import Text
+
+from taskdog.constants.colors import STATUS_COLORS_BOLD
+from taskdog_core.domain.entities.task import TaskStatus
+
+# Timeline constants
+CHARS_PER_HOUR = 4  # Number of characters per hour in the timeline
+TIMELINE_BAR_CHAR = "█"  # Full block character for work bars
+TIMELINE_EMPTY_CHAR = " "  # Space for empty cells
+
+
+class TimelineCellFormatter:
+    """Formatter for Timeline chart cells and headers.
+
+    This class provides static methods for formatting Timeline chart components.
+    All methods are stateless and return Rich Text objects or tuples.
+    """
+
+    @staticmethod
+    def build_hour_header(start_hour: int, end_hour: int) -> Text:
+        """Build hour header row for the timeline.
+
+        Args:
+            start_hour: First hour to display (e.g., 8)
+            end_hour: Last hour to display (e.g., 18)
+
+        Returns:
+            Rich Text object with hour labels
+        """
+        header = Text()
+        for hour in range(start_hour, end_hour + 1):
+            # Format: "08  " or "12  " (4 chars per hour)
+            label = f"{hour:02d}  "
+            header.append(label, style="dim")
+        return header
+
+    @staticmethod
+    def build_timeline_bar(
+        actual_start: time,
+        actual_end: time,
+        start_hour: int,
+        end_hour: int,
+        status: TaskStatus,
+    ) -> Text:
+        """Build a timeline bar showing work period.
+
+        Args:
+            actual_start: Start time of work
+            actual_end: End time of work
+            start_hour: Display start hour
+            end_hour: Display end hour
+            status: Task status for coloring
+
+        Returns:
+            Rich Text object with timeline bar
+        """
+        timeline = Text()
+        total_chars = (end_hour - start_hour + 1) * CHARS_PER_HOUR
+        bar_color = TimelineCellFormatter.get_status_color(status)
+
+        # Calculate positions in character space
+        start_minutes = actual_start.hour * 60 + actual_start.minute
+        end_minutes = actual_end.hour * 60 + actual_end.minute
+        display_start_minutes = start_hour * 60
+
+        for char_idx in range(total_chars):
+            # Calculate the time range this character represents
+            char_start_minutes = display_start_minutes + (
+                char_idx * 60 // CHARS_PER_HOUR
+            )
+            char_end_minutes = display_start_minutes + (
+                (char_idx + 1) * 60 // CHARS_PER_HOUR
+            )
+
+            # Check if this character falls within the work period
+            if char_start_minutes < end_minutes and char_end_minutes > start_minutes:
+                timeline.append(TIMELINE_BAR_CHAR, style=bar_color)
+            else:
+                timeline.append(TIMELINE_EMPTY_CHAR, style="dim")
+
+        return timeline
+
+    @staticmethod
+    def get_status_color(status: TaskStatus) -> str:
+        """Get color for task status.
+
+        Args:
+            status: Task status
+
+        Returns:
+            Color string with bold modifier
+        """
+        status_key = status.value if hasattr(status, "value") else str(status)
+        return STATUS_COLORS_BOLD.get(status_key, "white")
+
+    @staticmethod
+    def format_duration(hours: float) -> str:
+        """Format duration for display.
+
+        Args:
+            hours: Duration in hours
+
+        Returns:
+            Formatted string (e.g., "2.5h", "1.0h")
+        """
+        return f"{hours:.1f}h"
+
+    @staticmethod
+    def build_legend() -> Text:
+        """Build the legend text for the Timeline chart.
+
+        Returns:
+            Rich Text object with legend
+        """
+        legend = Text()
+        legend.append("Legend: ", style="bold yellow")
+        legend.append(TIMELINE_BAR_CHAR * 3, style="bold blue")
+        legend.append(" IN_PROGRESS  ", style="dim")
+        legend.append(TIMELINE_BAR_CHAR * 3, style="bold green")
+        legend.append(" COMPLETED  ", style="dim")
+        legend.append(TIMELINE_BAR_CHAR * 3, style="bold red")
+        legend.append(" CANCELED", style="dim")
+        return legend

--- a/packages/taskdog-ui/src/taskdog/view_models/timeline_view_model.py
+++ b/packages/taskdog-ui/src/taskdog/view_models/timeline_view_model.py
@@ -1,0 +1,70 @@
+"""ViewModels for Timeline (daily time-based Gantt) presentation.
+
+These ViewModels contain only the data needed for rendering the Timeline chart,
+which shows actual_start/actual_end times for a specific day on a horizontal time axis.
+"""
+
+from dataclasses import dataclass
+from datetime import date, time
+
+from taskdog.view_models.base import BaseViewModel
+from taskdog_core.domain.entities.task import TaskStatus
+
+
+@dataclass(frozen=True)
+class TimelineTaskRowViewModel(BaseViewModel):
+    """ViewModel for a single task row in the Timeline chart.
+
+    This contains all data needed to render a task in the Timeline chart,
+    with presentation logic already applied (e.g., strikethrough for finished tasks).
+
+    Attributes:
+        task_id: Task ID
+        name: Task name (raw, without formatting)
+        formatted_name: Task name with presentation formatting (strikethrough, etc.)
+        actual_start: Actual start time on the target date
+        actual_end: Actual end time on the target date
+        duration_hours: Work duration in hours for this date
+        status: Task status (needed for bar coloring)
+        is_finished: Whether task is in a finished state (COMPLETED/CANCELED)
+    """
+
+    task_id: int
+    name: str
+    formatted_name: str
+    actual_start: time
+    actual_end: time
+    duration_hours: float
+    status: TaskStatus
+    is_finished: bool
+
+
+@dataclass(frozen=True)
+class TimelineViewModel(BaseViewModel):
+    """ViewModel for complete Timeline chart data.
+
+    This is the presentation-ready data for displaying a day's work timeline.
+
+    Attributes:
+        target_date: The date being displayed
+        rows: List of task row view models for display
+        start_hour: Display start hour (e.g., 8 for 08:00)
+        end_hour: Display end hour (e.g., 18 for 18:00)
+        total_work_hours: Total hours worked on this day
+        task_count: Number of tasks with work on this day
+    """
+
+    target_date: date
+    rows: list[TimelineTaskRowViewModel]
+    start_hour: int
+    end_hour: int
+    total_work_hours: float
+    task_count: int
+
+    def is_empty(self) -> bool:
+        """Check if the Timeline chart has any task data.
+
+        Returns:
+            True if no tasks are present
+        """
+        return len(self.rows) == 0

--- a/packages/taskdog-ui/tests/presenters/__init__.py
+++ b/packages/taskdog-ui/tests/presenters/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for presenters."""

--- a/packages/taskdog-ui/tests/presenters/test_timeline_presenter.py
+++ b/packages/taskdog-ui/tests/presenters/test_timeline_presenter.py
@@ -1,0 +1,352 @@
+"""Tests for TimelinePresenter."""
+
+from datetime import date, datetime, time
+
+import pytest
+
+from taskdog.presenters.timeline_presenter import TimelinePresenter
+from taskdog_core.application.dto.task_dto import TaskRowDto
+from taskdog_core.application.dto.task_list_output import TaskListOutput
+from taskdog_core.domain.entities.task import TaskStatus
+
+
+class TestTimelinePresenter:
+    """Test cases for TimelinePresenter."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Set up test fixtures."""
+        self.presenter = TimelinePresenter()
+        self.target_date = date(2026, 1, 30)
+
+    def _create_task_row_dto(
+        self,
+        task_id: int,
+        name: str,
+        status: TaskStatus = TaskStatus.COMPLETED,
+        actual_start: datetime | None = None,
+        actual_end: datetime | None = None,
+    ) -> TaskRowDto:
+        """Create a TaskRowDto for testing."""
+        now = datetime.now()
+        is_finished = status in (TaskStatus.COMPLETED, TaskStatus.CANCELED)
+        return TaskRowDto(
+            id=task_id,
+            name=name,
+            priority=50,
+            status=status,
+            planned_start=None,
+            planned_end=None,
+            deadline=None,
+            actual_start=actual_start,
+            actual_end=actual_end,
+            estimated_duration=None,
+            actual_duration_hours=None,
+            is_fixed=False,
+            depends_on=[],
+            tags=[],
+            is_archived=False,
+            is_finished=is_finished,
+            created_at=now,
+            updated_at=now,
+        )
+
+    def _create_task_list_output(self, tasks: list[TaskRowDto]) -> TaskListOutput:
+        """Create a TaskListOutput for testing."""
+        return TaskListOutput(
+            tasks=tasks,
+            total_count=len(tasks),
+            filtered_count=len(tasks),
+        )
+
+    def test_present_empty_list(self):
+        """Test with no tasks."""
+        task_list = self._create_task_list_output([])
+        result = self.presenter.present(task_list, self.target_date)
+
+        assert result.is_empty()
+        assert result.task_count == 0
+        assert result.total_work_hours == 0.0
+
+    def test_present_no_tasks_with_actual_times(self):
+        """Test with tasks that have no actual times."""
+        tasks = [
+            self._create_task_row_dto(1, "Task A", TaskStatus.PENDING),
+            self._create_task_row_dto(2, "Task B", TaskStatus.PENDING),
+        ]
+        task_list = self._create_task_list_output(tasks)
+        result = self.presenter.present(task_list, self.target_date)
+
+        assert result.is_empty()
+        assert result.task_count == 0
+
+    def test_present_task_on_target_date(self):
+        """Test with a task that has work on the target date."""
+        actual_start = datetime(2026, 1, 30, 9, 0, 0)
+        actual_end = datetime(2026, 1, 30, 12, 0, 0)
+        tasks = [
+            self._create_task_row_dto(
+                1, "Task A", TaskStatus.COMPLETED, actual_start, actual_end
+            ),
+        ]
+        task_list = self._create_task_list_output(tasks)
+        result = self.presenter.present(task_list, self.target_date)
+
+        assert not result.is_empty()
+        assert result.task_count == 1
+        assert result.total_work_hours == 3.0
+        assert len(result.rows) == 1
+
+        row = result.rows[0]
+        assert row.task_id == 1
+        assert row.name == "Task A"
+        assert row.actual_start == time(9, 0)
+        assert row.actual_end == time(12, 0)
+        assert row.duration_hours == 3.0
+
+    def test_present_task_on_different_date(self):
+        """Test with a task that has work on a different date."""
+        actual_start = datetime(2026, 1, 29, 9, 0, 0)
+        actual_end = datetime(2026, 1, 29, 12, 0, 0)
+        tasks = [
+            self._create_task_row_dto(
+                1, "Task A", TaskStatus.COMPLETED, actual_start, actual_end
+            ),
+        ]
+        task_list = self._create_task_list_output(tasks)
+        result = self.presenter.present(task_list, self.target_date)
+
+        assert result.is_empty()
+        assert result.task_count == 0
+
+    def test_present_multiple_tasks_sorted_by_start_time(self):
+        """Test that tasks are sorted by actual_start time."""
+        tasks = [
+            self._create_task_row_dto(
+                1,
+                "Task A",
+                TaskStatus.COMPLETED,
+                datetime(2026, 1, 30, 14, 0),
+                datetime(2026, 1, 30, 16, 0),
+            ),
+            self._create_task_row_dto(
+                2,
+                "Task B",
+                TaskStatus.COMPLETED,
+                datetime(2026, 1, 30, 9, 0),
+                datetime(2026, 1, 30, 11, 0),
+            ),
+            self._create_task_row_dto(
+                3,
+                "Task C",
+                TaskStatus.COMPLETED,
+                datetime(2026, 1, 30, 11, 30),
+                datetime(2026, 1, 30, 13, 0),
+            ),
+        ]
+        task_list = self._create_task_list_output(tasks)
+        result = self.presenter.present(task_list, self.target_date)
+
+        assert result.task_count == 3
+        # Should be sorted by start time: B (9:00), C (11:30), A (14:00)
+        assert result.rows[0].task_id == 2  # Task B
+        assert result.rows[1].task_id == 3  # Task C
+        assert result.rows[2].task_id == 1  # Task A
+
+    def test_present_calculates_time_range(self):
+        """Test that display time range is calculated correctly."""
+        tasks = [
+            self._create_task_row_dto(
+                1,
+                "Task A",
+                TaskStatus.COMPLETED,
+                datetime(2026, 1, 30, 7, 0),
+                datetime(2026, 1, 30, 9, 0),
+            ),
+            self._create_task_row_dto(
+                2,
+                "Task B",
+                TaskStatus.COMPLETED,
+                datetime(2026, 1, 30, 16, 0),
+                datetime(2026, 1, 30, 19, 0),
+            ),
+        ]
+        task_list = self._create_task_list_output(tasks)
+        result = self.presenter.present(task_list, self.target_date)
+
+        # start_hour should be min(7, ...) = 7
+        # end_hour should be max(9, 19) + 1 = 20
+        assert result.start_hour == 7
+        assert result.end_hour == 20
+
+    def test_present_finished_task_strikethrough(self):
+        """Test that finished tasks have strikethrough formatting."""
+        tasks = [
+            self._create_task_row_dto(
+                1,
+                "Completed Task",
+                TaskStatus.COMPLETED,
+                datetime(2026, 1, 30, 9, 0),
+                datetime(2026, 1, 30, 10, 0),
+            ),
+            self._create_task_row_dto(
+                2,
+                "Canceled Task",
+                TaskStatus.CANCELED,
+                datetime(2026, 1, 30, 11, 0),
+                datetime(2026, 1, 30, 12, 0),
+            ),
+        ]
+        task_list = self._create_task_list_output(tasks)
+        result = self.presenter.present(task_list, self.target_date)
+
+        assert result.rows[0].is_finished is True
+        assert "[strike dim]" in result.rows[0].formatted_name
+        assert result.rows[1].is_finished is True
+        assert "[strike dim]" in result.rows[1].formatted_name
+
+    def test_present_total_work_hours(self):
+        """Test that total work hours is calculated correctly."""
+        tasks = [
+            self._create_task_row_dto(
+                1,
+                "Task A",
+                TaskStatus.COMPLETED,
+                datetime(2026, 1, 30, 9, 0),
+                datetime(2026, 1, 30, 11, 30),  # 2.5h
+            ),
+            self._create_task_row_dto(
+                2,
+                "Task B",
+                TaskStatus.COMPLETED,
+                datetime(2026, 1, 30, 13, 0),
+                datetime(2026, 1, 30, 16, 0),  # 3.0h
+            ),
+        ]
+        task_list = self._create_task_list_output(tasks)
+        result = self.presenter.present(task_list, self.target_date)
+
+        assert result.total_work_hours == 5.5
+
+    def test_present_task_spanning_multiple_days_start_day(self):
+        """Test task that spans multiple days, looking at start day."""
+        tasks = [
+            self._create_task_row_dto(
+                1,
+                "Spanning Task",
+                TaskStatus.COMPLETED,
+                datetime(2026, 1, 30, 22, 0),  # Started at 10pm
+                datetime(2026, 1, 31, 2, 0),  # Ended at 2am next day
+            ),
+        ]
+        task_list = self._create_task_list_output(tasks)
+        result = self.presenter.present(task_list, self.target_date)
+
+        # Should show 22:00 to 23:59:59 (clipped to target date)
+        assert result.task_count == 1
+        row = result.rows[0]
+        assert row.actual_start == time(22, 0)
+        assert row.actual_end == time(23, 59, 59)
+
+    def test_present_task_spanning_multiple_days_end_day(self):
+        """Test task that spans multiple days, looking at end day."""
+        target_date = date(2026, 1, 31)
+        tasks = [
+            self._create_task_row_dto(
+                1,
+                "Spanning Task",
+                TaskStatus.COMPLETED,
+                datetime(2026, 1, 30, 22, 0),  # Started at 10pm yesterday
+                datetime(2026, 1, 31, 2, 0),  # Ended at 2am today
+            ),
+        ]
+        task_list = self._create_task_list_output(tasks)
+        result = self.presenter.present(task_list, target_date)
+
+        # Should show 00:00 to 02:00 (clipped to target date)
+        assert result.task_count == 1
+        row = result.rows[0]
+        assert row.actual_start == time(0, 0)
+        assert row.actual_end == time(2, 0)
+
+
+class TestTimelinePresenterWorkTimes:
+    """Test cases for _get_work_times_on_date method."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Set up test fixtures."""
+        self.presenter = TimelinePresenter()
+        self.target_date = date(2026, 1, 30)
+
+    def test_work_entirely_on_target_date(self):
+        """Test work that is entirely on the target date."""
+        actual_start = datetime(2026, 1, 30, 9, 0)
+        actual_end = datetime(2026, 1, 30, 17, 0)
+
+        start_time, end_time = self.presenter._get_work_times_on_date(
+            actual_start, actual_end, self.target_date
+        )
+
+        assert start_time == time(9, 0)
+        assert end_time == time(17, 0)
+
+    def test_work_before_target_date(self):
+        """Test work that ended before the target date."""
+        actual_start = datetime(2026, 1, 28, 9, 0)
+        actual_end = datetime(2026, 1, 29, 17, 0)
+
+        start_time, end_time = self.presenter._get_work_times_on_date(
+            actual_start, actual_end, self.target_date
+        )
+
+        assert start_time is None
+        assert end_time is None
+
+    def test_work_after_target_date(self):
+        """Test work that started after the target date."""
+        actual_start = datetime(2026, 1, 31, 9, 0)
+        actual_end = datetime(2026, 2, 1, 17, 0)
+
+        start_time, end_time = self.presenter._get_work_times_on_date(
+            actual_start, actual_end, self.target_date
+        )
+
+        assert start_time is None
+        assert end_time is None
+
+
+class TestTimelinePresenterDurationCalculation:
+    """Test cases for _calculate_duration_hours method."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Set up test fixtures."""
+        self.presenter = TimelinePresenter()
+
+    def test_calculate_whole_hours(self):
+        """Test calculation with whole hours."""
+        start_time = time(9, 0)
+        end_time = time(12, 0)
+
+        duration = self.presenter._calculate_duration_hours(start_time, end_time)
+
+        assert duration == 3.0
+
+    def test_calculate_partial_hours(self):
+        """Test calculation with partial hours."""
+        start_time = time(9, 0)
+        end_time = time(11, 30)
+
+        duration = self.presenter._calculate_duration_hours(start_time, end_time)
+
+        assert duration == 2.5
+
+    def test_calculate_same_time(self):
+        """Test calculation with same start and end time."""
+        start_time = time(9, 0)
+        end_time = time(9, 0)
+
+        duration = self.presenter._calculate_duration_hours(start_time, end_time)
+
+        assert duration == 0.0

--- a/packages/taskdog-ui/tests/renderers/test_rich_timeline_renderer.py
+++ b/packages/taskdog-ui/tests/renderers/test_rich_timeline_renderer.py
@@ -1,0 +1,169 @@
+"""Tests for RichTimelineRenderer."""
+
+from datetime import date, time
+from unittest.mock import MagicMock
+
+import pytest
+
+from taskdog.renderers.rich_timeline_renderer import RichTimelineRenderer
+from taskdog.renderers.timeline_cell_formatter import TimelineCellFormatter
+from taskdog.view_models.timeline_view_model import (
+    TimelineTaskRowViewModel,
+    TimelineViewModel,
+)
+from taskdog_core.domain.entities.task import TaskStatus
+
+
+class TestRichTimelineRenderer:
+    """Test cases for RichTimelineRenderer."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Set up test fixtures."""
+        self.console_writer = MagicMock()
+        self.renderer = RichTimelineRenderer(self.console_writer)
+
+    def _create_row_vm(
+        self,
+        task_id: int = 1,
+        name: str = "Test Task",
+        actual_start: time = time(9, 0),
+        actual_end: time = time(12, 0),
+        duration_hours: float = 3.0,
+        status: TaskStatus = TaskStatus.COMPLETED,
+        is_finished: bool = True,
+    ) -> TimelineTaskRowViewModel:
+        """Create a TimelineTaskRowViewModel for testing."""
+        formatted_name = name
+        if is_finished:
+            formatted_name = f"[strike dim]{name}[/strike dim]"
+        return TimelineTaskRowViewModel(
+            task_id=task_id,
+            name=name,
+            formatted_name=formatted_name,
+            actual_start=actual_start,
+            actual_end=actual_end,
+            duration_hours=duration_hours,
+            status=status,
+            is_finished=is_finished,
+        )
+
+    def _create_timeline_vm(
+        self,
+        rows: list[TimelineTaskRowViewModel] | None = None,
+        target_date: date = date(2026, 1, 30),
+        start_hour: int = 8,
+        end_hour: int = 18,
+        total_work_hours: float = 0.0,
+    ) -> TimelineViewModel:
+        """Create a TimelineViewModel for testing."""
+        if rows is None:
+            rows = []
+        return TimelineViewModel(
+            target_date=target_date,
+            rows=rows,
+            start_hour=start_hour,
+            end_hour=end_hour,
+            total_work_hours=total_work_hours,
+            task_count=len(rows),
+        )
+
+    def test_render_empty_timeline(self):
+        """Test rendering with no tasks."""
+        timeline_vm = self._create_timeline_vm()
+        self.renderer.render(timeline_vm)
+
+        # Should show warning message
+        self.console_writer.warning.assert_called_once()
+        assert "No tasks with actual work times found" in str(
+            self.console_writer.warning.call_args
+        )
+
+    def test_render_with_tasks(self):
+        """Test rendering with tasks."""
+        rows = [
+            self._create_row_vm(1, "Task A", time(9, 0), time(11, 0), 2.0),
+            self._create_row_vm(2, "Task B", time(13, 0), time(15, 0), 2.0),
+        ]
+        timeline_vm = self._create_timeline_vm(
+            rows=rows,
+            total_work_hours=4.0,
+        )
+        self.renderer.render(timeline_vm)
+
+        # Should call print (for the table)
+        self.console_writer.print.assert_called_once()
+
+    def test_build_table_returns_none_for_empty(self):
+        """Test that build_table returns None for empty timeline."""
+        timeline_vm = self._create_timeline_vm()
+        result = self.renderer.build_table(timeline_vm)
+
+        assert result is None
+
+    def test_build_table_returns_table_for_tasks(self):
+        """Test that build_table returns a Table for timeline with tasks."""
+        rows = [self._create_row_vm()]
+        timeline_vm = self._create_timeline_vm(rows=rows, total_work_hours=3.0)
+        result = self.renderer.build_table(timeline_vm)
+
+        assert result is not None
+        # Check that the table has the expected columns
+        assert len(result.columns) == 4  # ID, Task, Timeline, Time
+
+
+class TestTimelineCellFormatter:
+    """Test cases for TimelineCellFormatter."""
+
+    def test_build_hour_header(self):
+        """Test building hour header."""
+        header = TimelineCellFormatter.build_hour_header(8, 12)
+
+        # Should contain hour labels
+        header_str = str(header)
+        assert "08" in header_str
+        assert "12" in header_str
+
+    def test_build_timeline_bar(self):
+        """Test building timeline bar."""
+        bar = TimelineCellFormatter.build_timeline_bar(
+            actual_start=time(9, 0),
+            actual_end=time(11, 0),
+            start_hour=8,
+            end_hour=12,
+            status=TaskStatus.COMPLETED,
+        )
+
+        # Should have some content
+        assert len(bar) > 0
+
+    def test_get_status_color_completed(self):
+        """Test status color for completed tasks."""
+        color = TimelineCellFormatter.get_status_color(TaskStatus.COMPLETED)
+        assert "green" in color
+
+    def test_get_status_color_in_progress(self):
+        """Test status color for in-progress tasks."""
+        color = TimelineCellFormatter.get_status_color(TaskStatus.IN_PROGRESS)
+        assert "blue" in color
+
+    def test_get_status_color_canceled(self):
+        """Test status color for canceled tasks."""
+        color = TimelineCellFormatter.get_status_color(TaskStatus.CANCELED)
+        assert "red" in color
+
+    def test_format_duration(self):
+        """Test duration formatting."""
+        assert TimelineCellFormatter.format_duration(2.5) == "2.5h"
+        assert TimelineCellFormatter.format_duration(1.0) == "1.0h"
+        assert TimelineCellFormatter.format_duration(0.5) == "0.5h"
+
+    def test_build_legend(self):
+        """Test building legend."""
+        legend = TimelineCellFormatter.build_legend()
+
+        # Should contain status labels
+        legend_str = str(legend)
+        assert "IN_PROGRESS" in legend_str
+        assert "COMPLETED" in legend_str
+        assert "CANCELED" in legend_str


### PR DESCRIPTION
## Summary

- Add `taskdog timeline` command that displays actual work times for a specific day
- Horizontal Gantt-like format with time-of-day on the x-axis and tasks on the y-axis
- Shows work periods with status-based colors (blue=IN_PROGRESS, green=COMPLETED, red=CANCELED)

## Usage

```bash
taskdog timeline              # Show today's work times
taskdog timeline -d 2026-01-29  # Show specific date
```

## Output Example

```
┌─ Timeline - 2026-01-30 (Thu) ─────────────────────────────────┐
│ ID │ Task    │ Timeline                              │ Time  │
├────┼─────────┼───────────────────────────────────────┼───────┤
│    │ Hour    │ 08   09   10   11   12   13   14   15 │       │
│  1 │ Task A  │      ████████████                     │  2.5h │
│  2 │ Task B  │                  ████████████████     │  3.0h │
├────┴─────────┴───────────────────────────────────────┴───────┤
│ Summary: 2 tasks | 5.5h worked                               │
└──────────────────────────────────────────────────────────────┘
```

## Implementation

- `TimelineViewModel` / `TimelineTaskRowViewModel` - Presentation data
- `TimelinePresenter` - Filters tasks by actual_start/actual_end on target date
- `TimelineCellFormatter` - Builds hour headers and timeline bars
- `RichTimelineRenderer` - Renders as Rich Table

## Note

🧪 **Experimental command** - This is a new visualization feature. API may change in future versions.

## Test plan

- [x] 27 unit tests for presenter and renderer
- [x] `make test-ui` passes (922 tests)
- [x] `make lint` passes
- [x] `make typecheck` passes

🤖 Generated with [Claude Code](https://claude.ai/code)