### PR TITLE
fix: skip unit tests in pre-commit when only non-Python files change

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,3 +67,4 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-commit]
+        types_or: [python]


### PR DESCRIPTION
## Summary
- Add `types_or: [python]` filter to the local `unittest` pre-commit hook
- Tests now only run when Python files are staged, skipping for TOML-only changes (e.g., version bumps)

## Test plan
- [x] Verified pre-commit skips tests when committing `.pre-commit-config.yaml` only (see hook output: `Run unit tests... (no files to check) Skipped`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)