### PR TITLE
refactor(ui): remove hide_completed toggle feature from TUI

### DIFF
--- a/packages/taskdog-ui/src/taskdog/services/task_data_loader.py
+++ b/packages/taskdog-ui/src/taskdog/services/task_data_loader.py
@@ -11,7 +11,6 @@ from taskdog.view_models.gantt_view_model import GanttViewModel
 from taskdog.view_models.task_view_model import TaskRowViewModel
 from taskdog_core.application.dto.task_dto import TaskRowDto
 from taskdog_core.application.dto.task_list_output import TaskListOutput
-from taskdog_core.domain.entities.task import TaskStatus
 
 
 @dataclass
@@ -64,7 +63,6 @@ class TaskDataLoader:
         all: bool = False,
         sort_by: str = "id",
         reverse: bool = False,
-        hide_completed: bool = False,
         date_range: tuple[date, date] | None = None,
     ) -> TaskData:
         """Load tasks from API and create ViewModels.
@@ -73,7 +71,6 @@ class TaskDataLoader:
             all: Include archived tasks (default: False)
             sort_by: Sort field name
             reverse: Sort direction (default: False for ascending)
-            hide_completed: Whether to hide completed/canceled tasks
             date_range: Optional (start_date, end_date) for gantt data
 
         Returns:
@@ -95,8 +92,8 @@ class TaskDataLoader:
         # Cache all tasks
         all_tasks = task_list_output.tasks
 
-        # Apply display filter
-        filtered_tasks = self.apply_display_filter(all_tasks, hide_completed)
+        # filtered_tasks is now identical to all_tasks (no hide_completed filter)
+        filtered_tasks = all_tasks
 
         # Create table ViewModels from ALL tasks (not filtered)
         # TUIState will handle filtering via filtered_viewmodels property
@@ -124,27 +121,6 @@ class TaskDataLoader:
             gantt_view_model=gantt_view_model,
             filtered_gantt_view_model=filtered_gantt_view_model,
         )
-
-    def apply_display_filter(
-        self, tasks: list[TaskRowDto], hide_completed: bool
-    ) -> list[TaskRowDto]:
-        """Apply display filter based on hide_completed setting.
-
-        Args:
-            tasks: List of all tasks
-            hide_completed: Whether to hide completed/canceled tasks
-
-        Returns:
-            Filtered list of tasks
-        """
-        if not hide_completed:
-            return tasks
-
-        return [
-            task
-            for task in tasks
-            if task.status not in (TaskStatus.COMPLETED, TaskStatus.CANCELED)
-        ]
 
     def filter_gantt_by_tasks(
         self, gantt_view_model: GanttViewModel, tasks: list[TaskRowDto]

--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -135,13 +135,6 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
             tooltip="Edit markdown notes for the selected task",
         ),
         Binding(
-            "t",
-            "toggle_completed",
-            "Toggle Done",
-            show=False,
-            tooltip="Toggle visibility of completed and canceled tasks",
-        ),
-        Binding(
             "/", "show_search", "Search", show=False, tooltip="Search for tasks by name"
         ),
         Binding(
@@ -238,7 +231,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         self.connection_manager = ConnectionStatusManager()
 
         # NOTE: All legacy state fields migrated to self.state (Phase 2 complete)
-        # - _gantt_sort_by, _gantt_reverse, _hide_completed → state (Step 2-3)
+        # - _gantt_sort_by, _gantt_reverse → state (Step 2-3)
         # - _all_tasks, _gantt_view_model → state (Step 4)
         # - viewmodels → state (Step 5)
 
@@ -455,18 +448,6 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         """Hide the search input and clear the filter."""
         if self.main_screen:
             self.main_screen.hide_search()
-
-    def action_toggle_completed(self) -> None:
-        """Toggle visibility of completed and canceled tasks."""
-        self.state.hide_completed = not self.state.hide_completed
-
-        # Reload tasks with new filter to recalculate gantt date range
-        if self.task_ui_manager:
-            self.task_ui_manager.load_tasks(keep_scroll_position=True)
-
-        # Show notification
-        status = "hidden" if self.state.hide_completed else "shown"
-        self.notify(f"Completed tasks {status}")
 
     def action_toggle_sort_reverse(self) -> None:
         """Toggle sort direction (ascending ⇔ descending)."""

--- a/packages/taskdog-ui/src/taskdog/tui/constants/keybindings.py
+++ b/packages/taskdog-ui/src/taskdog/tui/constants/keybindings.py
@@ -34,7 +34,6 @@ MAIN_FEATURES: str = """## Key Features
 
 - **Task Table** - Main view showing all your tasks
   - Use `j`/`k` or arrow keys to navigate
