### PR TITLE
refactor: simplify has_notes flow by adding field to TaskRowDto

### DIFF
--- a/packages/taskdog-client/src/taskdog_client/converters/task_converters.py
+++ b/packages/taskdog-client/src/taskdog_client/converters/task_converters.py
@@ -117,24 +117,17 @@ def convert_to_update_task_output(data: dict[str, Any]) -> TaskUpdateOutput:
     )
 
 
-def convert_to_task_list_output(
-    data: dict[str, Any], has_notes_cache: dict[int, bool] | None = None
-) -> TaskListOutput:
+def convert_to_task_list_output(data: dict[str, Any]) -> TaskListOutput:
     """Convert API response to TaskListOutput.
 
     Args:
         data: API response data
-        has_notes_cache: Optional cache dictionary to populate with has_notes info
 
     Returns:
         TaskListOutput with task list and metadata
     """
     tasks = []
     for task in data["tasks"]:
-        # Cache has_notes information if cache provided
-        if has_notes_cache is not None:
-            has_notes_cache[task["id"]] = task.get("has_notes", False)
-
         # Parse datetime fields using utility
         dt_fields = _parse_datetime_fields(
             task,
@@ -161,6 +154,7 @@ def convert_to_task_list_output(
                 is_finished=task.get("is_finished", False),
                 created_at=_parse_required_datetime(task, "created_at"),
                 updated_at=_parse_required_datetime(task, "updated_at"),
+                has_notes=task.get("has_notes", False),
             )
         )
 

--- a/packages/taskdog-client/src/taskdog_client/notes_client.py
+++ b/packages/taskdog-client/src/taskdog_client/notes_client.py
@@ -4,12 +4,10 @@ from taskdog_client.base_client import BaseApiClient
 
 
 class NotesClient:
-    """Client for task notes operations with caching.
+    """Client for task notes operations.
 
     Operations:
     - Get, update, delete notes
-    - Check note existence (with cache)
-    - Cache management
     """
 
     def __init__(self, base_client: BaseApiClient):
@@ -19,7 +17,6 @@ class NotesClient:
             base_client: Base API client for HTTP operations
         """
         self._base = base_client
-        self._has_notes_cache: dict[int, bool] = {}
 
     def get_task_notes(self, task_id: int) -> tuple[str, bool]:
         """Get task notes.
@@ -67,26 +64,3 @@ class NotesClient:
         response = self._base._safe_request("delete", f"/api/v1/tasks/{task_id}/notes")
         if response.status_code != 204:
             self._base._handle_error(response)
-
-    def has_task_notes(self, task_id: int) -> bool:
-        """Check if task has notes.
-
-        Uses cached information from list_tasks if available, otherwise queries API.
-
-        Args:
-            task_id: Task ID
-
-        Returns:
-            True if task has notes, False otherwise
-
-        Raises:
-            TaskNotFoundException: If task not found
-        """
-        # Use cache if available (populated by list_tasks)
-        if task_id in self._has_notes_cache:
-            return self._has_notes_cache[task_id]
-
-        # Fall back to API call
-        _, has_notes = self.get_task_notes(task_id)
-        self._has_notes_cache[task_id] = has_notes
-        return has_notes

--- a/packages/taskdog-client/src/taskdog_client/query_client.py
+++ b/packages/taskdog-client/src/taskdog_client/query_client.py
@@ -28,15 +28,13 @@ class QueryClient:
     - Tag statistics
     """
 
-    def __init__(self, base_client: BaseApiClient, has_notes_cache: dict[int, bool]):
+    def __init__(self, base_client: BaseApiClient):
         """Initialize query client.
 
         Args:
             base_client: Base API client for HTTP operations
-            has_notes_cache: Shared cache for has_notes information
         """
         self._base = base_client
