### PR TITLE
refactor(tui): remove unused get_success_message methods

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/commands/batch_confirmation_base.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/batch_confirmation_base.py
@@ -89,18 +89,6 @@ class BatchConfirmationCommandBase(TUICommandBase):
         """
         pass
 
-    @abstractmethod
-    def get_success_message(self, task_count: int) -> str:
-        """Return success message after batch operation.
-
-        Args:
-            task_count: Number of tasks successfully processed
-
-        Returns:
-            Success message text
-        """
-        pass
-
     def execute(self) -> None:
         """Execute batch operation with confirmation.
 

--- a/packages/taskdog-ui/src/taskdog/tui/commands/batch_status_change_base.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/batch_status_change_base.py
@@ -29,19 +29,6 @@ class BatchStatusChangeCommandBase(TUICommandBase):
         """
         pass
 
-    @abstractmethod
-    def get_success_message(self, task_name: str, task_id: int) -> str:
-        """Generate success message for a task.
-
-        Args:
-            task_name: Name of the task
-            task_id: ID of the task
-
-        Returns:
-            Success message string
-        """
-        pass
-
     def execute(self) -> None:
         """Execute status change on all selected tasks.
 

--- a/packages/taskdog-ui/src/taskdog/tui/commands/cancel.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/cancel.py
@@ -1,7 +1,6 @@
 """Cancel task command for TUI."""
 
 from taskdog.tui.commands.batch_confirmation_base import BatchConfirmationCommandBase
-from taskdog.tui.messages import TUIMessageBuilder
 
 
 class CancelCommand(BatchConfirmationCommandBase):
@@ -22,7 +21,3 @@ class CancelCommand(BatchConfirmationCommandBase):
     def execute_confirmed_action(self, task_id: int) -> None:
         """Cancel the task via API client."""
         self.context.api_client.cancel_task(task_id)
-
-    def get_success_message(self, task_count: int) -> str:
-        """Return the success message."""
-        return TUIMessageBuilder.batch_success("Canceled", task_count)

--- a/packages/taskdog-ui/src/taskdog/tui/commands/done.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/done.py
@@ -1,7 +1,6 @@
 """Complete task command for TUI."""
 
 from taskdog.tui.commands.batch_status_change_base import BatchStatusChangeCommandBase
-from taskdog.tui.messages import TUIMessageBuilder
 from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 
 
@@ -11,7 +10,3 @@ class DoneCommand(BatchStatusChangeCommandBase):
     def execute_single_task(self, task_id: int) -> TaskOperationOutput:
         """Complete the task via API client."""
         return self.context.api_client.complete_task(task_id)
-
-    def get_success_message(self, task_name: str, task_id: int) -> str:
-        """Return success message."""
-        return TUIMessageBuilder.task_action("Completed", task_name, task_id)

--- a/packages/taskdog-ui/src/taskdog/tui/commands/hard_delete.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/hard_delete.py
@@ -1,7 +1,6 @@
 """Hard delete task command for TUI."""
 
 from taskdog.tui.commands.batch_confirmation_base import BatchConfirmationCommandBase
-from taskdog.tui.messages import TUIMessageBuilder
 
 
 class HardDeleteCommand(BatchConfirmationCommandBase):
@@ -30,7 +29,3 @@ class HardDeleteCommand(BatchConfirmationCommandBase):
     def execute_confirmed_action(self, task_id: int) -> None:
         """Permanently delete the task (hard delete)."""
         self.context.api_client.remove_task(task_id)
-
-    def get_success_message(self, task_count: int) -> str:
-        """Return the success message."""
-        return TUIMessageBuilder.batch_success("Permanently deleted", task_count)

--- a/packages/taskdog-ui/src/taskdog/tui/commands/pause.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/pause.py
@@ -1,7 +1,6 @@
 """Pause task command for TUI."""
 
 from taskdog.tui.commands.batch_status_change_base import BatchStatusChangeCommandBase
-from taskdog.tui.messages import TUIMessageBuilder
 from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 
 
@@ -11,7 +10,3 @@ class PauseCommand(BatchStatusChangeCommandBase):
     def execute_single_task(self, task_id: int) -> TaskOperationOutput:
         """Pause the task via API client."""
         return self.context.api_client.pause_task(task_id)
-
-    def get_success_message(self, task_name: str, task_id: int) -> str:
-        """Return success message."""
-        return TUIMessageBuilder.task_action("Paused", task_name, task_id)

