### PR TITLE
refactor: remove work_hours config dependency from optimizer

### DIFF
--- a/examples/core.toml
+++ b/examples/core.toml
@@ -3,37 +3,12 @@
 # Copy this file to ~/.config/taskdog/core.toml (or $XDG_CONFIG_HOME/taskdog/core.toml)
 # to customize business logic defaults.
 #
-# This config is for CORE BUSINESS LOGIC (work hours, optimization, storage).
+# This config is for CORE BUSINESS LOGIC (region, storage).
 # For CLI/TUI infrastructure settings (API connection, input defaults), see cli.toml.
 # For server-specific settings (authentication), see server.toml.
 #
 # Note: Server host/port are configured via CLI arguments (taskdog-server --host --port),
 # not in this config file.
-
-# =============================================================================
-# Time Settings (Work Hours for Optimization)
-# =============================================================================
-#
-# Work hours used by the schedule optimization algorithm.
-# These define the daily working time window for task scheduling.
-
-[time]
-# Work day start time (default: "09:30")
-# Format: "HH:MM" (24-hour format)
-# Used by optimizer to determine when tasks can be scheduled
-work_hours_start = "09:30"
-
-# Work day end time (default: "18:30")
-# Format: "HH:MM" (24-hour format)
-# Used by optimizer to determine when tasks should end
-work_hours_end = "18:30"
-
-# Examples:
-# work_hours_start = "08:00"  # Start at 8:00 AM
-# work_hours_end = "17:00"    # End at 5:00 PM
-#
-# Note: UI input completion defaults (deadline_time, planned_start_time, etc.)
-# are configured separately in cli.toml [input_defaults] section.
 
 # =============================================================================
 # Region Settings
@@ -76,8 +51,6 @@ backend = "sqlite"
 #
 # Environment variables override settings in this file:
 #
-# - TASKDOG_TIME_WORK_HOURS_START: Work day start time
-# - TASKDOG_TIME_WORK_HOURS_END: Work day end time
 # - TASKDOG_REGION_COUNTRY: Country code for holidays
 # - TASKDOG_STORAGE_BACKEND: Storage backend type
 # - TASKDOG_STORAGE_DATABASE_URL: Database file path

--- a/packages/taskdog-core/src/taskdog_core/application/services/optimization/allocation_helpers.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/optimization/allocation_helpers.py
@@ -5,6 +5,11 @@ from datetime import date, datetime, time
 
 from taskdog_core.domain.entities.task import Task
 
+# Fixed schedule time boundaries for optimizer
+# max_hours_per_day constrains actual work hours; these just set planned_start/end timestamps
+SCHEDULE_START_TIME = time(0, 0, 0)
+SCHEDULE_END_TIME = time(23, 59, 59)
+
 
 def prepare_task_for_allocation(task: Task) -> Task | None:
     """Validate and prepare task copy for allocation.
@@ -36,7 +41,6 @@ def calculate_available_hours(
     date_obj: date,
     max_hours_per_day: float,
     current_time: datetime | None,
-    default_end_time: time,
 ) -> float:
     """Calculate available hours for a specific date.
 
