### PR TITLE
refactor(core): inject HolidayChecker into TaskCrudController via DI

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/controllers/task_crud_controller.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/task_crud_controller.py
@@ -26,7 +26,6 @@ from taskdog_core.domain.repositories.notes_repository import NotesRepository
 from taskdog_core.domain.repositories.task_repository import TaskRepository
 from taskdog_core.domain.services.holiday_checker import IHolidayChecker
 from taskdog_core.domain.services.logger import Logger
-from taskdog_core.infrastructure.holiday_checker import HolidayChecker
 from taskdog_core.shared.config_manager import Config
 
 
@@ -54,6 +53,7 @@ class TaskCrudController(BaseTaskController):
         notes_repository: NotesRepository,
         config: Config,
         logger: Logger,
+        holiday_checker: IHolidayChecker | None = None,
     ):
         """Initialize the CRUD controller.
 
@@ -62,25 +62,11 @@ class TaskCrudController(BaseTaskController):
             notes_repository: Notes repository
             config: Application configuration
             logger: Logger for operation tracking
+            holiday_checker: Holiday checker for workload calculations (optional)
         """
         super().__init__(repository, config, logger)
         self.notes_repository = notes_repository
-        self._holiday_checker = self._create_holiday_checker()
-
-    def _create_holiday_checker(self) -> IHolidayChecker | None:
-        """Create HolidayChecker from config country setting.
-
-        Returns:
-            HolidayChecker if country is configured, None otherwise
-        """
-        country = self.config.region.country if self.config.region else None
-        if not country or not isinstance(country, str):
-            return None
-        try:
-            return HolidayChecker(country)
-        except (ImportError, NotImplementedError):
-            # holidays package not installed or country not supported
-            return None
+        self._holiday_checker = holiday_checker
 
     def create_task(
         self,

--- a/packages/taskdog-core/tests/controllers/test_task_crud_controller.py
+++ b/packages/taskdog-core/tests/controllers/test_task_crud_controller.py
@@ -132,12 +132,31 @@ class TestTaskCrudController:
         assert self.controller.repository == self.repository
         assert self.controller.config == self.config
 
-    def test_create_holiday_checker_with_valid_country(self, repository):
-        """Test that HolidayChecker is created when country is configured."""
+    def test_holiday_checker_injected(self, repository):
+        """Test that HolidayChecker is properly injected via DI."""
         # Arrange
         notes_repository = MagicMock()
         config = MagicMock()
-        config.region.country = "JP"  # Valid country code
+        logger = Mock(spec=Logger)
+        holiday_checker = MagicMock()
+
+        # Act
+        controller = TaskCrudController(
+            repository=repository,
+            notes_repository=notes_repository,
+            config=config,
+            logger=logger,
+            holiday_checker=holiday_checker,
+        )
+
+        # Assert - HolidayChecker should be the injected instance
+        assert controller._holiday_checker is holiday_checker
+
+    def test_holiday_checker_defaults_to_none(self, repository):
+        """Test that HolidayChecker is None when not provided."""
+        # Arrange
+        notes_repository = MagicMock()
+        config = MagicMock()
         logger = Mock(spec=Logger)
 
         # Act
@@ -148,24 +167,5 @@ class TestTaskCrudController:
             logger=logger,
         )
 
-        # Assert - HolidayChecker should be created
-        assert controller._holiday_checker is not None
-
-    def test_create_holiday_checker_without_region(self, repository):
-        """Test that HolidayChecker is None when region is not configured."""
-        # Arrange
-        notes_repository = MagicMock()
-        config = MagicMock()
-        config.region = None  # No region configured
-        logger = Mock(spec=Logger)
-
-        # Act
-        controller = TaskCrudController(
-            repository=repository,
-            notes_repository=notes_repository,
-            config=config,
-            logger=logger,
-        )
-
-        # Assert - HolidayChecker should be None
+        # Assert - HolidayChecker should be None when not provided
         assert controller._holiday_checker is None

--- a/packages/taskdog-server/src/taskdog_server/api/dependencies.py
+++ b/packages/taskdog-server/src/taskdog_server/api/dependencies.py
@@ -125,7 +125,7 @@ def initialize_api_context(
         repository, config, holiday_checker, analytics_logger
     )
     crud_controller = TaskCrudController(
-        repository, notes_repository, config, crud_logger
+        repository, notes_repository, config, crud_logger, holiday_checker
     )
     audit_log_controller = AuditLogController(audit_log_repository, audit_log_logger)
 


### PR DESCRIPTION
## Summary
- Remove duplicate `HolidayChecker` initialization from `TaskCrudController`
- The `HolidayChecker` was already being created in `dependencies.py`, so the controller was unnecessarily creating its own instance internally
- Unify the DI pattern by accepting `holiday_checker` as a constructor parameter

## Changes
- Add `holiday_checker: IHolidayChecker | None` parameter to `TaskCrudController.__init__`
- Remove `_create_holiday_checker()` method from `TaskCrudController`
- Remove `HolidayChecker` import from controller (now only uses interface)
- Pass existing `holiday_checker` from `dependencies.py` to controller
- Update tests to reflect DI-based initialization

## Test plan
- [x] `make test-core` - All 1066 tests pass
- [x] `make test-server` - All 270 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)