### PR TITLE
refactor(core): remove dead code related to file-based notes

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/shared/constants/__init__.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/constants/__init__.py
@@ -16,11 +16,7 @@ from taskdog_core.shared.constants.config_defaults import (
     WORK_HOURS_END,
     WORK_HOURS_START,
 )
-from taskdog_core.shared.constants.file_management import (
-    CONFIG_FILE_NAME,
-    NOTE_FILE_EXTENSION,
-    NOTES_DIR_NAME,
-)
+from taskdog_core.shared.constants.file_management import CONFIG_FILE_NAME
 from taskdog_core.shared.constants.formats import DATETIME_FORMAT
 from taskdog_core.shared.constants.status_verbs import StatusVerbs
 from taskdog_core.shared.constants.time import (
@@ -61,8 +57,6 @@ __all__ = [
     "MAX_TASK_NAME_LENGTH",
     "MIN_HOURS_PER_DAY_EXCLUSIVE",
     "MIN_PRIORITY_EXCLUSIVE",
-    "NOTES_DIR_NAME",
-    "NOTE_FILE_EXTENSION",
     "SATURDAY",
     "SORT_SENTINEL_FUTURE",
     "SORT_SENTINEL_PAST",

--- a/packages/taskdog-core/src/taskdog_core/shared/constants/file_management.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/constants/file_management.py
@@ -1,10 +1,4 @@
 """File and directory management constants."""
 
-# File Extensions
-NOTE_FILE_EXTENSION = ".md"
-
 # File Names
 CONFIG_FILE_NAME = "core.toml"
-
-# Directory Names
-NOTES_DIR_NAME = "notes"

--- a/packages/taskdog-core/src/taskdog_core/shared/xdg_utils.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/xdg_utils.py
@@ -7,11 +7,7 @@ https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 import os
 from pathlib import Path
 
-from taskdog_core.shared.constants.file_management import (
-    CONFIG_FILE_NAME,
-    NOTE_FILE_EXTENSION,
-    NOTES_DIR_NAME,
-)
+from taskdog_core.shared.constants.file_management import CONFIG_FILE_NAME
 
 
 class XDGDirectories:
@@ -54,29 +50,6 @@ class XDGDirectories:
             config_dir.mkdir(parents=True, exist_ok=True)
 
         return config_dir
-
-    @classmethod
-    def get_notes_dir(cls) -> Path:
-        """Get path to notes directory.
-
-        Returns:
-            Path to notes directory in data directory
-        """
-        notes_dir = cls.get_data_home() / NOTES_DIR_NAME
-        notes_dir.mkdir(parents=True, exist_ok=True)
-        return notes_dir
-
-    @classmethod
-    def get_note_file(cls, task_id: int | None) -> Path:
-        """Get path to a specific task's note file.
-
-        Args:
-            task_id: Task ID
-
-        Returns:
-            Path to note markdown file
-        """
-        return cls.get_notes_dir() / f"{task_id}{NOTE_FILE_EXTENSION}"
 
     @classmethod
     def get_config_file(cls) -> Path:

--- a/packages/taskdog-core/tests/shared/test_xdg_utils.py
+++ b/packages/taskdog-core/tests/shared/test_xdg_utils.py
@@ -40,21 +40,6 @@ class TestXDGDirectories:
             expected = Path("/tmp/test_config/taskdog")
             assert config_home == expected
 
-    def test_get_note_file(self):
-        """Test get_note_file returns correct path for task ID."""
-        with patch.dict(os.environ, {"XDG_DATA_HOME": "/tmp/test_data"}):
-            note_file = XDGDirectories.get_note_file(42)
-            # Note: get_note_file calls get_notes_dir which creates the directory
-            expected = Path("/tmp/test_data/taskdog/notes/42.md")
-            assert note_file == expected
-
-    def test_get_notes_dir(self):
-        """Test get_notes_dir returns correct path."""
-        with patch.dict(os.environ, {"XDG_DATA_HOME": "/tmp/test_data"}):
-            notes_dir = XDGDirectories.get_notes_dir()
-            expected = Path("/tmp/test_data/taskdog/notes")
-            assert notes_dir == expected
-
     def test_get_config_file(self):
         """Test get_config_file returns correct path."""
         with patch.dict(os.environ, {"XDG_CONFIG_HOME": "/tmp/test_config"}):


### PR DESCRIPTION
## Summary

- Remove utility functions and constants left behind after `FileNotesRepository` was deleted in PR #602
- Clean up unused `get_notes_dir()` and `get_note_file()` methods from `XDGDirectories`
- Remove `NOTES_DIR_NAME` and `NOTE_FILE_EXTENSION` constants
- Remove related test cases

## Changes

| File | Changes |
|------|---------|
| `xdg_utils.py` | Removed `get_notes_dir()` and `get_note_file()` methods |
| `file_management.py` | Removed `NOTE_FILE_EXTENSION` and `NOTES_DIR_NAME` constants |
| `constants/__init__.py` | Removed exports of deleted constants |
| `test_xdg_utils.py` | Removed tests for deleted methods |

## Test plan

- [x] `make test-core` passes (1068 tests)
- [x] `make typecheck` passes (all 5 packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)