### PR TITLE
fix(ui): show column headers in TUI Gantt when no tasks exist

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_data_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_data_table.py
@@ -108,15 +108,16 @@ class GanttDataTable(DataTable):  # type: ignore[type-arg]
             gantt_view_model.end_date,
         )
 
-        if gantt_view_model.is_empty():
-            return
-
         # Add date header rows (Month, Today marker, Day)
+        # Always add these to give Timeline column proper width
         self._add_date_header_rows(
             gantt_view_model.start_date,
             gantt_view_model.end_date,
             gantt_view_model.holidays,
         )
+
+        if gantt_view_model.is_empty():
+            return
 
         # Add task rows
         for idx, task_vm in enumerate(gantt_view_model.tasks):

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
@@ -178,11 +178,11 @@ class GanttWidget(Vertical, ViNavigationMixin, TUIWidget):
             return
 
         gantt_view_model = self._get_gantt_from_state()
-        if not gantt_view_model or gantt_view_model.is_empty():
+        if not gantt_view_model:
             self._show_empty_message()
             return
 
-        # Directly load the pre-computed gantt data
+        # Load gantt data (shows column headers even when empty, matching TaskTable behavior)
         self._load_gantt_data()
 
     def _display_table_message(self, column_label: str, message: str) -> None:


### PR DESCRIPTION
## Summary

- Unify empty state display between TaskTable and Gantt widgets
- Previously, Gantt showed "No tasks to display" message while TaskTable showed column headers
- Now both widgets show column headers (ID, Task, Estimated[h], Timeline) and date headers when empty

## Changes

- `gantt_widget.py`: Call `_load_gantt_data()` even when gantt is empty (only show empty message when `gantt_view_model` is `None`)
- `gantt_data_table.py`: Move `_add_date_header_rows()` before `is_empty()` check to ensure Timeline column has proper width

## Test plan

- [x] `make test-ui` passes (898 tests)
- [ ] Manual verification: Archive/delete all tasks in TUI and check Gantt view shows column headers with proper alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)