-        self._has_notes_cache = has_notes_cache
 
     def _build_list_params(
         self,
@@ -120,7 +118,7 @@ class QueryClient:
 
         params = self._build_list_params(all, sort_by, reverse, status, tags, **extra)
         data = self._base._request_json("get", "/api/v1/tasks", params=params)
-        return convert_to_task_list_output(data, self._has_notes_cache)
+        return convert_to_task_list_output(data)
 
     def list_today_tasks(
         self,
@@ -147,7 +145,7 @@ class QueryClient:
         """
         params = self._build_list_params(all, sort_by, reverse, status)
         data = self._base._request_json("get", "/api/v1/tasks/today", params=params)
-        return convert_to_task_list_output(data, self._has_notes_cache)
+        return convert_to_task_list_output(data)
 
     def list_week_tasks(
         self,
@@ -174,7 +172,7 @@ class QueryClient:
         """
         params = self._build_list_params(all, sort_by, reverse, status)
         data = self._base._request_json("get", "/api/v1/tasks/week", params=params)
-        return convert_to_task_list_output(data, self._has_notes_cache)
+        return convert_to_task_list_output(data)
 
     def get_task_by_id(self, task_id: int) -> TaskByIdOutput:
         """Get task by ID.

--- a/packages/taskdog-client/src/taskdog_client/taskdog_api_client.py
+++ b/packages/taskdog-client/src/taskdog_client/taskdog_api_client.py
@@ -52,19 +52,15 @@ class TaskdogApiClient:
         """
         self.base_url = base_url
         self._base = BaseApiClient(base_url, timeout, api_key=api_key)
-        self._has_notes_cache: dict[int, bool] = {}
 
         # Initialize specialized clients
         self._tasks = TaskClient(self._base)
         self._lifecycle = LifecycleClient(self._base)
         self._relationships = RelationshipClient(self._base)
-        self._queries = QueryClient(self._base, self._has_notes_cache)
+        self._queries = QueryClient(self._base)
         self._analytics = AnalyticsClient(self._base)
         self._notes = NotesClient(self._base)
         self._audit = AuditClient(self._base)
-
-        # Share the notes cache with notes client
-        self._notes._has_notes_cache = self._has_notes_cache
 
     @property
     def client(self) -> httpx.Client:
@@ -388,10 +384,6 @@ class TaskdogApiClient:
     def delete_task_notes(self, task_id: int) -> None:
         """Delete task notes."""
         return self._notes.delete_task_notes(task_id)
-
-    def has_task_notes(self, task_id: int) -> bool:
-        """Check if task has notes."""
-        return self._notes.has_task_notes(task_id)
 
     # Audit log methods - delegate to AuditClient
 

--- a/packages/taskdog-client/tests/converters/test_task_converters.py
+++ b/packages/taskdog-client/tests/converters/test_task_converters.py
@@ -256,8 +256,8 @@ class TestConvertToTaskListOutput:
         assert result.tasks[1].id == 2
         assert result.tasks[1].is_finished is True
 
-    def test_with_has_notes_cache(self):
-        """Test that has_notes cache is populated."""
+    def test_has_notes_set_on_task_row_dto(self):
+        """Test that has_notes is set directly on TaskRowDto."""
         data = {
             "tasks": [
                 {
@@ -307,11 +307,10 @@ class TestConvertToTaskListOutput:
             "filtered_count": 2,
         }
 
-        cache: dict[int, bool] = {}
-        convert_to_task_list_output(data, cache)
+        result = convert_to_task_list_output(data)
 
-        assert cache[1] is False
-        assert cache[2] is True
+        assert result.tasks[0].has_notes is False
+        assert result.tasks[1].has_notes is True
 
     def test_empty_task_list(self):
         """Test conversion with empty task list."""

--- a/packages/taskdog-client/tests/test_converters.py
+++ b/packages/taskdog-client/tests/test_converters.py
@@ -163,19 +163,16 @@ class TestConverters:
             "filtered_count": 2,
         }
 
-        cache = {}
-        result = convert_to_task_list_output(data, cache)
+        result = convert_to_task_list_output(data)
 
         assert len(result.tasks) == 2
         assert result.total_count == 10
         assert result.filtered_count == 2
         assert result.tasks[0].id == 1
+        assert result.tasks[0].has_notes is False
         assert result.tasks[1].id == 2
         assert result.tasks[1].is_finished is True
-
-        # Check cache was populated
-        assert cache[1] is False
-        assert cache[2] is True
+        assert result.tasks[1].has_notes is True
 
     def test_convert_to_get_task_by_id_output(self):
         """Test convert_to_get_task_by_id_output."""

--- a/packages/taskdog-client/tests/test_notes_client.py
+++ b/packages/taskdog-client/tests/test_notes_client.py
@@ -73,25 +73,3 @@ class TestNotesClient:
         self.mock_base._safe_request.assert_called_once_with(
             "delete", "/api/v1/tasks/1/notes"
         )
-
-    def test_has_task_notes_from_cache(self):
-        """Test has_task_notes uses cache."""
-        self.client._has_notes_cache[1] = True
-
-        result = self.client.has_task_notes(task_id=1)
-
-        assert result is True
-        self.mock_base._safe_request.assert_not_called()
-
-    def test_has_task_notes_from_api(self):
-        """Test has_task_notes queries API when not cached."""
-        mock_response = Mock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"content": "Notes", "has_notes": True}
-        self.mock_base._safe_request.return_value = mock_response
-
-        result = self.client.has_task_notes(task_id=1)
-
-        assert result is True
-        # Should be cached now
-        assert self.client._has_notes_cache[1] is True

--- a/packages/taskdog-client/tests/test_query_client.py
+++ b/packages/taskdog-client/tests/test_query_client.py
@@ -14,8 +14,7 @@ class TestQueryClient:
     def setup(self):
         """Set up test fixtures."""
         self.mock_base = Mock()
-        self.notes_cache = {}
-        self.client = QueryClient(self.mock_base, self.notes_cache)
+        self.client = QueryClient(self.mock_base)
 
     @patch("taskdog_client.query_client.convert_to_task_list_output")
     def test_list_tasks(self, mock_convert):
@@ -55,7 +54,7 @@ class TestQueryClient:
         assert params["reverse"] == "true"
 
         assert result == mock_output
-        mock_convert.assert_called_once_with(mock_json, self.notes_cache)
+        mock_convert.assert_called_once_with(mock_json)
 
     @pytest.mark.parametrize(
         "method_name,converter_name,mock_json",

--- a/packages/taskdog-client/tests/test_taskdog_api_client.py
+++ b/packages/taskdog-client/tests/test_taskdog_api_client.py
@@ -309,11 +309,6 @@ class TestTaskdogApiClientDelegation:
         client.delete_task_notes(task_id=1)
         client._notes.delete_task_notes.assert_called_once_with(1)
 
-    def test_has_task_notes(self, client):
-        """Test has_task_notes delegates to NotesClient."""
-        client.has_task_notes(task_id=1)
-        client._notes.has_task_notes.assert_called_once_with(1)
-
     # Audit methods
     def test_list_audit_logs(self, client):
         """Test list_audit_logs delegates to AuditClient."""

--- a/packages/taskdog-core/src/taskdog_core/application/dto/task_dto.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/task_dto.py
@@ -125,6 +125,7 @@ class TaskRowDto:
     is_finished: bool
     created_at: datetime
     updated_at: datetime
+    has_notes: bool = False
 
     @classmethod
     def from_entity(cls, task: Task) -> TaskRowDto:
@@ -192,6 +193,7 @@ class TaskRowDto:
             "is_finished": self.is_finished,
             "created_at": self.created_at.isoformat(),
             "updated_at": self.updated_at.isoformat(),
+            "has_notes": self.has_notes,
         }
 
 

--- a/packages/taskdog-ui/src/taskdog/cli/commands/table_helpers.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/table_helpers.py
@@ -17,10 +17,9 @@ def render_table(
         fields: Optional list of fields to display (None = all fields)
     """
     console_writer = ctx_obj.console_writer
-    api_client = ctx_obj.api_client
 
     # Convert DTO to ViewModels using Presenter
-    presenter = TablePresenter(api_client)
+    presenter = TablePresenter()
     task_view_models = presenter.present(output)
 
     # Render using ViewModels

--- a/packages/taskdog-ui/src/taskdog/presenters/table_presenter.py
+++ b/packages/taskdog-ui/src/taskdog/presenters/table_presenter.py
@@ -4,29 +4,9 @@ This presenter extracts necessary fields from TaskRowDto within TaskListOutput
 and creates presentation-ready view models for table/list display.
 """
 
-from typing import TYPE_CHECKING, Protocol
-
 from taskdog.view_models.task_view_model import TaskRowViewModel
 from taskdog_core.application.dto.task_dto import TaskRowDto
 from taskdog_core.application.dto.task_list_output import TaskListOutput
-
-if TYPE_CHECKING:
-    from taskdog_client import TaskdogApiClient
-
-
-class NotesChecker(Protocol):
-    """Protocol for checking notes existence (supports API client)."""
-
-    def has_task_notes(self, task_id: int) -> bool:
-        """Check if task has notes.
-
-        Args:
-            task_id: Task ID
-
-        Returns:
-            True if task has notes, False otherwise
-        """
-        ...
 
 
 class TablePresenter:
@@ -34,17 +14,8 @@ class TablePresenter:
 
     This class is responsible for:
     1. Extracting necessary fields from TaskRowDto within DTOs
-    2. Checking for associated notes via API client
-    3. Converting DTO data to presentation-ready ViewModels
+    2. Converting DTO data to presentation-ready ViewModels
     """
-
-    def __init__(self, notes_checker: "NotesChecker | TaskdogApiClient"):
-        """Initialize the presenter.
-
-        Args:
-            notes_checker: API client or object with has_task_notes method
-        """
-        self.notes_checker = notes_checker
 
     def present(self, output: TaskListOutput) -> list[TaskRowViewModel]:
         """Convert TaskListOutput DTO to list of TaskRowViewModels.
@@ -66,9 +37,6 @@ class TablePresenter:
         Returns:
             TaskRowViewModel with presentation-ready data
         """
-        # Check if task has notes via API
-        has_notes = self.notes_checker.has_task_notes(task.id)
-
         return TaskRowViewModel(
             id=task.id,
             name=task.name,
@@ -85,7 +53,7 @@ class TablePresenter:
             depends_on=task.depends_on.copy() if task.depends_on else [],
             tags=task.tags.copy() if task.tags else [],
             is_finished=task.is_finished,
-            has_notes=has_notes,
+            has_notes=task.has_notes,
             created_at=task.created_at,
             updated_at=task.updated_at,
         )

--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -250,7 +250,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         )
 
         # Initialize presenters for view models
-        self.table_presenter = TablePresenter(api_client)
+        self.table_presenter = TablePresenter()
         self.gantt_presenter = GanttPresenter()
 
         # Initialize TaskDataLoader for data fetching

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_table_helpers.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_table_helpers.py
@@ -49,7 +49,7 @@ class TestRenderTable:
             render_table(self.cli_context, mock_output)
 
             # Verify
-            mock_presenter_cls.assert_called_once_with(self.api_client)
+            mock_presenter_cls.assert_called_once_with()
             mock_presenter.present.assert_called_once_with(mock_output)
             mock_renderer_cls.assert_called_once_with(self.console_writer)
             mock_renderer.render.assert_called_once_with(mock_view_models, fields=None)

--- a/packages/taskdog-ui/tests/presentation/presenters/test_table_presenter.py
+++ b/packages/taskdog-ui/tests/presentation/presenters/test_table_presenter.py
@@ -3,11 +3,11 @@
 import os
 import tempfile
 from datetime import datetime, timedelta
-from unittest.mock import Mock
 
 import pytest
 
 from taskdog.presenters.table_presenter import TablePresenter
+from taskdog_core.application.dto.task_dto import TaskRowDto
 from taskdog_core.application.dto.task_list_output import TaskListOutput
 from taskdog_core.domain.entities.task import TaskStatus
 from taskdog_core.infrastructure.persistence.database.sqlite_task_repository import (
@@ -27,9 +27,7 @@ class TestTablePresenter:
         self.test_file.close()
         self.test_filename = self.test_file.name
         self.repository = SqliteTaskRepository(f"sqlite:///{self.test_filename}")
-        self.notes_checker = Mock()
-        self.notes_checker.has_task_notes = Mock(return_value=False)
-        self.presenter = TablePresenter(self.notes_checker)
+        self.presenter = TablePresenter()
         yield
         # Teardown
         if hasattr(self, "repository") and hasattr(self.repository, "close"):
@@ -37,18 +35,21 @@ class TestTablePresenter:
         if os.path.exists(self.test_filename):
             os.unlink(self.test_filename)
 
+    def _to_dto(self, task) -> TaskRowDto:
+        """Convert Task entity to TaskRowDto."""
+        return TaskRowDto.from_entity(task)
+
     def test_present_converts_dto_to_view_models(self):
         """Test present converts TaskListOutput to list of TaskRowViewModels."""
         # Create test tasks
-        task1 = self.repository.create(
-            name="Task 1", priority=1, status=TaskStatus.PENDING
+        task1 = self._to_dto(
+            self.repository.create(name="Task 1", priority=1, status=TaskStatus.PENDING)
         )
-        task2 = self.repository.create(
-            name="Task 2", priority=2, status=TaskStatus.IN_PROGRESS
+        task2 = self._to_dto(
+            self.repository.create(
+                name="Task 2", priority=2, status=TaskStatus.IN_PROGRESS
+            )
         )
-
-        # Mock notes checker
-        self.notes_checker.has_task_notes.return_value = False
 
         # Create DTO
         output = TaskListOutput(tasks=[task1, task2], total_count=2, filtered_count=2)
@@ -65,24 +66,38 @@ class TestTablePresenter:
         assert view_models[1].name == "Task 2"
         assert view_models[1].status == TaskStatus.IN_PROGRESS
 
-    def test_present_includes_notes_flag(self):
-        """Test present includes has_notes flag from notes repository."""
-        # Create test task
-        task = self.repository.create(name="Task with notes", priority=1)
+    def test_present_includes_has_notes_from_dto(self):
+        """Test present uses has_notes from TaskRowDto."""
+        now = datetime.now()
+        task_with_notes = TaskRowDto(
+            id=1,
+            name="Task with notes",
+            priority=1,
+            status=TaskStatus.PENDING,
+            planned_start=None,
+            planned_end=None,
+            deadline=None,
+            actual_start=None,
+            actual_end=None,
+            estimated_duration=None,
+            actual_duration_hours=None,
+            is_fixed=False,
+            depends_on=[],
+            tags=[],
+            is_archived=False,
+            is_finished=False,
+            created_at=now,
+            updated_at=now,
+            has_notes=True,
+        )
 
-        # Mock notes repository to return True for this task
-        self.notes_checker.has_task_notes.return_value = True
-
-        # Create DTO
-        output = TaskListOutput(tasks=[task], total_count=1, filtered_count=1)
-
-        # Convert to view models
+        output = TaskListOutput(
+            tasks=[task_with_notes], total_count=1, filtered_count=1
+        )
         view_models = self.presenter.present(output)
 
-        # Verify has_notes is True
         assert len(view_models) == 1
         assert view_models[0].has_notes is True
-        self.notes_checker.has_task_notes.assert_called_once_with(task.id)
 
     def test_present_copies_task_fields(self):
         """Test present copies all relevant task fields to view model."""
@@ -92,21 +107,20 @@ class TestTablePresenter:
         planned_start = now + timedelta(days=1)
         planned_end = now + timedelta(days=3)
 
-        task = self.repository.create(
-            name="Full task",
-            priority=5,
-            status=TaskStatus.PENDING,
-            is_fixed=True,
-            estimated_duration=8.0,
-            deadline=deadline,
-            planned_start=planned_start,
-            planned_end=planned_end,
-            depends_on=[1, 2, 3],
-            tags=["urgent", "backend"],
+        task = self._to_dto(
+            self.repository.create(
+                name="Full task",
+                priority=5,
+                status=TaskStatus.PENDING,
+                is_fixed=True,
+                estimated_duration=8.0,
+                deadline=deadline,
+                planned_start=planned_start,
+                planned_end=planned_end,
+                depends_on=[1, 2, 3],
+                tags=["urgent", "backend"],
+            )
         )
-
-        # Mock notes checker
-        self.notes_checker.has_task_notes.return_value = False
 
         # Create DTO
         output = TaskListOutput(tasks=[task], total_count=1, filtered_count=1)
@@ -142,12 +156,11 @@ class TestTablePresenter:
     def test_present_sets_is_finished_for_completed_task(self):
         """Test present sets is_finished=True for completed tasks."""
         # Create completed task
-        task = self.repository.create(
-            name="Completed task", priority=1, status=TaskStatus.COMPLETED
+        task = self._to_dto(
+            self.repository.create(
+                name="Completed task", priority=1, status=TaskStatus.COMPLETED
+            )
         )
-
-        # Mock notes checker
-        self.notes_checker.has_task_notes.return_value = False
 
         # Create DTO
         output = TaskListOutput(tasks=[task], total_count=1, filtered_count=1)
@@ -161,12 +174,11 @@ class TestTablePresenter:
     def test_present_sets_is_finished_for_canceled_task(self):
         """Test present sets is_finished=True for canceled tasks."""
         # Create canceled task
-        task = self.repository.create(
-            name="Canceled task", priority=1, status=TaskStatus.CANCELED
+        task = self._to_dto(
+            self.repository.create(
+                name="Canceled task", priority=1, status=TaskStatus.CANCELED
+            )
         )
-
-        # Mock notes checker
-        self.notes_checker.has_task_notes.return_value = False
 
         # Create DTO
         output = TaskListOutput(tasks=[task], total_count=1, filtered_count=1)
@@ -180,15 +192,14 @@ class TestTablePresenter:
     def test_present_copies_dependencies_and_tags(self):
         """Test present creates copies of depends_on and tags lists."""
         # Create task with dependencies and tags
-        task = self.repository.create(
-            name="Task",
-            priority=1,
-            depends_on=[1, 2],
-            tags=["tag1", "tag2"],
+        task = self._to_dto(
+            self.repository.create(
+                name="Task",
+                priority=1,
+                depends_on=[1, 2],
+                tags=["tag1", "tag2"],
+            )
         )
-
-        # Mock notes checker
-        self.notes_checker.has_task_notes.return_value = False
 
         # Create DTO
         output = TaskListOutput(tasks=[task], total_count=1, filtered_count=1)


### PR DESCRIPTION
## Summary
- Added `has_notes` field directly to `TaskRowDto`, allowing the API response value to flow through the DTO instead of being cached separately
- Removed `_has_notes_cache` shared between `QueryClient` and `NotesClient`, the `NotesChecker` protocol, and the `has_task_notes()` method from `NotesClient` / `TaskdogApiClient`
- Updated `TablePresenter` to read `has_notes` from the DTO directly, removing its dependency on an external notes checker

## Motivation
The server already includes `has_notes` in task list API responses via batch query, but `TaskRowDto` lacked this field. This forced the client side into an unnecessarily complex workaround:

1. `convert_to_task_list_output()` stashed `has_notes` into a separate `_has_notes_cache`
2. `TaskdogApiClient` shared this cache between `QueryClient` and `NotesClient`
3. `TablePresenter` looked up each task's notes status via a `NotesChecker` protocol

The root cause was simply a missing field on `TaskRowDto`.

## Test plan
- [x] `make test` — all tests pass (core: 1052, client: 225, server: 107, ui: 894)
- [x] `make lint` — no issues
- [x] Pre-commit hooks pass (ruff, mypy, format, unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)