@@ -45,7 +49,6 @@ def calculate_available_hours(
         date_obj: Date to check
         max_hours_per_day: Maximum work hours per day
         current_time: Optional current time for today's remaining hours
-        default_end_time: Default end time for work day (e.g., time(18, 0))
 
     Returns:
         Available hours (0.0 if fully allocated or past end time)
@@ -55,7 +58,7 @@ def calculate_available_hours(
 
     if current_time and date_obj == current_time.date():
         current_hour = current_time.hour + current_time.minute / 60.0
-        end_hour = default_end_time.hour + default_end_time.minute / 60.0
+        end_hour = SCHEDULE_END_TIME.hour + SCHEDULE_END_TIME.minute / 60.0
         remaining_hours_today = max(0.0, end_hour - current_hour)
         return min(available_from_max, remaining_hours_today)
 
@@ -67,8 +70,6 @@ def set_planned_times(
     schedule_start: datetime,
     schedule_end: datetime,
     task_daily_allocations: dict[date, float],
-    default_start_time: time,
-    default_end_time: time,
 ) -> None:
     """Set planned start, end, and daily allocations on task.
 
@@ -77,16 +78,18 @@ def set_planned_times(
         schedule_start: Start date of schedule
         schedule_end: End date of schedule
         task_daily_allocations: Daily hour allocations
-        default_start_time: Default start time for tasks (e.g., time(9, 0))
-        default_end_time: Default end time for tasks (e.g., time(18, 0))
     """
     start_date_with_time = schedule_start.replace(
-        hour=default_start_time.hour, minute=default_start_time.minute, second=0
+        hour=SCHEDULE_START_TIME.hour,
+        minute=SCHEDULE_START_TIME.minute,
+        second=SCHEDULE_START_TIME.second,
     )
     task.planned_start = start_date_with_time
 
     end_date_with_time = schedule_end.replace(
-        hour=default_end_time.hour, minute=default_end_time.minute, second=0
+        hour=SCHEDULE_END_TIME.hour,
+        minute=SCHEDULE_END_TIME.minute,
+        second=SCHEDULE_END_TIME.second,
     )
     task.planned_end = end_date_with_time
 

--- a/packages/taskdog-core/src/taskdog_core/application/services/optimization/backward_optimization_strategy.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/optimization/backward_optimization_strategy.py
@@ -1,10 +1,11 @@
 """Backward optimization strategy implementation."""
 
-from datetime import date, datetime, time, timedelta
+from datetime import date, datetime, timedelta
 
 from taskdog_core.application.dto.optimize_params import OptimizeParams
 from taskdog_core.application.dto.optimize_result import OptimizeResult
 from taskdog_core.application.services.optimization.allocation_helpers import (
+    SCHEDULE_START_TIME,
     calculate_available_hours,
     prepare_task_for_allocation,
     set_planned_times,
@@ -27,10 +28,6 @@ class BackwardOptimizationStrategy(OptimizationStrategy):
 
     DISPLAY_NAME = "Backward"
     DESCRIPTION = "Just-in-time from deadlines"
-
-    def __init__(self, default_start_time: time, default_end_time: time):
-        self.default_start_time = default_start_time
-        self.default_end_time = default_end_time
 
     def optimize_tasks(
         self,
@@ -104,7 +101,6 @@ class BackwardOptimizationStrategy(OptimizationStrategy):
                 date_obj,
                 params.max_hours_per_day,
                 params.current_time,
-                self.default_end_time,
             )
 
             if available_hours > 0:
@@ -126,17 +122,15 @@ class BackwardOptimizationStrategy(OptimizationStrategy):
 
         if schedule_start and schedule_end:
             start_with_time = schedule_start.replace(
-                hour=self.default_start_time.hour,
-                minute=self.default_start_time.minute,
-                second=0,
+                hour=SCHEDULE_START_TIME.hour,
+                minute=SCHEDULE_START_TIME.minute,
+                second=SCHEDULE_START_TIME.second,
             )
             set_planned_times(
                 task_copy,
                 start_with_time,
                 schedule_end,
                 task_daily_allocations,
-                self.default_start_time,
-                self.default_end_time,
             )
             return task_copy
 

--- a/packages/taskdog-core/src/taskdog_core/application/services/optimization/balanced_optimization_strategy.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/optimization/balanced_optimization_strategy.py
@@ -1,7 +1,7 @@
 """Balanced optimization strategy implementation."""
 
 from dataclasses import dataclass
-from datetime import date, datetime, time, timedelta
+from datetime import date, datetime, timedelta
 
 from taskdog_core.application.constants.optimization import SCHEDULING_EPSILON
 from taskdog_core.application.dto.optimize_params import OptimizeParams
@@ -44,10 +44,6 @@ class BalancedOptimizationStrategy(OptimizationStrategy):
 
     DISPLAY_NAME = "Balanced"
     DESCRIPTION = "Even workload distribution"
-
-    def __init__(self, default_start_time: time, default_end_time: time):
-        self.default_start_time = default_start_time
-        self.default_end_time = default_end_time
 
     def optimize_tasks(
         self,
@@ -132,8 +128,6 @@ class BalancedOptimizationStrategy(OptimizationStrategy):
                 state.schedule_start,
                 actual_schedule_end,
                 state.task_daily_allocations,
-                self.default_start_time,
-                self.default_end_time,
             )
             return task_copy
 
@@ -187,7 +181,6 @@ class BalancedOptimizationStrategy(OptimizationStrategy):
             date_obj,
             params.max_hours_per_day,
             params.current_time,
-            self.default_end_time,
         )
 
         if available_hours <= SCHEDULING_EPSILON:

--- a/packages/taskdog-core/src/taskdog_core/application/services/optimization/dependency_aware_optimization_strategy.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/optimization/dependency_aware_optimization_strategy.py
@@ -1,6 +1,6 @@
 """Dependency-aware optimization strategy implementation using Critical Path Method."""
 
-from datetime import datetime, time
+from datetime import datetime
 
 from taskdog_core.application.services.optimization.greedy_based_optimization_strategy import (
     GreedyBasedOptimizationStrategy,
@@ -23,9 +23,6 @@ class DependencyAwareOptimizationStrategy(GreedyBasedOptimizationStrategy):
 
     DISPLAY_NAME = "Dependency Aware"
     DESCRIPTION = "Critical Path Method"
-
-    def __init__(self, default_start_time: time, default_end_time: time):
-        super().__init__(default_start_time, default_end_time)
 
     def _sort_tasks(self, tasks: list[Task], start_date: datetime) -> list[Task]:
         """Sort tasks using Critical Path Method (CPM)."""

--- a/packages/taskdog-core/src/taskdog_core/application/services/optimization/earliest_deadline_optimization_strategy.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/optimization/earliest_deadline_optimization_strategy.py
@@ -1,6 +1,6 @@
 """Earliest Deadline First (EDF) optimization strategy implementation."""
 
-from datetime import datetime, time
+from datetime import datetime
 
 from taskdog_core.application.services.optimization.greedy_based_optimization_strategy import (
     GreedyBasedOptimizationStrategy,
@@ -19,9 +19,6 @@ class EarliestDeadlineOptimizationStrategy(GreedyBasedOptimizationStrategy):
 
     DISPLAY_NAME = "Earliest Deadline"
     DESCRIPTION = "EDF algorithm"
-
-    def __init__(self, default_start_time: time, default_end_time: time):
-        super().__init__(default_start_time, default_end_time)
 
     def _sort_tasks(self, tasks: list[Task], start_date: datetime) -> list[Task]:
         """Sort tasks by deadline (earliest first)."""

--- a/packages/taskdog-core/src/taskdog_core/application/services/optimization/genetic_optimization_strategy.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/optimization/genetic_optimization_strategy.py
@@ -2,7 +2,7 @@
 
 import copy
 import random
-from datetime import date, time
+from datetime import date
 
 from taskdog_core.application.constants.optimization import (
     GENETIC_CROSSOVER_RATE,
@@ -53,15 +53,8 @@ class GeneticOptimizationStrategy(OptimizationStrategy):
     EARLY_TERMINATION_GENERATIONS = GENETIC_EARLY_TERMINATION_GENERATIONS
     TOURNAMENT_SIZE = GENETIC_TOURNAMENT_SIZE
 
-    def __init__(self, default_start_time: time, default_end_time: time):
-        """Initialize strategy with configuration.
-
-        Args:
-            default_start_time: Default start time for tasks (e.g., time(9, 0))
-            default_end_time: Default end time for tasks (e.g., time(18, 0))
-        """
-        self.default_start_time = default_start_time
-        self.default_end_time = default_end_time
+    def __init__(self) -> None:
+        """Initialize strategy."""
         self.fitness_calculator = ScheduleFitnessCalculator()
         # Cache for fitness evaluations: stores (fitness, daily_allocations, scheduled_tasks)
         self._fitness_cache: dict[
@@ -95,10 +88,7 @@ class GeneticOptimizationStrategy(OptimizationStrategy):
         result = OptimizeResult(daily_allocations=dict(existing_allocations))
 
         # Create greedy strategy instance for allocation
-        greedy_strategy = GreedyOptimizationStrategy(
-            self.default_start_time,
-            self.default_end_time,
-        )
+        greedy_strategy = GreedyOptimizationStrategy()
 
         # Clear fitness cache for new optimization run
         self._fitness_cache.clear()

--- a/packages/taskdog-core/src/taskdog_core/application/services/optimization/greedy_based_optimization_strategy.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/optimization/greedy_based_optimization_strategy.py
@@ -1,6 +1,6 @@
 """Base class for greedy-based optimization strategies."""
 
-from datetime import date, datetime, time, timedelta
+from datetime import date, datetime, timedelta
 
 from taskdog_core.application.dto.optimize_params import OptimizeParams
 from taskdog_core.application.dto.optimize_result import OptimizeResult
@@ -32,17 +32,6 @@ class GreedyBasedOptimizationStrategy(OptimizationStrategy):
 
     DISPLAY_NAME = "Greedy"
     DESCRIPTION = "Front-loads tasks"
-
-    def __init__(self, default_start_time: time, default_end_time: time):
-        """Initialize strategy with configuration.
-
-        Args:
-            default_start_time: Default start time for tasks (e.g., time(9, 0))
-            default_end_time: Default end time for tasks (e.g., time(18, 0))
-        """
-        super().__init__()
-        self.default_start_time = default_start_time
-        self.default_end_time = default_end_time
 
     def optimize_tasks(
         self,
@@ -145,7 +134,6 @@ class GreedyBasedOptimizationStrategy(OptimizationStrategy):
                 date_obj,
                 params.max_hours_per_day,
                 params.current_time,
-                self.default_end_time,
             )
 
             if available_hours > 0:
@@ -168,8 +156,6 @@ class GreedyBasedOptimizationStrategy(OptimizationStrategy):
                 schedule_start,
                 schedule_end,
                 task_daily_allocations,
-                self.default_start_time,
-                self.default_end_time,
             )
             return task_copy
 

--- a/packages/taskdog-core/src/taskdog_core/application/services/optimization/monte_carlo_optimization_strategy.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/optimization/monte_carlo_optimization_strategy.py
@@ -1,7 +1,7 @@
 """Monte Carlo optimization strategy implementation."""
 
 import random
-from datetime import date, time
+from datetime import date
 
 from taskdog_core.application.constants.optimization import MONTE_CARLO_NUM_SIMULATIONS
 from taskdog_core.application.dto.optimize_params import OptimizeParams
@@ -37,15 +37,8 @@ class MonteCarloOptimizationStrategy(OptimizationStrategy):
 
     NUM_SIMULATIONS = MONTE_CARLO_NUM_SIMULATIONS
 
-    def __init__(self, default_start_time: time, default_end_time: time):
-        """Initialize strategy with configuration.
-
-        Args:
-            default_start_time: Default start time for tasks (e.g., time(9, 0))
-            default_end_time: Default end time for tasks (e.g., time(18, 0))
-        """
-        self.default_start_time = default_start_time
-        self.default_end_time = default_end_time
+    def __init__(self) -> None:
+        """Initialize strategy."""
         self.fitness_calculator = ScheduleFitnessCalculator()
         self._evaluation_cache: dict[
             tuple[int | None, ...], float
@@ -80,10 +73,7 @@ class MonteCarloOptimizationStrategy(OptimizationStrategy):
         result = OptimizeResult(daily_allocations=dict(existing_allocations))
 
         # Create greedy strategy instance for allocation
-        greedy_strategy = GreedyOptimizationStrategy(
-            self.default_start_time,
-            self.default_end_time,
-        )
+        greedy_strategy = GreedyOptimizationStrategy()
 
         # Clear evaluation cache for new optimization run
         self._evaluation_cache.clear()

--- a/packages/taskdog-core/src/taskdog_core/application/services/optimization/optimization_strategy.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/optimization/optimization_strategy.py
@@ -17,15 +17,9 @@ class OptimizationStrategy(ABC):
     - Implement optimize_tasks() method
 
     Example:
-        from datetime import time
-
         class MyStrategy(OptimizationStrategy):
             DISPLAY_NAME = "My Algorithm"
             DESCRIPTION = "Does something cool"
-
-            def __init__(self, default_start_time: time, default_end_time: time):
-                self.default_start_time = default_start_time
-                self.default_end_time = default_end_time
 
             def optimize_tasks(self, tasks, existing_allocations, params) -> OptimizeResult:
                 # Custom implementation

--- a/packages/taskdog-core/src/taskdog_core/application/services/optimization/priority_first_optimization_strategy.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/optimization/priority_first_optimization_strategy.py
@@ -1,6 +1,6 @@
 """Priority-first optimization strategy implementation."""
 
-from datetime import datetime, time
+from datetime import datetime
 
 from taskdog_core.application.services.optimization.greedy_based_optimization_strategy import (
     GreedyBasedOptimizationStrategy,
@@ -19,9 +19,6 @@ class PriorityFirstOptimizationStrategy(GreedyBasedOptimizationStrategy):
 
     DISPLAY_NAME = "Priority First"
     DESCRIPTION = "Priority-based scheduling"
-
-    def __init__(self, default_start_time: time, default_end_time: time):
-        super().__init__(default_start_time, default_end_time)
 
     def _sort_tasks(self, tasks: list[Task], start_date: datetime) -> list[Task]:
         """Sort tasks by priority field only (priority-first approach)."""

--- a/packages/taskdog-core/src/taskdog_core/application/services/optimization/round_robin_optimization_strategy.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/optimization/round_robin_optimization_strategy.py
@@ -1,7 +1,7 @@
 """Round-robin optimization strategy implementation."""
 
 import copy
-from datetime import date, datetime, time, timedelta
+from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from taskdog_core.application.constants.optimization import (
@@ -10,6 +10,10 @@ from taskdog_core.application.constants.optimization import (
 )
 from taskdog_core.application.dto.optimize_params import OptimizeParams
 from taskdog_core.application.dto.optimize_result import OptimizeResult
+from taskdog_core.application.services.optimization.allocation_helpers import (
+    SCHEDULE_END_TIME,
+    SCHEDULE_START_TIME,
+)
 from taskdog_core.application.services.optimization.optimization_strategy import (
     OptimizationStrategy,
 )
@@ -33,16 +37,6 @@ class RoundRobinOptimizationStrategy(OptimizationStrategy):
 
     DISPLAY_NAME = "Round Robin"
     DESCRIPTION = "Parallel progress on tasks"
-
-    def __init__(self, default_start_time: time, default_end_time: time):
-        """Initialize strategy with configuration.
-
-        Args:
-            default_start_time: Default start time for tasks (e.g., time(9, 0))
-            default_end_time: Default end time for tasks (e.g., time(18, 0))
-        """
-        self.default_start_time = default_start_time
-        self.default_end_time = default_end_time
 
     def optimize_tasks(
         self,
@@ -279,17 +273,15 @@ class RoundRobinOptimizationStrategy(OptimizationStrategy):
                 start_dt = task_start_dates[task_id]
                 end_dt = task_end_dates[task_id]
 
-                # Set start time to default_start_time (default: 9:00)
                 start_with_time = start_dt.replace(
-                    hour=self.default_start_time.hour,
-                    minute=self.default_start_time.minute,
-                    second=0,
+                    hour=SCHEDULE_START_TIME.hour,
+                    minute=SCHEDULE_START_TIME.minute,
+                    second=SCHEDULE_START_TIME.second,
                 )
-                # Set end time to default_end_time (default: 18:00)
                 end_with_time = end_dt.replace(
-                    hour=self.default_end_time.hour,
-                    minute=self.default_end_time.minute,
-                    second=0,
+                    hour=SCHEDULE_END_TIME.hour,
+                    minute=SCHEDULE_END_TIME.minute,
+                    second=SCHEDULE_END_TIME.second,
                 )
 
                 task.planned_start = start_with_time

--- a/packages/taskdog-core/src/taskdog_core/application/services/optimization/strategy_factory.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/optimization/strategy_factory.py
@@ -1,6 +1,5 @@
 """Factory for creating optimization strategy instances."""
 
-from datetime import time
 from typing import ClassVar
 
 from taskdog_core.application.services.optimization.backward_optimization_strategy import (
@@ -33,10 +32,6 @@ from taskdog_core.application.services.optimization.priority_first_optimization_
 from taskdog_core.application.services.optimization.round_robin_optimization_strategy import (
     RoundRobinOptimizationStrategy,
 )
-from taskdog_core.shared.constants.config_defaults import (
-    WORK_HOURS_END,
-    WORK_HOURS_START,
-)
 
 
 class StrategyFactory:
@@ -63,15 +58,11 @@ class StrategyFactory:
     def create(
         cls,
         algorithm_name: str = "greedy",
-        default_start_time: time = WORK_HOURS_START,
-        default_end_time: time = WORK_HOURS_END,
     ) -> OptimizationStrategy:
         """Create an optimization strategy instance.
 
         Args:
             algorithm_name: Name of the algorithm to use (default: "greedy")
-            default_start_time: Default start time for tasks (e.g., time(9, 0))
-            default_end_time: Default end time for tasks (e.g., time(18, 0))
 
         Returns:
             Instance of the requested optimization strategy
@@ -87,8 +78,7 @@ class StrategyFactory:
             )
 
         strategy_constructor = cls._strategies[algorithm_name]
-        # All concrete subclasses have __init__(default_start_time, default_end_time)
-        return strategy_constructor(default_start_time, default_end_time)  # type: ignore[call-arg]
+        return strategy_constructor()
 
     @classmethod
     def get_algorithm_metadata(cls) -> list[tuple[str, str, str]]:

--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/optimize_schedule.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/optimize_schedule.py
@@ -1,6 +1,6 @@
 """Use case for optimizing task schedules."""
 
-from datetime import datetime, time
+from datetime import datetime
 
 from taskdog_core.application.dto.optimization_output import OptimizationOutput
 from taskdog_core.application.dto.optimize_params import OptimizeParams
@@ -33,21 +33,15 @@ class OptimizeScheduleUseCase(UseCase[OptimizeScheduleInput, OptimizationOutput]
     def __init__(
         self,
         repository: TaskRepository,
-        default_start_time: time,
-        default_end_time: time,
         holiday_checker: IHolidayChecker | None = None,
     ):
         """Initialize use case.
 
         Args:
             repository: Task repository for data access
-            default_start_time: Default start time for tasks (e.g., time(9, 0))
-            default_end_time: Default end time for tasks (e.g., time(18, 0))
             holiday_checker: Holiday checker for workday validation (optional)
         """
         self.repository = repository
-        self.default_start_time = default_start_time
-        self.default_end_time = default_end_time
         self.summary_builder = OptimizationSummaryBuilder(repository)
         self.holiday_checker = holiday_checker
 
@@ -122,9 +116,7 @@ class OptimizeScheduleUseCase(UseCase[OptimizeScheduleInput, OptimizationOutput]
         )
 
         # Get optimization strategy
-        strategy = StrategyFactory.create(
-            input_dto.algorithm_name, self.default_start_time, self.default_end_time
-        )
+        strategy = StrategyFactory.create(input_dto.algorithm_name)
 
         # Create OptimizeParams from input_dto
         params = OptimizeParams(

--- a/packages/taskdog-core/src/taskdog_core/controllers/task_analytics_controller.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/task_analytics_controller.py
@@ -116,8 +116,6 @@ class TaskAnalyticsController(BaseTaskController):
 
         use_case = OptimizeScheduleUseCase(
             self.repository,
-            self.config.time.work_hours_start,
-            self.config.time.work_hours_end,
             self.holiday_checker,
         )
         return use_case.execute(optimize_input)

--- a/packages/taskdog-core/src/taskdog_core/shared/constants/__init__.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/constants/__init__.py
@@ -13,8 +13,6 @@ from taskdog_core.shared.constants.config_defaults import (
     DEFAULT_PLANNED_END_TIME,
     DEFAULT_PLANNED_START_TIME,
     MAX_ESTIMATED_DURATION_HOURS,
-    WORK_HOURS_END,
-    WORK_HOURS_START,
 )
 from taskdog_core.shared.constants.file_management import CONFIG_FILE_NAME
 from taskdog_core.shared.constants.formats import DATETIME_FORMAT
@@ -64,7 +62,5 @@ __all__ = [
     "WEEKDAY_THRESHOLD",
     "WORKLOAD_COMFORTABLE_HOURS",
     "WORKLOAD_MODERATE_HOURS",
-    "WORK_HOURS_END",
-    "WORK_HOURS_START",
     "StatusVerbs",
 ]

--- a/packages/taskdog-core/src/taskdog_core/shared/constants/config_defaults.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/constants/config_defaults.py
@@ -10,8 +10,3 @@ MAX_ESTIMATED_DURATION_HOURS = 999  # Maximum estimated duration in hours
 DEFAULT_DEADLINE_TIME = time(18, 30)  # Default time for deadline input
 DEFAULT_PLANNED_START_TIME = time(9, 30)  # Default time for planned_start input
 DEFAULT_PLANNED_END_TIME = time(18, 30)  # Default time for planned_end input
-
-# === Work Hours (for optimization) ===
-# Defines the available working hours per day for schedule optimization
-WORK_HOURS_START = time(9, 30)  # Work day start time
-WORK_HOURS_END = time(18, 30)  # Work day end time

--- a/packages/taskdog-core/tests/application/services/optimization/optimization_strategy_test_base.py
+++ b/packages/taskdog-core/tests/application/services/optimization/optimization_strategy_test_base.py
@@ -1,6 +1,6 @@
 """Base test class for optimization strategy tests."""
 
-from datetime import datetime, time
+from datetime import datetime
 
 import pytest
 
@@ -29,13 +29,7 @@ class BaseOptimizationStrategyTest:
         """Set up test fixtures using repository from conftest."""
         self.repository = repository
         self.create_use_case = CreateTaskUseCase(self.repository)
-        # Use default time values directly instead of loading config
-        # to avoid tests depending on user's local config
-        self.optimize_use_case = OptimizeScheduleUseCase(
-            self.repository,
-            time(9, 0),  # default start time
-            time(18, 0),  # default end time
-        )
+        self.optimize_use_case = OptimizeScheduleUseCase(self.repository)
 
     def create_task(
         self,

--- a/packages/taskdog-core/tests/application/services/optimization/test_backward_optimization_strategy.py
+++ b/packages/taskdog-core/tests/application/services/optimization/test_backward_optimization_strategy.py
@@ -30,8 +30,8 @@ class TestBackwardOptimizationStrategy(BaseOptimizationStrategyTest):
         # Should be scheduled on Friday (closest to deadline)
         self.assert_task_scheduled(
             task,
-            expected_start=datetime(2025, 10, 24, 9, 0, 0),
-            expected_end=datetime(2025, 10, 24, 18, 0, 0),
+            expected_start=datetime(2025, 10, 24, 0, 0, 0),
+            expected_end=datetime(2025, 10, 24, 23, 59, 59),
         )
 
         # Re-fetch task from repository to verify allocations
@@ -58,8 +58,8 @@ class TestBackwardOptimizationStrategy(BaseOptimizationStrategyTest):
         # Should start on Thursday, end on Friday
         self.assert_task_scheduled(
             task,
-            expected_start=datetime(2025, 10, 23, 9, 0, 0),
-            expected_end=datetime(2025, 10, 24, 18, 0, 0),
+            expected_start=datetime(2025, 10, 23, 0, 0, 0),
+            expected_end=datetime(2025, 10, 24, 23, 59, 59),
         )
 
         # 6h on Thursday, 6h on Friday
@@ -130,12 +130,12 @@ class TestBackwardOptimizationStrategy(BaseOptimizationStrategyTest):
         # Task 1 (further deadline) is processed first, scheduled on Friday
         updated_task1 = self.repository.get_by_id(task1.id)
         assert updated_task1 is not None
-        assert updated_task1.planned_start == datetime(2025, 10, 24, 9, 0, 0)
+        assert updated_task1.planned_start == datetime(2025, 10, 24, 0, 0, 0)
 
         # Task 2 (closer deadline) is processed second, scheduled on Wednesday
         updated_task2 = self.repository.get_by_id(task2.id)
         assert updated_task2 is not None
-        assert updated_task2.planned_start == datetime(2025, 10, 22, 9, 0, 0)
+        assert updated_task2.planned_start == datetime(2025, 10, 22, 0, 0, 0)
 
     def test_backward_fails_when_deadline_before_start(self):
         """Test that backward strategy fails when deadline is before start date."""
@@ -169,8 +169,8 @@ class TestBackwardOptimizationStrategy(BaseOptimizationStrategyTest):
         # Should be scheduled on Monday (deadline day)
         self.assert_task_scheduled(
             task,
-            expected_start=datetime(2025, 10, 27, 9, 0, 0),
-            expected_end=datetime(2025, 10, 27, 18, 0, 0),
+            expected_start=datetime(2025, 10, 27, 0, 0, 0),
+            expected_end=datetime(2025, 10, 27, 23, 59, 59),
         )
 
         # Only Monday in allocations (no weekend days)

--- a/packages/taskdog-core/tests/application/services/optimization/test_balanced_optimization_strategy.py
+++ b/packages/taskdog-core/tests/application/services/optimization/test_balanced_optimization_strategy.py
@@ -1,6 +1,6 @@
 """Tests for BalancedOptimizationStrategy."""
 
-from datetime import date, datetime, time
+from datetime import date, datetime
 
 from taskdog_core.application.dto.optimize_params import OptimizeParams
 from taskdog_core.application.services.optimization.balanced_optimization_strategy import (
@@ -36,8 +36,8 @@ class TestBalancedOptimizationStrategy(BaseOptimizationStrategyTest):
         # Should start Monday, end Friday
         self.assert_task_scheduled(
             task,
-            expected_start=datetime(2025, 10, 20, 9, 0, 0),
-            expected_end=datetime(2025, 10, 24, 18, 0, 0),
+            expected_start=datetime(2025, 10, 20, 0, 0, 0),
+            expected_end=datetime(2025, 10, 24, 23, 59, 59),
         )
 
         # Check daily allocations: 10h / 5 days = 2h/day
@@ -175,9 +175,7 @@ class TestBalancedOptimizationStrategyWithHolidays:
         )
         daily_allocations: dict[date, float] = {}
 
-        strategy = BalancedOptimizationStrategy(
-            default_start_time=time(9, 0), default_end_time=time(18, 0)
-        )
+        strategy = BalancedOptimizationStrategy()
         result = strategy._allocate_task(task, daily_allocations, params)
 
         assert result is not None
@@ -214,9 +212,7 @@ class TestBalancedOptimizationStrategyWithHolidays:
         )
         daily_allocations: dict[date, float] = {}
 
-        strategy = BalancedOptimizationStrategy(
-            default_start_time=time(9, 0), default_end_time=time(18, 0)
-        )
+        strategy = BalancedOptimizationStrategy()
         result = strategy._allocate_task(task, daily_allocations, params)
 
         assert result is not None

--- a/packages/taskdog-core/tests/application/services/optimization/test_dependency_aware_optimization_strategy.py
+++ b/packages/taskdog-core/tests/application/services/optimization/test_dependency_aware_optimization_strategy.py
@@ -38,8 +38,8 @@ class TestDependencyAwareOptimizationStrategy(BaseOptimizationStrategyTest):
         updated_high_late = self.repository.get_by_id(high_late.id)
         assert updated_low_early is not None and updated_high_late is not None
 
-        assert updated_low_early.planned_start == datetime(2025, 10, 20, 9, 0, 0)
-        assert updated_high_late.planned_start == datetime(2025, 10, 21, 9, 0, 0)
+        assert updated_low_early.planned_start == datetime(2025, 10, 20, 0, 0, 0)
+        assert updated_high_late.planned_start == datetime(2025, 10, 21, 0, 0, 0)
 
     def test_dependency_aware_uses_priority_as_tiebreaker(self):
         """Test that priority is used when deadlines are equal."""
@@ -67,8 +67,8 @@ class TestDependencyAwareOptimizationStrategy(BaseOptimizationStrategyTest):
         updated_low = self.repository.get_by_id(low_priority.id)
         assert updated_high is not None and updated_low is not None
 
-        assert updated_high.planned_start == datetime(2025, 10, 20, 9, 0, 0)
-        assert updated_low.planned_start == datetime(2025, 10, 21, 9, 0, 0)
+        assert updated_high.planned_start == datetime(2025, 10, 20, 0, 0, 0)
+        assert updated_low.planned_start == datetime(2025, 10, 21, 0, 0, 0)
 
     def test_dependency_aware_schedules_no_deadline_tasks_last(self):
         """Test that tasks without deadlines are scheduled last."""
@@ -93,8 +93,8 @@ class TestDependencyAwareOptimizationStrategy(BaseOptimizationStrategyTest):
         updated_no = self.repository.get_by_id(no_deadline.id)
         assert updated_with is not None and updated_no is not None
 
-        assert updated_with.planned_start == datetime(2025, 10, 20, 9, 0, 0)
-        assert updated_no.planned_start == datetime(2025, 10, 21, 9, 0, 0)
+        assert updated_with.planned_start == datetime(2025, 10, 20, 0, 0, 0)
+        assert updated_no.planned_start == datetime(2025, 10, 21, 0, 0, 0)
 
     def test_dependency_aware_uses_greedy_allocation(self):
         """Test that dependency-aware strategy uses greedy allocation."""
@@ -181,8 +181,8 @@ class TestDependencyAwareOptimizationStrategy(BaseOptimizationStrategyTest):
         )
 
         # Earliest deadline should be first
-        assert updated_urgent.planned_start == datetime(2025, 10, 20, 9, 0, 0)
+        assert updated_urgent.planned_start == datetime(2025, 10, 20, 0, 0, 0)
         # Middle deadline should be second
-        assert updated_medium.planned_start == datetime(2025, 10, 21, 9, 0, 0)
+        assert updated_medium.planned_start == datetime(2025, 10, 21, 0, 0, 0)
         # Latest deadline should be last
-        assert updated_high.planned_start == datetime(2025, 10, 22, 9, 0, 0)
+        assert updated_high.planned_start == datetime(2025, 10, 22, 0, 0, 0)

--- a/packages/taskdog-core/tests/application/services/optimization/test_earliest_deadline_optimization_strategy.py
+++ b/packages/taskdog-core/tests/application/services/optimization/test_earliest_deadline_optimization_strategy.py
@@ -40,8 +40,8 @@ class TestEarliestDeadlineOptimizationStrategy(BaseOptimizationStrategyTest):
         updated_task2 = self.repository.get_by_id(task2.id)
         assert updated_task1 is not None and updated_task2 is not None
 
-        assert updated_task1.planned_start == datetime(2025, 10, 20, 9, 0, 0)  # Monday
-        assert updated_task2.planned_start == datetime(2025, 10, 21, 9, 0, 0)  # Tuesday
+        assert updated_task1.planned_start == datetime(2025, 10, 20, 0, 0, 0)  # Monday
+        assert updated_task2.planned_start == datetime(2025, 10, 21, 0, 0, 0)  # Tuesday
 
     def test_earliest_deadline_handles_no_deadline(self):
         """Test that EDF schedules tasks without deadlines last."""
@@ -67,8 +67,8 @@ class TestEarliestDeadlineOptimizationStrategy(BaseOptimizationStrategyTest):
         updated_task2 = self.repository.get_by_id(task2.id)
         assert updated_task1 is not None and updated_task2 is not None
 
-        assert updated_task1.planned_start == datetime(2025, 10, 20, 9, 0, 0)  # Monday
-        assert updated_task2.planned_start == datetime(2025, 10, 21, 9, 0, 0)  # Tuesday
+        assert updated_task1.planned_start == datetime(2025, 10, 20, 0, 0, 0)  # Monday
+        assert updated_task2.planned_start == datetime(2025, 10, 21, 0, 0, 0)  # Tuesday
 
     def test_earliest_deadline_respects_deadline_constraints(self):
         """Test that EDF fails tasks that cannot meet their deadlines."""
@@ -125,11 +125,11 @@ class TestEarliestDeadlineOptimizationStrategy(BaseOptimizationStrategyTest):
         )
 
         # Earliest deadline should be scheduled first
-        assert updated_low.planned_start == datetime(2025, 10, 20, 9, 0, 0)
+        assert updated_low.planned_start == datetime(2025, 10, 20, 0, 0, 0)
         # Middle deadline should be scheduled second
-        assert updated_medium.planned_start == datetime(2025, 10, 21, 9, 0, 0)
+        assert updated_medium.planned_start == datetime(2025, 10, 21, 0, 0, 0)
         # Latest deadline should be scheduled last
-        assert updated_high.planned_start == datetime(2025, 10, 22, 9, 0, 0)
+        assert updated_high.planned_start == datetime(2025, 10, 22, 0, 0, 0)
 
     def test_earliest_deadline_uses_greedy_allocation(self):
         """Test that EDF uses greedy forward allocation strategy."""

--- a/packages/taskdog-core/tests/application/services/optimization/test_greedy_optimization_strategy.py
+++ b/packages/taskdog-core/tests/application/services/optimization/test_greedy_optimization_strategy.py
@@ -30,8 +30,8 @@ class TestGreedyOptimizationStrategy(BaseOptimizationStrategyTest):
         # Should start on Monday, end on Tuesday (12h / 6h per day = 2 days)
         self.assert_task_scheduled(
             task,
-            expected_start=datetime(2025, 10, 20, 9, 0, 0),
-            expected_end=datetime(2025, 10, 21, 18, 0, 0),
+            expected_start=datetime(2025, 10, 20, 0, 0, 0),
+            expected_end=datetime(2025, 10, 21, 23, 59, 59),
         )
 
         # Check daily allocations: greedy fills each day to max
@@ -85,8 +85,8 @@ class TestGreedyOptimizationStrategy(BaseOptimizationStrategyTest):
         # Should start Friday, end Monday (skipping Saturday/Sunday)
         self.assert_task_scheduled(
             task,
-            expected_start=datetime(2025, 10, 24, 9, 0, 0),
-            expected_end=datetime(2025, 10, 27, 18, 0, 0),
+            expected_start=datetime(2025, 10, 24, 0, 0, 0),
+            expected_end=datetime(2025, 10, 27, 23, 59, 59),
         )
 
         # Verify no weekend allocations

--- a/packages/taskdog-core/tests/application/services/optimization/test_optimization_strategy_base.py
+++ b/packages/taskdog-core/tests/application/services/optimization/test_optimization_strategy_base.py
@@ -1,10 +1,10 @@
 """Tests for allocation helper functions."""
 
-from datetime import date, datetime, time
-
-import pytest
+from datetime import date, datetime
 
 from taskdog_core.application.services.optimization.allocation_helpers import (
+    SCHEDULE_END_TIME,
+    SCHEDULE_START_TIME,
     calculate_available_hours,
     prepare_task_for_allocation,
     set_planned_times,
@@ -19,12 +19,6 @@ class TestOptimizationStrategyHelpers:
     from individual strategy classes to eliminate code duplication.
     """
 
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        """Set up test fixtures."""
-        self.default_start_time = time(9, 0)
-        self.default_end_time = time(18, 0)
-
     def test_calculate_available_hours_with_no_allocation(self):
         """Test available hours calculation when no hours are allocated."""
         daily_allocations: dict[date, float] = {}
@@ -37,7 +31,6 @@ class TestOptimizationStrategyHelpers:
             date_obj,
             max_hours_per_day,
             current_time,
-            self.default_end_time,
         )
 
         assert available == 8.0
@@ -54,7 +47,6 @@ class TestOptimizationStrategyHelpers:
             date_obj,
             max_hours_per_day,
             current_time,
-            self.default_end_time,
         )
 
         assert available == 5.0  # 8.0 - 3.0
@@ -71,7 +63,6 @@ class TestOptimizationStrategyHelpers:
             date_obj,
             max_hours_per_day,
             current_time,
-            self.default_end_time,
         )
 
         assert available == 0.0
@@ -82,8 +73,8 @@ class TestOptimizationStrategyHelpers:
         date_obj = date(2025, 10, 20)
         max_hours_per_day = 8.0
         # Current time: 2025-10-20 14:00 (2:00 PM)
-        # End hour: 18:00 (6:00 PM)
-        # Remaining: 4.0 hours
+        # End hour: 23:59:59
+        # Remaining: ~9.98 hours, but capped by max_hours_per_day = 8.0
         current_time = datetime(2025, 10, 20, 14, 0, 0)
 
         available = calculate_available_hours(
@@ -91,10 +82,9 @@ class TestOptimizationStrategyHelpers:
             date_obj,
             max_hours_per_day,
             current_time,
-            self.default_end_time,
         )
 
-        assert available == 4.0  # min(8.0, 4.0)
+        assert available == 8.0  # min(8.0, ~9.98)
 
     def test_calculate_available_hours_today_with_allocation_and_time(self):
         """Test available hours for today considering both allocation and time."""
@@ -102,10 +92,10 @@ class TestOptimizationStrategyHelpers:
         date_obj = date(2025, 10, 20)
         max_hours_per_day = 8.0
         # Current time: 2025-10-20 14:00 (2:00 PM)
-        # End hour: 18:00 (6:00 PM)
+        # End hour: 23:59:59
         # Available from max: 8.0 - 2.0 = 6.0 hours
-        # Remaining time: 4.0 hours
-        # Result: min(6.0, 4.0) = 4.0
+        # Remaining time: ~9.98 hours
+        # Result: min(6.0, ~9.98) = 6.0
         current_time = datetime(2025, 10, 20, 14, 0, 0)
 
         available = calculate_available_hours(
@@ -113,28 +103,28 @@ class TestOptimizationStrategyHelpers:
             date_obj,
             max_hours_per_day,
             current_time,
-            self.default_end_time,
         )
 
-        assert available == 4.0
+        assert available == 6.0
 
     def test_calculate_available_hours_today_past_end_hour(self):
-        """Test available hours for today when past end hour."""
+        """Test available hours for today when current time is very late."""
         daily_allocations: dict[date, float] = {}
         date_obj = date(2025, 10, 20)
         max_hours_per_day = 8.0
-        # Current time: 2025-10-20 19:00 (7:00 PM) - past end hour (18:00)
-        current_time = datetime(2025, 10, 20, 19, 0, 0)
+        # Current time: 2025-10-20 23:59 - near end of day
+        # End hour: 23:59:59, remaining: ~0.98 minutes
+        current_time = datetime(2025, 10, 20, 23, 59, 0)
 
         available = calculate_available_hours(
             daily_allocations,
             date_obj,
             max_hours_per_day,
             current_time,
-            self.default_end_time,
         )
 
-        assert available == 0.0  # No time remaining today
+        # Very small remaining time (< 1 minute)
+        assert available < 0.02
 
     def test_calculate_available_hours_with_minutes(self):
         """Test available hours calculation with fractional hours (minutes)."""
@@ -142,8 +132,8 @@ class TestOptimizationStrategyHelpers:
         date_obj = date(2025, 10, 20)
         max_hours_per_day = 8.0
         # Current time: 2025-10-20 14:30 (2:30 PM)
-        # End hour: 18:00 (6:00 PM)
-        # Remaining: 3.5 hours
+        # End hour: 23:59:59
+        # Remaining: ~9.49 hours, but capped by max_hours_per_day = 8.0
         current_time = datetime(2025, 10, 20, 14, 30, 0)
 
         available = calculate_available_hours(
@@ -151,10 +141,9 @@ class TestOptimizationStrategyHelpers:
             date_obj,
             max_hours_per_day,
             current_time,
-            self.default_end_time,
         )
 
-        assert available == 3.5
+        assert available == 8.0
 
     def test_set_planned_times(self):
         """Test setting planned start, end, and daily allocations on task."""
@@ -164,8 +153,8 @@ class TestOptimizationStrategyHelpers:
             priority=100,
             estimated_duration=10.0,
         )
-        schedule_start = datetime(2025, 10, 20, 0, 0, 0)  # Will be set to 9:00
-        schedule_end = datetime(2025, 10, 22, 0, 0, 0)  # Will be set to 18:00
+        schedule_start = datetime(2025, 10, 20, 0, 0, 0)
+        schedule_end = datetime(2025, 10, 22, 0, 0, 0)
         task_daily_allocations = {
             date(2025, 10, 20): 5.0,
             date(2025, 10, 21): 3.0,
@@ -177,15 +166,13 @@ class TestOptimizationStrategyHelpers:
             schedule_start,
             schedule_end,
             task_daily_allocations,
-            self.default_start_time,
-            self.default_end_time,
         )
 
-        # Verify planned_start is set to 9:00 AM
-        assert task.planned_start == datetime(2025, 10, 20, 9, 0, 0)
+        # Verify planned_start is set to 00:00:00
+        assert task.planned_start == datetime(2025, 10, 20, 0, 0, 0)
 
-        # Verify planned_end is set to 6:00 PM
-        assert task.planned_end == datetime(2025, 10, 22, 18, 0, 0)
+        # Verify planned_end is set to 23:59:59
+        assert task.planned_end == datetime(2025, 10, 22, 23, 59, 59)
 
         # Verify daily allocations are set
         assert task.daily_allocations == task_daily_allocations
@@ -215,22 +202,20 @@ class TestOptimizationStrategyHelpers:
             schedule_start,
             schedule_end,
             task_daily_allocations,
-            self.default_start_time,
-            self.default_end_time,
         )
 
-        # Date should be preserved, but time should be set to default hours
+        # Date should be preserved, but time should be set to schedule constants
         assert task.planned_start is not None
         assert task.planned_start.date() == schedule_start.date()  # Same date
-        assert task.planned_start.hour == 9  # Default start hour
-        assert task.planned_start.minute == 0
-        assert task.planned_start.second == 0
+        assert task.planned_start.hour == SCHEDULE_START_TIME.hour
+        assert task.planned_start.minute == SCHEDULE_START_TIME.minute
+        assert task.planned_start.second == SCHEDULE_START_TIME.second
 
         assert task.planned_end is not None
         assert task.planned_end.date() == schedule_end.date()  # Same date
-        assert task.planned_end.hour == 18  # Default end hour
-        assert task.planned_end.minute == 0
-        assert task.planned_end.second == 0
+        assert task.planned_end.hour == SCHEDULE_END_TIME.hour
+        assert task.planned_end.minute == SCHEDULE_END_TIME.minute
+        assert task.planned_end.second == SCHEDULE_END_TIME.second
 
     def test_prepare_task_for_allocation_valid_task(self):
         """Test prepare_task_for_allocation with valid task."""

--- a/packages/taskdog-core/tests/application/services/optimization/test_priority_first_optimization_strategy.py
+++ b/packages/taskdog-core/tests/application/services/optimization/test_priority_first_optimization_strategy.py
@@ -51,11 +51,11 @@ class TestPriorityFirstOptimizationStrategy(BaseOptimizationStrategyTest):
         )
 
         # High priority starts first (Monday)
-        assert updated_high.planned_start == datetime(2025, 10, 20, 9, 0, 0)
+        assert updated_high.planned_start == datetime(2025, 10, 20, 0, 0, 0)
         # Medium priority starts second (Tuesday)
-        assert updated_medium.planned_start == datetime(2025, 10, 21, 9, 0, 0)
+        assert updated_medium.planned_start == datetime(2025, 10, 21, 0, 0, 0)
         # Low priority starts last (Wednesday)
-        assert updated_low.planned_start == datetime(2025, 10, 22, 9, 0, 0)
+        assert updated_low.planned_start == datetime(2025, 10, 22, 0, 0, 0)
 
     def test_priority_first_ignores_deadlines(self):
         """Test that priority_first ignores deadlines and focuses only on priority."""
@@ -85,6 +85,6 @@ class TestPriorityFirstOptimizationStrategy(BaseOptimizationStrategyTest):
         assert updated_high_far is not None and updated_low_urgent is not None
 
         # High priority task scheduled first despite far deadline
-        assert updated_high_far.planned_start == datetime(2025, 10, 20, 9, 0, 0)
+        assert updated_high_far.planned_start == datetime(2025, 10, 20, 0, 0, 0)
         # Urgent task scheduled second despite earlier deadline
-        assert updated_low_urgent.planned_start == datetime(2025, 10, 21, 9, 0, 0)
+        assert updated_low_urgent.planned_start == datetime(2025, 10, 21, 0, 0, 0)

--- a/packages/taskdog-core/tests/application/services/optimization/test_round_robin_optimization_strategy.py
+++ b/packages/taskdog-core/tests/application/services/optimization/test_round_robin_optimization_strategy.py
@@ -82,7 +82,7 @@ class TestRoundRobinOptimizationStrategy(BaseOptimizationStrategyTest):
         for task in tasks:
             updated_task = self.repository.get_by_id(task.id)
             assert updated_task is not None
-            assert updated_task.planned_start == datetime(2025, 10, 20, 9, 0, 0)
+            assert updated_task.planned_start == datetime(2025, 10, 20, 0, 0, 0)
 
     def test_round_robin_stops_allocating_after_task_completion(self):
         """Test that round-robin stops allocating to completed tasks."""

--- a/packages/taskdog-core/tests/application/services/optimization/test_strategy_factory.py
+++ b/packages/taskdog-core/tests/application/services/optimization/test_strategy_factory.py
@@ -1,7 +1,5 @@
 """Tests for StrategyFactory."""
 
-from datetime import time
-
 import pytest
 
 from taskdog_core.application.services.optimization.backward_optimization_strategy import (
@@ -66,13 +64,13 @@ class TestStrategyFactory:
     )
     def test_create_all_strategy_types(self, algo_name, expected_class):
         """Test create returns correct strategy type for each algorithm."""
-        strategy = StrategyFactory.create(algo_name, time(9, 0), time(18, 0))
+        strategy = StrategyFactory.create(algo_name)
         assert isinstance(strategy, expected_class)
 
     def test_create_with_unknown_algorithm_raises_error(self):
         """Test create raises ValueError for unknown algorithm."""
         with pytest.raises(ValueError) as exc_info:
-            StrategyFactory.create("unknown_algo", time(9, 0), time(18, 0))
+            StrategyFactory.create("unknown_algo")
 
         error_msg = str(exc_info.value)
         assert "Unknown optimization algorithm" in error_msg
@@ -81,10 +79,7 @@ class TestStrategyFactory:
 
     def test_create_defaults_to_greedy(self):
         """Test create uses 'greedy' as default algorithm when not specified."""
-        # When algorithm_name defaults to "greedy"
-        strategy = StrategyFactory.create(
-            default_start_time=time(9, 0), default_end_time=time(18, 0)
-        )
+        strategy = StrategyFactory.create()
 
         assert isinstance(strategy, GreedyOptimizationStrategy)
 
@@ -123,11 +118,11 @@ class TestStrategyFactory:
         metadata = StrategyFactory.get_algorithm_metadata()
 
         for algo_id, _, _ in metadata:
-            strategy = StrategyFactory.create(algo_id, time(9, 0), time(18, 0))
+            strategy = StrategyFactory.create(algo_id)
             assert strategy is not None
 
     @pytest.mark.parametrize("case_variant", ["Greedy", "GREEDY"])
     def test_create_is_case_sensitive(self, case_variant):
         """Test that algorithm names are case-sensitive."""
         with pytest.raises(ValueError):
-            StrategyFactory.create(case_variant, time(9, 0), time(18, 0))
+            StrategyFactory.create(case_variant)

--- a/packages/taskdog-core/tests/application/use_cases/test_optimize_schedule_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_optimize_schedule_use_case.py
@@ -1,6 +1,6 @@
 """Tests for OptimizeScheduleUseCase."""
 
-from datetime import date, datetime, time
+from datetime import date, datetime
 
 import pytest
 
@@ -25,13 +25,7 @@ class TestOptimizeScheduleUseCase:
         """Initialize use cases for each test."""
         self.repository = repository
         self.create_use_case = CreateTaskUseCase(self.repository)
-        # Use default time values directly instead of loading config
-        # to avoid tests depending on user's local config
-        self.optimize_use_case = OptimizeScheduleUseCase(
-            self.repository,
-            time(9, 0),  # default start time
-            time(18, 0),  # default end time
-        )
+        self.optimize_use_case = OptimizeScheduleUseCase(self.repository)
 
     def test_optimize_single_task(self):
         """Test optimizing a single task with estimated duration."""
@@ -59,8 +53,8 @@ class TestOptimizeScheduleUseCase:
         assert task.planned_end is not None
 
         # Task should be scheduled on the start date
-        assert task.planned_start == datetime(2025, 10, 15, 9, 0, 0)
-        assert task.planned_end == datetime(2025, 10, 15, 18, 0, 0)
+        assert task.planned_start == datetime(2025, 10, 15, 0, 0, 0)
+        assert task.planned_end == datetime(2025, 10, 15, 23, 59, 59)
 
         # Verify daily_allocations
         assert task.daily_allocations is not None
@@ -91,8 +85,8 @@ class TestOptimizeScheduleUseCase:
             # Re-fetch task from repository to verify scheduling
             task = self.repository.get_by_id(task_dto.id)
             assert task is not None
-            assert task.planned_start == datetime(2025, 10, 15, 9, 0, 0)
-            assert task.planned_end == datetime(2025, 10, 15, 18, 0, 0)
+            assert task.planned_start == datetime(2025, 10, 15, 0, 0, 0)
+            assert task.planned_end == datetime(2025, 10, 15, 23, 59, 59)
 
     def test_optimize_tasks_spanning_multiple_days(self):
         """Test optimizing tasks that span multiple days."""
@@ -130,14 +124,14 @@ class TestOptimizeScheduleUseCase:
         assert task1 is not None and task2 is not None
 
         # First task (priority 200, 5h) starts on start date and fits in one day
-        assert task1.planned_start == datetime(2025, 10, 15, 9, 0, 0)
-        assert task1.planned_end == datetime(2025, 10, 15, 18, 0, 0)
+        assert task1.planned_start == datetime(2025, 10, 15, 0, 0, 0)
+        assert task1.planned_end == datetime(2025, 10, 15, 23, 59, 59)
         # Verify daily_allocations for task1
         assert task1.daily_allocations[date(2025, 10, 15)] == 5.0
 
         # Second task (priority 100, 5h) starts on same day (1h left) and spans to next day
-        assert task2.planned_start == datetime(2025, 10, 15, 9, 0, 0)
-        assert task2.planned_end == datetime(2025, 10, 16, 18, 0, 0)
+        assert task2.planned_start == datetime(2025, 10, 15, 0, 0, 0)
+        assert task2.planned_end == datetime(2025, 10, 16, 23, 59, 59)
         # Verify daily_allocations for task2: 1h on first day, 4h on second day
         assert task2.daily_allocations[date(2025, 10, 15)] == 1.0
         assert task2.daily_allocations[date(2025, 10, 16)] == 4.0
@@ -165,10 +159,10 @@ class TestOptimizeScheduleUseCase:
         assert task is not None
 
         # Task should start on Friday
-        assert task.planned_start == datetime(2025, 10, 17, 9, 0, 0)
+        assert task.planned_start == datetime(2025, 10, 17, 0, 0, 0)
         # And end on Monday (skipping weekend)
         # Friday: 5h allocated
-        assert task.planned_end == datetime(2025, 10, 17, 18, 0, 0)
+        assert task.planned_end == datetime(2025, 10, 17, 23, 59, 59)
 
     def test_optimize_respects_priority(self):
         """Test that high priority tasks are scheduled first."""
@@ -198,7 +192,7 @@ class TestOptimizeScheduleUseCase:
             # Re-fetch task from repository to verify scheduling
             task = self.repository.get_by_id(task_dto.id)
             assert task is not None
-            assert task.planned_start == datetime(2025, 10, 15, 9, 0, 0)
+            assert task.planned_start == datetime(2025, 10, 15, 0, 0, 0)
 
     def test_optimize_respects_deadline(self):
         """Test that tasks with closer deadlines are prioritized."""
@@ -235,7 +229,7 @@ class TestOptimizeScheduleUseCase:
             # Re-fetch task from repository to verify scheduling
             task = self.repository.get_by_id(task_dto.id)
             assert task is not None
-            assert task.planned_start == datetime(2025, 10, 15, 9, 0, 0)
+            assert task.planned_start == datetime(2025, 10, 15, 0, 0, 0)
 
     def test_optimize_skips_completed_tasks(self):
         """Test that completed tasks are not scheduled."""
@@ -363,7 +357,7 @@ class TestOptimizeScheduleUseCase:
         task = self.repository.get_by_id(task_result.id)
         assert task is not None
         assert task.planned_start != old_start
-        assert task.planned_start == datetime(2025, 10, 15, 9, 0, 0)
+        assert task.planned_start == datetime(2025, 10, 15, 0, 0, 0)
 
     def test_optimize_specific_tasks_only(self):
         """Test optimizing only specific task IDs."""

--- a/packages/taskdog-core/tests/fixtures/pytest_fixtures.py
+++ b/packages/taskdog-core/tests/fixtures/pytest_fixtures.py
@@ -16,7 +16,7 @@ Usage in conftest.py:
     )
 """
 
-from datetime import datetime, time
+from datetime import datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -28,10 +28,6 @@ from .factories import TaskFactory
 
 def create_mock_config(
     max_hours_per_day: float = 8.0,
-    default_start_time: time = time(9, 0),
-    default_end_time: time = time(18, 0),
-    work_hours_start: time = time(9, 0),
-    work_hours_end: time = time(18, 0),
     country: str | None = None,
 ) -> MagicMock:
     """Create a mock configuration with customizable defaults.
@@ -40,10 +36,6 @@ def create_mock_config(
     """
     config = MagicMock()
     config.optimization.max_hours_per_day = max_hours_per_day
-    config.time.default_start_time = default_start_time
-    config.time.default_end_time = default_end_time
-    config.time.work_hours_start = work_hours_start
-    config.time.work_hours_end = work_hours_end
     config.region.country = country
     return config
 


### PR DESCRIPTION
## Summary

- Replace configurable `work_hours_start`/`work_hours_end` with fixed `SCHEDULE_START_TIME (00:00:00)` / `SCHEDULE_END_TIME (23:59:59)` constants in the optimizer. The `max_hours_per_day` parameter already constrains daily work capacity, making work_hours redundant for scheduling.
- Remove `default_start_time`/`default_end_time` parameters from all 9 optimization strategies, `StrategyFactory`, `OptimizeScheduleUseCase`, and `TaskAnalyticsController`.
- Remove `TimeConfig` class, `Config.time` field, and `WORK_HOURS_START`/`WORK_HOURS_END` constants since they only served the optimizer.

## Test plan

- [x] `make test-core` — 1058 passed
- [x] `make test-server` — 270 passed
- [x] `make lint` — All checks passed
- [x] `make typecheck` — No issues found across all 5 packages
- [x] Pre-commit hooks passed (ruff, mypy, unit tests, conventional commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)