### PR TITLE
feat(ui): add fzf-style exclusion syntax to TUI search filter

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/widgets/search_query_parser.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/search_query_parser.py
@@ -1,0 +1,127 @@
+"""Search query parser for fzf-style filter syntax."""
+
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import ClassVar
+
+
+class TokenType(Enum):
+    """Type of search token."""
+
+    INCLUDE = auto()  # Normal substring match
+    EXCLUDE = auto()  # !term - exclude matches
+    EXCLUDE_STATUS = auto()  # !status:VALUE or !completed shorthand
+    EXCLUDE_TAG = auto()  # !tag:tagname
+
+
+@dataclass(frozen=True)
+class SearchToken:
+    """A parsed search token.
+
+    Attributes:
+        type: The type of token (include, exclude, etc.)
+        value: The value to match against
+    """
+
+    type: TokenType
+    value: str
+
+
+class SearchQueryParser:
+    """Parser for fzf-style search queries.
+
+    Supports:
+    - Simple terms: substring match (e.g., "bug")
+    - Exclusion: !term (e.g., "!bug" excludes tasks containing "bug")
+    - Status exclusion: !status:VALUE (e.g., "!status:COMPLETED")
+    - Status shorthands: !completed, !pending, !in_progress, !canceled
+    - Tag exclusion: !tag:tagname (e.g., "!tag:urgent")
+    - Multiple tokens: AND logic (e.g., "bug !completed" = contains bug AND not completed)
+    """
+
+    # Status shorthands that map to status values
+    # !completed is special - maps to is_finished which covers COMPLETED + CANCELED
+    STATUS_SHORTHANDS: ClassVar[dict[str, str]] = {
+        "completed": "is_finished",
+        "pending": "PENDING",
+        "in_progress": "IN_PROGRESS",
+        "canceled": "CANCELED",
+    }
+
+    def parse(self, query: str) -> list[SearchToken]:
+        """Parse a query string into a list of search tokens.
+
+        Args:
+            query: The search query string
+
+        Returns:
+            List of SearchToken objects representing the parsed query
+        """
+        if not query or not query.strip():
+            return []
+
+        tokens: list[SearchToken] = []
+        parts = query.split()
+
+        for part in parts:
+            token = self._parse_token(part)
+            if token is not None:
+                tokens.append(token)
+
+        return tokens
+
+    def _parse_token(self, part: str) -> SearchToken | None:
+        """Parse a single token from the query.
+
+        Args:
+            part: A single space-separated part of the query
+
+        Returns:
+            A SearchToken representing this part, or None if token should be skipped
+        """
+        # Check for exclusion prefix
+        if part.startswith("!"):
+            if len(part) == 1:
+                # Lone "!" = empty exclusion = matches everything (fzf behavior)
+                return None
+            return self._parse_exclusion(part[1:])
+
+        # Regular include token
+        return SearchToken(type=TokenType.INCLUDE, value=part)
+
+    def _parse_exclusion(self, value: str) -> SearchToken:
+        """Parse an exclusion token (after the ! prefix).
+
+        Args:
+            value: The value after the ! prefix
+
+        Returns:
+            A SearchToken for the exclusion
+        """
+        lower_value = value.lower()
+
+        # Check for status shorthands first
+        if lower_value in self.STATUS_SHORTHANDS:
+            return SearchToken(
+                type=TokenType.EXCLUDE_STATUS,
+                value=self.STATUS_SHORTHANDS[lower_value],
+            )
+
+        # Check for explicit status: prefix
+        if lower_value.startswith("status:"):
+            status_value = value[7:]  # Preserve original case after prefix
+            if status_value:  # Has value after prefix
+                return SearchToken(type=TokenType.EXCLUDE_STATUS, value=status_value)
+            # No value after prefix, treat as literal exclude
+            return SearchToken(type=TokenType.EXCLUDE, value=value)
+
+        # Check for tag: prefix
+        if lower_value.startswith("tag:"):
+            tag_value = value[4:]  # Preserve original case after prefix
+            if tag_value:  # Has value after prefix
+                return SearchToken(type=TokenType.EXCLUDE_TAG, value=tag_value)
+            # No value after prefix, treat as literal exclude
+            return SearchToken(type=TokenType.EXCLUDE, value=value)
+
+        # Regular exclusion
+        return SearchToken(type=TokenType.EXCLUDE, value=value)