-  - Press `t` to toggle completed/canceled tasks
 
 - **Gantt Chart** - Visual timeline of your tasks
   - Shows task schedules and workload per day

--- a/packages/taskdog-ui/src/taskdog/tui/services/task_ui_manager.py
+++ b/packages/taskdog-ui/src/taskdog/tui/services/task_ui_manager.py
@@ -98,7 +98,6 @@ class TaskUIManager:
                 all=False,  # Non-archived by default
                 sort_by=self.state.sort_by,
                 reverse=self.state.sort_reverse,
-                hide_completed=self.state.hide_completed,
                 date_range=date_range,
             )
         except ServerConnectionError as e:
@@ -238,15 +237,6 @@ class TaskUIManager:
         gantt_view_model = self.task_data_loader.gantt_presenter.present(
             task_list_output.gantt_data
         )
-
-        # Apply display filter based on hide_completed setting
-        if self.state.hide_completed:
-            filtered_tasks = self.task_data_loader.apply_display_filter(
-                task_list_output.tasks, self.state.hide_completed
-            )
-            gantt_view_model = self.task_data_loader.filter_gantt_by_tasks(
-                gantt_view_model, filtered_tasks
-            )
 
         return gantt_view_model
 

--- a/packages/taskdog-ui/src/taskdog/tui/state/tui_state.py
+++ b/packages/taskdog-ui/src/taskdog/tui/state/tui_state.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass, field
 from taskdog.view_models.gantt_view_model import GanttViewModel
 from taskdog.view_models.task_view_model import TaskRowViewModel
 from taskdog_core.application.dto.task_dto import TaskRowDto
-from taskdog_core.domain.entities.task import TaskStatus
 
 
 @dataclass
@@ -20,7 +19,6 @@ class TUIState:
     duplication and synchronization issues.
 
     State Categories:
-    - Filter Settings: hide_completed
     - Sort Settings: sort_by, sort_reverse
     - Data Caches: tasks_cache, viewmodels_cache, gantt_cache
 
@@ -28,10 +26,6 @@ class TUIState:
     application state, replacing scattered state fields across
     TaskdogTUI, GanttWidget, and TaskTable.
     """
-
-    # === Filter Settings ===
-    hide_completed: bool = False
-    """Whether to hide completed/canceled tasks (default: show all)."""
 
     # === Sort Settings ===
     sort_by: str = "deadline"
@@ -53,35 +47,21 @@ class TUIState:
     # === Computed Properties ===
     @property
     def filtered_tasks(self) -> list[TaskRowDto]:
-        """Get tasks after applying display filter.
+        """Get tasks for display.
 
         Returns:
-            Filtered task list based on hide_completed setting.
-            If hide_completed=False, returns all tasks.
-            If hide_completed=True, returns only non-finished tasks.
+            All tasks from cache.
         """
-        if not self.hide_completed:
-            return self.tasks_cache
-
-        return [
-            task
-            for task in self.tasks_cache
-            if task.status not in (TaskStatus.COMPLETED, TaskStatus.CANCELED)
-        ]
+        return self.tasks_cache
 
     @property
     def filtered_viewmodels(self) -> list[TaskRowViewModel]:
-        """Get ViewModels after applying display filter.
+        """Get ViewModels for display.
 
         Returns:
