### PR TITLE
fix(ui): unify task name column width between Task Table and Gantt widgets

### DIFF
--- a/packages/taskdog-ui/src/taskdog/constants/table_dimensions.py
+++ b/packages/taskdog-ui/src/taskdog/constants/table_dimensions.py
@@ -1,7 +1,7 @@
 """Table and UI dimension constants for presentation layer."""
 
 # Task Table Display Limits
-TASK_NAME_MAX_DISPLAY_LENGTH = 28
+TASK_NAME_COLUMN_WIDTH = 30
 PAGE_SCROLL_SIZE = 10
 
 # Gantt Chart Column Widths (CLI)

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_data_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_data_table.py
@@ -12,6 +12,7 @@ from rich.text import Text
 from textual.binding import Binding
 from textual.widgets import DataTable
 
+from taskdog.constants.table_dimensions import TASK_NAME_COLUMN_WIDTH
 from taskdog.renderers.gantt_cell_formatter import GanttCellFormatter
 from taskdog.view_models.gantt_view_model import GanttViewModel, TaskGanttRowViewModel
 
@@ -66,7 +67,7 @@ class GanttDataTable(DataTable):  # type: ignore[type-arg]
 
         # Add fixed columns with centered headers
         self.add_column(Text("ID", justify="center"))
-        self.add_column(Text("Task", justify="center"))
+        self.add_column(Text("Task", justify="center"), width=TASK_NAME_COLUMN_WIDTH)
         self.add_column(Text("Estimated[h]", justify="center"))
 
         # Add single Timeline column (contains all dates)

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/task_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/task_table.py
@@ -17,7 +17,7 @@ from textual.widgets import DataTable
 if TYPE_CHECKING:
     pass
 
-from taskdog.constants.table_dimensions import PAGE_SCROLL_SIZE
+from taskdog.constants.table_dimensions import PAGE_SCROLL_SIZE, TASK_NAME_COLUMN_WIDTH
 from taskdog.tui.widgets.base_widget import TUIWidget
 from taskdog.tui.widgets.task_table_row_builder import TaskTableRowBuilder
 from taskdog.tui.widgets.vi_navigation_mixin import ViNavigationMixin
@@ -100,7 +100,7 @@ class TaskTable(DataTable, TUIWidget, ViNavigationMixin):  # type: ignore[type-a
         """Set up table columns."""
         self.add_column(Text("", justify="center"))
         self.add_column(Text("ID", justify="center"))
-        self.add_column(Text("Name", justify="center"))
+        self.add_column(Text("Name", justify="center"), width=TASK_NAME_COLUMN_WIDTH)
         self.add_column(Text("Status", justify="center"))
         self.add_column(Text("Priority", justify="center"))
         self.add_column(Text("Flags", justify="center"))

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/task_table_row_builder.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/task_table_row_builder.py
@@ -8,7 +8,6 @@ from rich.text import Text
 
 from taskdog.constants.colors import STATUS_STYLES
 from taskdog.constants.symbols import EMOJI_NOTE
-from taskdog.constants.table_dimensions import TASK_NAME_MAX_DISPLAY_LENGTH
 from taskdog.formatters.date_time_formatter import DateTimeFormatter
 from taskdog.formatters.duration_formatter import DurationFormatter
 from taskdog.view_models.task_view_model import TaskRowViewModel
@@ -54,7 +53,7 @@ class TaskTableRowBuilder:
             ColumnConfig(formatter=lambda vm: str(vm.id)),
             # Name column (left-aligned, strikethrough + dim for finished)
             ColumnConfig(
-                formatter=lambda vm: self._format_name(vm.name),
+                formatter=lambda vm: vm.name,
                 justification="left",
                 style_func=lambda vm: "strike dim" if vm.is_finished else None,
             ),
@@ -156,20 +155,6 @@ class TaskTableRowBuilder:
         fixed_indicator = "📌" if task_vm.is_fixed else ""
         note_indicator = EMOJI_NOTE if task_vm.has_notes else ""
         return fixed_indicator + note_indicator
-
-    @staticmethod
-    def _format_name(name: str) -> str:
-        """Format task name with truncation if needed.
-
-        Args:
-            name: Task name to format
-
-        Returns:
-            Formatted task name
-        """
-        if len(name) > TASK_NAME_MAX_DISPLAY_LENGTH:
-            return name[:TASK_NAME_MAX_DISPLAY_LENGTH] + "..."
-        return name
 
     @staticmethod
     def _format_tags(tags: list[str] | None) -> str:


### PR DESCRIPTION
## Summary

- Add `TASK_NAME_COLUMN_WIDTH` constant (30) for fixed column width in TUI
- Apply fixed width to Name column in TaskTable and Task column in GanttDataTable
- Remove manual truncation logic (`_format_name` method) as Textual handles it automatically
- Remove unused `TASK_NAME_MAX_DISPLAY_LENGTH` constant

## Background

Previously, the Task Table and Gantt widgets had inconsistent column widths for task names. The Task Table used manual truncation with `...` suffix, while both widgets relied on automatic column sizing.

This change unifies the approach by:
1. Setting a fixed column width using Textual's `add_column(width=...)` parameter
2. Letting Textual handle text truncation automatically
3. Removing redundant manual truncation code

## Test plan

- [x] `make test-ui` passes (898 tests)
- [x] Visually verify in TUI that Task Table and Gantt have consistent column widths

🤖 Generated with [Claude Code](https://claude.ai/code)