--- a/packages/taskdog-ui/src/taskdog/tui/commands/reopen.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/reopen.py
@@ -1,7 +1,6 @@
 """Reopen task command for TUI."""
 
 from taskdog.tui.commands.batch_confirmation_base import BatchConfirmationCommandBase
-from taskdog.tui.messages import TUIMessageBuilder
 
 
 class ReopenCommand(BatchConfirmationCommandBase):
@@ -22,7 +21,3 @@ class ReopenCommand(BatchConfirmationCommandBase):
     def execute_confirmed_action(self, task_id: int) -> None:
         """Reopen the task via API client."""
         self.context.api_client.reopen_task(task_id)
-
-    def get_success_message(self, task_count: int) -> str:
-        """Return the success message."""
-        return TUIMessageBuilder.batch_success("Reopened", task_count)

--- a/packages/taskdog-ui/src/taskdog/tui/commands/rm.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/rm.py
@@ -1,7 +1,6 @@
 """Delete task command for TUI."""
 
 from taskdog.tui.commands.batch_confirmation_base import BatchConfirmationCommandBase
-from taskdog.tui.messages import TUIMessageBuilder
 
 
 class RmCommand(BatchConfirmationCommandBase):
@@ -30,7 +29,3 @@ class RmCommand(BatchConfirmationCommandBase):
     def execute_confirmed_action(self, task_id: int) -> None:
         """Archive the task (soft delete)."""
         self.context.api_client.archive_task(task_id)
-
-    def get_success_message(self, task_count: int) -> str:
-        """Return the success message."""
-        return TUIMessageBuilder.batch_success("Archived", task_count)

--- a/packages/taskdog-ui/src/taskdog/tui/commands/start.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/start.py
@@ -1,7 +1,6 @@
 """Start task command for TUI."""
 
 from taskdog.tui.commands.batch_status_change_base import BatchStatusChangeCommandBase
-from taskdog.tui.messages import TUIMessageBuilder
 from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 
 
@@ -11,7 +10,3 @@ class StartCommand(BatchStatusChangeCommandBase):
     def execute_single_task(self, task_id: int) -> TaskOperationOutput:
         """Start the task via API client."""
         return self.context.api_client.start_task(task_id)
-
-    def get_success_message(self, task_name: str, task_id: int) -> str:
-        """Return success message."""
-        return TUIMessageBuilder.task_action("Started", task_name, task_id)

--- a/packages/taskdog-ui/tests/tui/commands/test_batch_confirmation_base.py
+++ b/packages/taskdog-ui/tests/tui/commands/test_batch_confirmation_base.py
@@ -30,10 +30,6 @@ class ConcreteBatchConfirmCommand(BatchConfirmationCommandBase):
         """Execute the action."""
         pass  # Will be mocked
 
-    def get_success_message(self, task_count: int) -> str:
-        """Return success message."""
-        return f"Processed {task_count} tasks"
-
 
 class TestBatchConfirmationCommandBase:
     """Test cases for BatchConfirmationCommandBase."""

--- a/packages/taskdog-ui/tests/tui/commands/test_batch_status_change_base.py
+++ b/packages/taskdog-ui/tests/tui/commands/test_batch_status_change_base.py
@@ -26,10 +26,6 @@ class ConcreteBatchCommand(BatchStatusChangeCommandBase):
         mock.name = f"Task {task_id}"
         return mock
 
-    def get_success_message(self, task_name: str, task_id: int) -> str:
-        """Get success message."""
-        return f"Completed: {task_name} (ID: {task_id})"
-
 
 class TestBatchStatusChangeCommandBase:
     """Test cases for BatchStatusChangeCommandBase."""


### PR DESCRIPTION
## Summary

- Remove dead code: `get_success_message()` methods that were defined but never called
- Success notifications are sent via WebSocket events, making these methods unnecessary
- Remove unused `TUIMessageBuilder` imports from subclasses

## Changes

**Base classes (abstract method removal):**
- `batch_status_change_base.py`: Removed abstract method
- `batch_confirmation_base.py`: Removed abstract method

**Subclasses (implementation + import removal):**
- `start.py`, `done.py`, `pause.py`: Removed method and import
- `cancel.py`, `reopen.py`, `rm.py`, `hard_delete.py`: Removed method and import

**Test files:**
- Updated concrete test classes to remove the method implementations

## Test plan

- [x] All 922 UI tests pass
- [x] Pre-commit hooks pass (ruff, mypy, etc.)
- [x] Verified no remaining calls to `get_success_message`

🤖 Generated with [Claude Code](https://claude.com/claude-code)