-            Filtered ViewModel list based on hide_completed setting.
-            If hide_completed=False, returns all ViewModels.
-            If hide_completed=True, returns only non-finished ViewModels.
+            All ViewModels from cache.
         """
-        if not self.hide_completed:
-            return self.viewmodels_cache
-
-        return [vm for vm in self.viewmodels_cache if not vm.is_finished]
+        return self.viewmodels_cache
 
     def clear_caches(self) -> None:
         """Clear all cached data.

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/task_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/task_table.py
@@ -209,10 +209,10 @@ class TaskTable(DataTable, TUIWidget, ViNavigationMixin):  # type: ignore[type-a
         return self._viewmodel_map.get(self.cursor_row)
 
     def _get_all_viewmodels_from_state(self) -> list[TaskRowViewModel]:
-        """Get filtered viewmodels from app state.
+        """Get viewmodels from app state.
 
         Returns:
-            List of filtered TaskRowViewModel based on hide_completed setting
+            List of TaskRowViewModel from state cache
         """
         return self.tui_state.filtered_viewmodels
 

--- a/packages/taskdog-ui/tests/services/test_task_data_loader.py
+++ b/packages/taskdog-ui/tests/services/test_task_data_loader.py
@@ -48,7 +48,6 @@ class TestTaskDataLoader:
         result = self.loader.load_tasks(
             all=False,
             sort_by="deadline",
-            hide_completed=False,
             date_range=None,
         )
 
@@ -65,34 +64,6 @@ class TestTaskDataLoader:
         call_args = self.api_client.list_tasks.call_args
         assert call_args.kwargs["sort_by"] == "deadline"
         assert call_args.kwargs["reverse"] is False
-
-    def test_load_tasks_with_hide_completed(self):
-        """Test loading tasks with hide_completed filter."""
-        # Setup mocks
-        task1 = Task(id=1, name="Task 1", priority=1, status=TaskStatus.PENDING)
-        task2 = Task(id=2, name="Task 2", priority=2, status=TaskStatus.COMPLETED)
-        task3 = Task(id=3, name="Task 3", priority=3, status=TaskStatus.CANCELED)
-
-        task_list_output = TaskListOutput(
-            tasks=[task1, task2, task3], total_count=3, filtered_count=3
-        )
-        self.api_client.list_tasks.return_value = task_list_output
-
-        view_model1 = Mock(spec=TaskRowViewModel)
-        self.table_presenter.present.return_value = [view_model1]
-
-        # Execute with hide_completed=True
-        result = self.loader.load_tasks(
-            all=False,
-            sort_by="deadline",
-            hide_completed=True,
-            date_range=None,
-        )
-
-        # Verify - only PENDING task should remain
-        assert len(result.all_tasks) == 3
-        assert len(result.filtered_tasks) == 1
-        assert result.filtered_tasks[0].id == 1
 
     def test_load_tasks_with_gantt(self):
         """Test loading tasks with gantt data."""
@@ -141,7 +112,6 @@ class TestTaskDataLoader:
         result = self.loader.load_tasks(
             all=False,
             sort_by="deadline",
-            hide_completed=False,
             date_range=(date(2025, 1, 1), date(2025, 1, 7)),
         )
 
@@ -157,31 +127,6 @@ class TestTaskDataLoader:
         assert call_args.kwargs["include_gantt"] is True
         assert call_args.kwargs["gantt_start_date"] == date(2025, 1, 1)
         assert call_args.kwargs["gantt_end_date"] == date(2025, 1, 7)
-
-    def test_apply_display_filter_show_all(self):
-        """Test apply_display_filter with hide_completed=False."""
-        task1 = Task(id=1, name="Task 1", priority=1, status=TaskStatus.PENDING)
-        task2 = Task(id=2, name="Task 2", priority=2, status=TaskStatus.COMPLETED)
-        tasks = [task1, task2]
-
-        result = self.loader.apply_display_filter(tasks, hide_completed=False)
-
-        assert len(result) == 2
-
-    def test_apply_display_filter_hide_completed(self):
-        """Test apply_display_filter with hide_completed=True."""
-        task1 = Task(id=1, name="Task 1", priority=1, status=TaskStatus.PENDING)
-        task2 = Task(id=2, name="Task 2", priority=2, status=TaskStatus.COMPLETED)
-        task3 = Task(id=3, name="Task 3", priority=3, status=TaskStatus.CANCELED)
-        task4 = Task(id=4, name="Task 4", priority=4, status=TaskStatus.IN_PROGRESS)
-        tasks = [task1, task2, task3, task4]
-
-        result = self.loader.apply_display_filter(tasks, hide_completed=True)
-
-        # Only PENDING and IN_PROGRESS should remain
-        assert len(result) == 2
-        statuses = {t.status for t in result}
-        assert statuses == {TaskStatus.PENDING, TaskStatus.IN_PROGRESS}
 
     def test_filter_gantt_by_tasks(self):
         """Test filtering gantt view model by tasks."""

--- a/packages/taskdog-ui/tests/tui/services/test_task_ui_manager.py
+++ b/packages/taskdog-ui/tests/tui/services/test_task_ui_manager.py
@@ -239,7 +239,6 @@ class TestTaskUIManager:
         # Setup state
         self.state.sort_by = "priority"
         self.state.sort_reverse = True
-        self.state.hide_completed = True
 
         task_data = create_task_data()
         self.task_data_loader.load_tasks.return_value = task_data
@@ -255,7 +254,6 @@ class TestTaskUIManager:
         call_kwargs = self.task_data_loader.load_tasks.call_args[1]
         assert call_kwargs["sort_by"] == "priority"
         assert call_kwargs["reverse"] is True
-        assert call_kwargs["hide_completed"] is True
 
     def test_update_cache_updates_state(self):
         """Test _update_cache updates TUIState correctly."""
@@ -409,40 +407,6 @@ class TestRecalculateGantt:
         assert (
             call_kwargs["sort_by"] == "priority"
         )  # Respects gantt_widget.get_sort_by()
-
-    def test_recalculate_gantt_applies_hide_completed_filter(self):
-        """Test recalculate_gantt respects hide_completed setting."""
-        # Setup
-        self.state.hide_completed = True
-
-        task = create_task_dto(1, "Test Task", TaskStatus.PENDING)
-        gantt = create_gantt_viewmodel()
-        filtered_gantt = create_gantt_viewmodel()
-
-        task_list_output = TaskListOutput(
-            tasks=[task],
-            total_count=1,
-            filtered_count=1,
-            gantt_data=MagicMock(),
-        )
-        self.task_data_loader.api_client.list_tasks.return_value = task_list_output
-        self.task_data_loader.gantt_presenter.present.return_value = gantt
-        self.task_data_loader.apply_display_filter.return_value = [task]
-        self.task_data_loader.filter_gantt_by_tasks.return_value = filtered_gantt
-
-        # Execute
-        self.manager.recalculate_gantt(date(2024, 1, 1), date(2024, 1, 31))
-
-        # Verify filter methods were called
-        self.task_data_loader.apply_display_filter.assert_called_once_with([task], True)
-        self.task_data_loader.filter_gantt_by_tasks.assert_called_once_with(
-            gantt, [task]
-        )
-
-        # Verify widget was updated with filtered gantt
-        self.main_screen.gantt_widget.update_view_model_and_render.assert_called_once_with(
-            filtered_gantt
-        )
 
     def test_recalculate_gantt_handles_connection_error(self):
         """Test recalculate_gantt calls error callback on failure."""

--- a/packages/taskdog-ui/tests/tui/state/test_tui_state.py
+++ b/packages/taskdog-ui/tests/tui/state/test_tui_state.py
@@ -71,15 +71,14 @@ class TestTUIState:
 
     def test_default_values(self):
         """Test default state values are correctly initialized."""
-        assert self.state.hide_completed is False
         assert self.state.sort_by == "deadline"
         assert self.state.sort_reverse is False
         assert self.state.tasks_cache == []
         assert self.state.viewmodels_cache == []
         assert self.state.gantt_cache is None
 
-    def test_filtered_tasks_show_all(self):
-        """Test filtered_tasks returns all tasks when hide_completed=False."""
+    def test_filtered_tasks_returns_all(self):
+        """Test filtered_tasks returns all tasks from cache."""
         # Setup tasks with mixed statuses
         tasks = [
             create_task_dto(1, "Task 1", TaskStatus.COMPLETED),
@@ -87,60 +86,23 @@ class TestTUIState:
             create_task_dto(3, "Task 3", TaskStatus.CANCELED),
         ]
         self.state.tasks_cache = tasks
-        self.state.hide_completed = False
 
         # Should return all tasks
         filtered = self.state.filtered_tasks
         assert len(filtered) == 3
 
-    def test_filtered_tasks_hide_completed(self):
-        """Test filtered_tasks hides completed/canceled when hide_completed=True."""
-        # Setup tasks with mixed statuses
-        tasks = [
-            create_task_dto(1, "Task 1", TaskStatus.COMPLETED),
-            create_task_dto(2, "Task 2", TaskStatus.PENDING),
-            create_task_dto(3, "Task 3", TaskStatus.CANCELED),
-            create_task_dto(4, "Task 4", TaskStatus.IN_PROGRESS),
-        ]
-        self.state.tasks_cache = tasks
-        self.state.hide_completed = True
-
-        # Should return only non-finished tasks
-        filtered = self.state.filtered_tasks
-        assert len(filtered) == 2
-        assert filtered[0].id == 2
-        assert filtered[1].id == 4
-
-    def test_filtered_viewmodels_show_all(self):
-        """Test filtered_viewmodels returns all when hide_completed=False."""
+    def test_filtered_viewmodels_returns_all(self):
+        """Test filtered_viewmodels returns all viewmodels from cache."""
         # Setup viewmodels with mixed statuses
         vms = [
             create_task_viewmodel(1, "Task 1", TaskStatus.COMPLETED, True),
             create_task_viewmodel(2, "Task 2", TaskStatus.PENDING, False),
         ]
         self.state.viewmodels_cache = vms
-        self.state.hide_completed = False
 
         # Should return all
         filtered = self.state.filtered_viewmodels
         assert len(filtered) == 2
-
-    def test_filtered_viewmodels_hide_completed(self):
-        """Test filtered_viewmodels hides finished when hide_completed=True."""
-        # Setup viewmodels with mixed statuses
-        vms = [
-            create_task_viewmodel(1, "Task 1", TaskStatus.COMPLETED, True),
-            create_task_viewmodel(2, "Task 2", TaskStatus.PENDING, False),
-            create_task_viewmodel(3, "Task 3", TaskStatus.CANCELED, True),
-        ]
-        self.state.viewmodels_cache = vms
-        self.state.hide_completed = True
-
-        # Should return only non-finished
-        filtered = self.state.filtered_viewmodels
-        assert len(filtered) == 1
-        assert filtered[0].id == 2
-        assert filtered[0].is_finished is False
 
     def test_update_caches_atomically(self):
         """Test update_caches updates all fields atomically."""


### PR DESCRIPTION
## Summary

- Remove the `t` keybinding that toggled visibility of completed/canceled tasks in the TUI
- Simplify filter logic by always showing all non-archived tasks
- Remove `hide_completed` flag and related filtering methods

## Changes

- Remove `t` keybinding and `action_toggle_completed` method from `app.py`
- Remove `hide_completed` flag from `TUIState`
- Simplify `filtered_tasks`/`filtered_viewmodels` properties to return all cached data
- Remove `apply_display_filter` method from `TaskDataLoader`
- Remove `hide_completed` parameter from `load_tasks`
- Update help text to remove `t` key documentation
- Remove related tests (5 tests removed)

## Test plan

- [x] All existing tests pass (898 passed)
- [x] Lint passes
- [x] TUI displays all non-archived tasks without filter toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)