### PR TITLE
refactor(tui): remove unused methods from TUICommandBase

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/commands/base.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/base.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from taskdog.tui.context import TUIContext
 from taskdog.tui.events import TasksRefreshed
-from taskdog.view_models.task_view_model import TaskRowViewModel
-from taskdog_core.application.dto.task_dto import TaskDetailDto
 from taskdog_core.domain.exceptions.task_exceptions import (
     ServerConnectionError,
     TaskValidationError,
@@ -131,19 +129,6 @@ class TUICommandBase(ABC):  # noqa: B024
 
         return words
 
-    def get_selected_task(self) -> TaskDetailDto | None:
-        """Get the currently selected task from the table.
-
-        Returns:
-            The selected task DTO, or None if no task is selected or table not available
-        """
-        task_id = self.get_selected_task_id()
-        if task_id is None:
-            return None
-        # Use API client and extract task from output
-        output = self.context.api_client.get_task_by_id(task_id)
-        return output.task
-
     def get_selected_task_id(self) -> int | None:
         """Get the ID of the currently selected task.
 
@@ -153,16 +138,6 @@ class TUICommandBase(ABC):  # noqa: B024
         if not self.app.main_screen or not self.app.main_screen.task_table:
             return None
         return self.app.main_screen.task_table.get_selected_task_id()
-
-    def get_selected_task_vm(self) -> TaskRowViewModel | None:
-        """Get the currently selected task as a ViewModel.
-
-        Returns:
-            The selected TaskRowViewModel, or None if no task is selected
-        """
-        if not self.app.main_screen or not self.app.main_screen.task_table:
-            return None
-        return self.app.main_screen.task_table.get_selected_task_vm()
 
     def get_selected_task_ids(self) -> list[int]:
         """Get all selected task IDs for batch operations.

--- a/packages/taskdog-ui/tests/presentation/tui/commands/test_base.py
+++ b/packages/taskdog-ui/tests/presentation/tui/commands/test_base.py
@@ -5,9 +5,6 @@ from unittest.mock import MagicMock
 import pytest
 
 from taskdog.tui.commands.base import TUICommandBase
-from taskdog_core.application.dto.get_task_by_id_output import TaskByIdOutput
-from taskdog_core.application.dto.task_dto import TaskDetailDto
-from taskdog_core.domain.entities.task import Task, TaskStatus
 from taskdog_core.domain.exceptions.task_exceptions import TaskValidationError
 
 
@@ -50,63 +47,6 @@ class TestTUICommandBase:
         """Test command initialization."""
         assert self.command.app == self.app
         assert self.command.context == self.context
-
-    def test_get_selected_task_success(self):
-        """Test getting selected task successfully."""
-        task = Task(id=1, name="Test Task", priority=5, status=TaskStatus.PENDING)
-        # Create TaskDetailDto from task
-        task_dto = TaskDetailDto(
-            id=task.id,
-            name=task.name,
-            priority=task.priority,
-            status=task.status,
-            planned_start=None,
-            planned_end=None,
-            deadline=None,
-            actual_start=None,
-            actual_end=None,
-            actual_duration=None,
-            estimated_duration=None,
-            daily_allocations={},
-            is_fixed=False,
-            depends_on=[],
-            tags=[],
-            is_archived=False,
-            created_at=task.created_at,
-            updated_at=task.updated_at,
-            actual_duration_hours=None,
-            is_active=False,
-            is_finished=False,
-            can_be_modified=True,
-            is_schedulable=False,
-        )
-        # Mock get_selected_task_id to return the task ID
-        self.app.main_screen.task_table.get_selected_task_id.return_value = 1
-        # Mock API client to return the TaskByIdOutput
-        self.context.api_client.get_task_by_id.return_value = TaskByIdOutput(
-            task=task_dto
-        )
-
-        result = self.command.get_selected_task()
-
-        assert result == task_dto
-        self.context.api_client.get_task_by_id.assert_called_once_with(1)
-
-    def test_get_selected_task_no_screen(self):
-        """Test getting selected task when screen is not available."""
-        self.app.main_screen = None
-
-        result = self.command.get_selected_task()
-
-        assert result is None
-
-    def test_get_selected_task_no_table(self):
-        """Test getting selected task when table is not available."""
-        self.app.main_screen.task_table = None
-
-        result = self.command.get_selected_task()
-
-        assert result is None
 
     def test_reload_tasks(self):
         """Test reloading tasks posts TasksRefreshed event."""


### PR DESCRIPTION
## Summary

- Remove `get_selected_task()` method from `TUICommandBase` (only called in tests, not production code)
- Remove `get_selected_task_vm()` method from `TUICommandBase` (never called anywhere)
- Remove associated tests and unused imports (`TaskRowViewModel`, `TaskDetailDto`, `TaskByIdOutput`, `Task`, `TaskStatus`)

## Motivation

These methods were dead code that added maintenance burden without providing value. The actual implementations exist in `task_table.py` and `main_screen.py` widgets, and commands that need task data use `get_selected_task_id()` and fetch via API client directly.

## Changes

| File | Change |
|------|--------|
| `packages/taskdog-ui/src/taskdog/tui/commands/base.py` | Remove 2 methods + 2 imports |
| `packages/taskdog-ui/tests/presentation/tui/commands/test_base.py` | Remove 3 tests + 4 imports |

## Test plan

- [x] `make test-ui` - All 919 tests pass
- [x] `make typecheck` - No type errors
- [x] Verified no remaining usages in production code

🤖 Generated with [Claude Code](https://claude.com/claude-code)