--- a/packages/taskdog-ui/tests/presentation/tui/widgets/test_search_query_parser.py
+++ b/packages/taskdog-ui/tests/presentation/tui/widgets/test_search_query_parser.py
@@ -1,0 +1,201 @@
+"""Tests for SearchQueryParser."""
+
+import pytest
+
+from taskdog.tui.widgets.search_query_parser import (
+    SearchQueryParser,
+    SearchToken,
+    TokenType,
+)
+
+
+class TestSearchQueryParser:
+    """Test SearchQueryParser parsing functionality."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Set up test fixtures."""
+        self.parser = SearchQueryParser()
+
+    def test_parse_empty_query(self):
+        """Test parsing empty query returns empty list."""
+        tokens = self.parser.parse("")
+        assert tokens == []
+
+    def test_parse_whitespace_only_query(self):
+        """Test parsing whitespace-only query returns empty list."""
+        tokens = self.parser.parse("   ")
+        assert tokens == []
+
+    def test_parse_simple_term(self):
+        """Test parsing simple term returns INCLUDE token."""
+        tokens = self.parser.parse("bug")
+        assert len(tokens) == 1
+        assert tokens[0] == SearchToken(type=TokenType.INCLUDE, value="bug")
+
+    def test_parse_multiple_terms(self):
+        """Test parsing multiple terms returns multiple INCLUDE tokens."""
+        tokens = self.parser.parse("bug fix")
+        assert len(tokens) == 2
+        assert tokens[0] == SearchToken(type=TokenType.INCLUDE, value="bug")
+        assert tokens[1] == SearchToken(type=TokenType.INCLUDE, value="fix")
+
+    def test_parse_exclude_term(self):
+        """Test parsing !term returns EXCLUDE token."""
+        tokens = self.parser.parse("!bug")
+        assert len(tokens) == 1
+        assert tokens[0] == SearchToken(type=TokenType.EXCLUDE, value="bug")
+
+    def test_parse_exclude_completed_shorthand(self):
+        """Test parsing !completed returns EXCLUDE_STATUS with is_finished."""
+        tokens = self.parser.parse("!completed")
+        assert len(tokens) == 1
+        assert tokens[0] == SearchToken(
+            type=TokenType.EXCLUDE_STATUS, value="is_finished"
+        )
+
+    def test_parse_exclude_pending_shorthand(self):
+        """Test parsing !pending returns EXCLUDE_STATUS with PENDING."""
+        tokens = self.parser.parse("!pending")
+        assert len(tokens) == 1
+        assert tokens[0] == SearchToken(type=TokenType.EXCLUDE_STATUS, value="PENDING")
+
+    def test_parse_exclude_in_progress_shorthand(self):
+        """Test parsing !in_progress returns EXCLUDE_STATUS with IN_PROGRESS."""
+        tokens = self.parser.parse("!in_progress")
+        assert len(tokens) == 1
+        assert tokens[0] == SearchToken(
+            type=TokenType.EXCLUDE_STATUS, value="IN_PROGRESS"
+        )
+
+    def test_parse_exclude_canceled_shorthand(self):
+        """Test parsing !canceled returns EXCLUDE_STATUS with CANCELED."""
+        tokens = self.parser.parse("!canceled")
+        assert len(tokens) == 1
+        assert tokens[0] == SearchToken(type=TokenType.EXCLUDE_STATUS, value="CANCELED")
+
+    def test_parse_exclude_status_explicit(self):
+        """Test parsing !status:VALUE returns EXCLUDE_STATUS token."""
+        tokens = self.parser.parse("!status:COMPLETED")
+        assert len(tokens) == 1
+        assert tokens[0] == SearchToken(
+            type=TokenType.EXCLUDE_STATUS, value="COMPLETED"
+        )
+
+    def test_parse_exclude_status_case_insensitive(self):
+        """Test parsing !status:value is case-insensitive for prefix."""
+        tokens = self.parser.parse("!STATUS:COMPLETED")
+        assert len(tokens) == 1
+        assert tokens[0] == SearchToken(
+            type=TokenType.EXCLUDE_STATUS, value="COMPLETED"
+        )
+
+    def test_parse_exclude_tag(self):
+        """Test parsing !tag:tagname returns EXCLUDE_TAG token."""
+        tokens = self.parser.parse("!tag:urgent")
+        assert len(tokens) == 1
+        assert tokens[0] == SearchToken(type=TokenType.EXCLUDE_TAG, value="urgent")
+
+    def test_parse_exclude_tag_case_insensitive_prefix(self):
+        """Test parsing !TAG:tagname is case-insensitive for prefix."""
+        tokens = self.parser.parse("!TAG:urgent")
+        assert len(tokens) == 1
+        assert tokens[0] == SearchToken(type=TokenType.EXCLUDE_TAG, value="urgent")
+
+    def test_parse_mixed_include_and_exclude(self):
+        """Test parsing mixed include and exclude terms."""
+        tokens = self.parser.parse("bug !completed")
+        assert len(tokens) == 2
+        assert tokens[0] == SearchToken(type=TokenType.INCLUDE, value="bug")
+        assert tokens[1] == SearchToken(
+            type=TokenType.EXCLUDE_STATUS, value="is_finished"
+        )
+
+    def test_parse_complex_query(self):
+        """Test parsing complex query with multiple token types."""
+        tokens = self.parser.parse("auth !completed !tag:urgent")
+        assert len(tokens) == 3
+        assert tokens[0] == SearchToken(type=TokenType.INCLUDE, value="auth")
+        assert tokens[1] == SearchToken(
+            type=TokenType.EXCLUDE_STATUS, value="is_finished"
+        )
+        assert tokens[2] == SearchToken(type=TokenType.EXCLUDE_TAG, value="urgent")
+
+    def test_parse_exclamation_only(self):
+        """Test parsing lone ! returns empty list (fzf: empty exclusion = all match)."""
+        tokens = self.parser.parse("!")
+        assert len(tokens) == 0
+
+    def test_parse_exclamation_with_space(self):
+        """Test parsing ! followed by space skips the ! token."""
+        tokens = self.parser.parse("! bug")
+        assert len(tokens) == 1
+        assert tokens[0] == SearchToken(type=TokenType.INCLUDE, value="bug")
+
+    def test_parse_preserves_case_for_values(self):
+        """Test that values preserve their original case."""
+        tokens = self.parser.parse("BugFix")
+        assert tokens[0].value == "BugFix"
+
+    def test_parse_exclude_preserves_case_for_values(self):
+        """Test that exclude values preserve their original case."""
+        tokens = self.parser.parse("!BugFix")
+        assert tokens[0].value == "BugFix"
+
+    def test_parse_multiple_spaces_between_terms(self):
+        """Test parsing with multiple spaces between terms."""
+        tokens = self.parser.parse("bug    fix")
+        assert len(tokens) == 2
+        assert tokens[0].value == "bug"
+        assert tokens[1].value == "fix"
+
+    def test_parse_exclude_status_without_value(self):
+        """Test parsing !status: without value treats as literal exclude."""
+        tokens = self.parser.parse("!status:")
+        assert len(tokens) == 1
+        assert tokens[0] == SearchToken(type=TokenType.EXCLUDE, value="status:")
+
+    def test_parse_exclude_tag_without_value(self):
+        """Test parsing !tag: without value treats as literal exclude."""
+        tokens = self.parser.parse("!tag:")
+        assert len(tokens) == 1
+        assert tokens[0] == SearchToken(type=TokenType.EXCLUDE, value="tag:")
+
+
+class TestSearchToken:
+    """Test SearchToken dataclass."""
+
+    def test_token_equality(self):
+        """Test SearchToken equality."""
+        token1 = SearchToken(type=TokenType.INCLUDE, value="bug")
+        token2 = SearchToken(type=TokenType.INCLUDE, value="bug")
+        assert token1 == token2
+
+    def test_token_inequality_different_type(self):
+        """Test SearchToken inequality with different types."""
+        token1 = SearchToken(type=TokenType.INCLUDE, value="bug")
+        token2 = SearchToken(type=TokenType.EXCLUDE, value="bug")
+        assert token1 != token2
+
+    def test_token_inequality_different_value(self):
+        """Test SearchToken inequality with different values."""
+        token1 = SearchToken(type=TokenType.INCLUDE, value="bug")
+        token2 = SearchToken(type=TokenType.INCLUDE, value="fix")
+        assert token1 != token2
+
+    def test_token_is_frozen(self):
+        """Test SearchToken is immutable."""
+        token = SearchToken(type=TokenType.INCLUDE, value="bug")
+        with pytest.raises(AttributeError):
+            token.value = "new"
+
+
+class TestTokenType:
+    """Test TokenType enum."""
+
+    def test_token_types_exist(self):
+        """Test all expected token types exist."""
+        assert TokenType.INCLUDE
+        assert TokenType.EXCLUDE
+        assert TokenType.EXCLUDE_STATUS
+        assert TokenType.EXCLUDE_TAG


### PR DESCRIPTION
## Summary
- Add fzf-style exclusion syntax (`!term`) to TUI search filter
- Implement `SearchQueryParser` for extensible query parsing
- Support status shorthands: `!completed`, `!pending`, `!in_progress`, `!canceled`
- Support explicit syntax: `!status:VALUE`, `!tag:tagname`
- Multiple tokens use AND logic

## Supported Syntax
| Syntax | Meaning |
|--------|---------|
| `term` | Substring match (existing) |
| `!term` | Exclude tasks containing term |
| `!completed` | Exclude finished tasks (COMPLETED/CANCELED) |
| `!pending` | Exclude PENDING tasks |
| `!in_progress` | Exclude IN_PROGRESS tasks |
| `!canceled` | Exclude CANCELED tasks |
| `!status:VALUE` | Exclude specific status |
| `!tag:tagname` | Exclude specific tag |
| `bug !completed` | AND logic: contains "bug" AND not finished |

## Test plan
- [x] Run `make test-ui` - all 898 tests pass
- [x] Run `make lint` - passes
- [x] Run `make typecheck` - passes
- [ ] Manual test in TUI: `/` search with `!completed`, `!tag:urgent`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)