### PR TITLE
ci: add pre-commit autoupdate workflow

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,0 +1,41 @@
+name: Pre-commit Autoupdate
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"  # Every Monday at 9:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  autoupdate:
+    name: Update pre-commit hooks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Run pre-commit autoupdate
+        run: pre-commit autoupdate
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/pre-commit-autoupdate
+          commit-message: "chore: pre-commit autoupdate"
+          title: "chore: pre-commit autoupdate"
+          body: |
+            Automated update of pre-commit hook versions via `pre-commit autoupdate`.
+
+            Please review the version changes and ensure CI passes before merging.
+          labels: dependencies


### PR DESCRIPTION
## Summary

- Add a GitHub Actions workflow that automatically runs `pre-commit autoupdate` weekly (Monday 9:00 UTC) and creates a PR with updated hook versions
- Reduces manual maintenance burden for keeping pre-commit hooks up to date
- Supports `workflow_dispatch` for on-demand execution

## Details

The workflow uses `peter-evans/create-pull-request@v7` to open a PR on branch `chore/pre-commit-autoupdate` whenever hook versions change. PRs are labeled `dependencies` and require manual review/merge since CI should verify the updates.

Dependabot auto-merge does not apply to these PRs (`dependabot[bot]` actor check), which is intentional.

## Test plan

- [ ] Validate workflow syntax with `actionlint` (passed locally)
- [ ] Trigger manually via `workflow_dispatch` to confirm PR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)