### PR TITLE
refactor: simplify converters and add has_notes to TaskDetailResponse

### DIFF
--- a/packages/taskdog-client/src/taskdog_client/converters/statistics_converters.py
+++ b/packages/taskdog-client/src/taskdog_client/converters/statistics_converters.py
@@ -63,15 +63,8 @@ def _parse_task_summary_list(data: list[dict[str, Any]] | None) -> list[TaskSumm
     """
     if not data:
         return []
-    return [
-        TaskSummaryDto(
-            id=d["id"],
-            name=d["name"],
-            estimated_duration=d.get("estimated_duration"),
-            actual_duration_hours=d.get("actual_duration_hours"),
-        )
-        for d in data
-    ]
+    # Each element d is a dict (never None), so _parse_task_summary always returns TaskSummaryDto
+    return [_parse_task_summary(d) for d in data]  # type: ignore[misc]
 
 
 def _parse_time_statistics(time_data: dict[str, Any]) -> TimeStatistics:

--- a/packages/taskdog-client/src/taskdog_client/converters/task_converters.py
+++ b/packages/taskdog-client/src/taskdog_client/converters/task_converters.py
@@ -198,6 +198,6 @@ def convert_to_get_task_detail_output(data: dict[str, Any]) -> TaskDetailOutput:
 
     # Extract notes
     notes_content = data.get("notes")
-    has_notes = notes_content is not None and notes_content != ""
+    has_notes = data.get("has_notes", False)
 
     return TaskDetailOutput(task=task, notes_content=notes_content, has_notes=has_notes)

--- a/packages/taskdog-client/tests/converters/test_task_converters.py
+++ b/packages/taskdog-client/tests/converters/test_task_converters.py
@@ -492,15 +492,15 @@ class TestConvertToGetTaskDetailOutput:
     """Test cases for convert_to_get_task_detail_output."""
 
     @pytest.mark.parametrize(
-        "notes_value,expected_has_notes",
+        "notes_value,has_notes_value,expected_has_notes",
         [
-            ("# Important\n\nSome details here.", True),
-            (None, False),
-            ("", False),
+            ("# Important\n\nSome details here.", True, True),
+            (None, False, False),
+            ("", False, False),
         ],
         ids=["with_notes", "none_notes", "empty_notes"],
     )
-    def test_notes_handling(self, notes_value, expected_has_notes):
+    def test_notes_handling(self, notes_value, has_notes_value, expected_has_notes):
         """Test conversion with different notes values."""
         data = {
             "id": 1,
@@ -526,6 +526,7 @@ class TestConvertToGetTaskDetailOutput:
             "can_be_modified": True,
             "is_schedulable": True,
             "notes": notes_value,
+            "has_notes": has_notes_value,
         }
 
         result = convert_to_get_task_detail_output(data)

--- a/packages/taskdog-client/tests/test_converters.py
+++ b/packages/taskdog-client/tests/test_converters.py
@@ -234,6 +234,7 @@ class TestConverters:
             "can_be_modified": True,
             "is_schedulable": True,
             "notes": "# Important notes\n\nSome details here.",
+            "has_notes": True,
         }
 
         result = convert_to_get_task_detail_output(data)
@@ -268,6 +269,7 @@ class TestConverters:
             "can_be_modified": True,
             "is_schedulable": True,
             "notes": None,
+            "has_notes": False,
         }
 
         result = convert_to_get_task_detail_output(data)

--- a/packages/taskdog-server/src/taskdog_server/api/models/responses.py
+++ b/packages/taskdog-server/src/taskdog_server/api/models/responses.py
@@ -168,6 +168,7 @@ class TaskDetailResponse(BaseModel):
     is_finished: bool = False
     can_be_modified: bool = False
     is_schedulable: bool = False
+    has_notes: bool = False
     notes: str | None = None
     created_at: datetime
     updated_at: datetime
@@ -206,6 +207,7 @@ class TaskDetailResponse(BaseModel):
             is_finished=dto.task.is_finished,
             can_be_modified=dto.task.can_be_modified,
             is_schedulable=dto.task.is_schedulable,
+            has_notes=dto.has_notes,
             notes=dto.notes_content,
             created_at=dto.task.created_at,
             updated_at=dto.task.updated_at,

--- a/packages/taskdog-server/tests/api/models/test_responses.py
+++ b/packages/taskdog-server/tests/api/models/test_responses.py
@@ -250,6 +250,7 @@ class TestTaskDetailResponse:
         assert response.id == 1
         assert response.daily_allocations == {"2024-01-15": 4.0, "2024-01-16": 4.0}
         assert response.notes == "# Test Notes"
+        assert response.has_notes is False
         assert response.is_schedulable is True
 
     def test_from_dto_converts_task_detail_output(self):
@@ -297,6 +298,7 @@ class TestTaskDetailResponse:
         assert response.tags == task_dto.tags
         assert response.is_active == task_dto.is_active
         assert response.is_schedulable == task_dto.is_schedulable
+        assert response.has_notes is True
         assert response.notes == "# Notes Content"
         # Check date dict conversion (date -> ISO string)
         assert response.daily_allocations == {"2024-01-15": 4.0, "2024-01-16": 4.0}

--- a/packages/taskdog-server/tests/api/test_converters.py
+++ b/packages/taskdog-server/tests/api/test_converters.py
@@ -306,6 +306,7 @@ class TestConvertToTaskDetailResponse:
         assert response.name == "Test Task"
         assert response.priority == 1
         assert response.status == TaskStatus.PENDING
+        assert response.has_notes is False
         assert response.notes is None
         assert response.daily_allocations == {}
 
@@ -353,6 +354,7 @@ class TestConvertToTaskDetailResponse:
         assert response.depends_on == [2, 3]
         assert response.tags == ["backend", "api"]
         assert response.is_fixed is True
+        assert response.has_notes is True
         assert response.notes == "# Task Notes\n\nSome notes."
         # Check date conversion to ISO strings
         assert "2025-01-01" in response.daily_allocations
@@ -447,4 +449,5 @@ class TestConvertToTaskDetailResponse:
         response = convert_to_task_detail_response(dto)
 
         # Assert
+        assert response.has_notes is False
         assert response.notes == ""


### PR DESCRIPTION
## Summary
- Deduplicate `_parse_task_summary_list` by delegating to the existing `_parse_task_summary` function, eliminating duplicated `TaskSummaryDto` construction logic
- Add `has_notes: bool` field to `TaskDetailResponse` so the client reads it directly from the server response instead of recalculating from `notes_content`

## Test plan
- [x] `make test` — all tests pass across all packages
- [x] `make typecheck` — mypy passes with no errors
- [x] `make lint` — ruff passes with no warnings
- [x] Pre-commit hooks pass (ruff, mypy, unit tests, conventional commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)