### PR TITLE
feat(ui): fix date header rows at top of TUI Gantt chart during vertical scroll

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/styles/main.tcss
+++ b/packages/taskdog-ui/src/taskdog/tui/styles/main.tcss
@@ -55,6 +55,11 @@ MainScreen {
     border: round $primary;
 }
 
+/* Style for fixed header rows in Gantt table */
+#gantt-table > .datatable--fixed {
+    background: $surface;
+}
+
 /* Task table - main content */
 #task-table {
     width: 100%;

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_data_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_data_table.py
@@ -116,6 +116,10 @@ class GanttDataTable(DataTable):  # type: ignore[type-arg]
             gantt_view_model.holidays,
         )
 
+        # Fix the date header rows at the top during vertical scrolling
+        # Must be set after rows are added, not in __init__
+        self.fixed_rows = GANTT_HEADER_ROW_COUNT
+
         if gantt_view_model.is_empty():
             return
 


### PR DESCRIPTION
## Summary

- Use Textual DataTable's `fixed_rows` feature to keep the 3 date header rows (Month, Today marker, Day) visible at the top when scrolling vertically through tasks
- Add styling for fixed rows background color using `$surface` theme variable

## Changes

- `gantt_data_table.py`: Set `fixed_rows = GANTT_HEADER_ROW_COUNT` after date header rows are added in `load_gantt()`
- `main.tcss`: Add `.datatable--fixed` style for consistent background color

## Test plan

- [x] Run `make test-ui` - all tests pass
- [x] Manual test with `taskdog tui`:
  - Verify date header rows stay fixed when scrolling vertically
  - Verify horizontal scrolling still works (headers scroll with timeline)
  - Verify background color looks consistent


🤖 Generated with [Claude Code](https://claude.com/claude-code)