### PR TITLE
fix: switch Dependabot from pip to uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
-  # Monitor workspace root Python dependencies
-  - package-ecosystem: "pip"
+  # Monitor Python dependencies (uv workspace)
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -22,39 +22,6 @@ updates:
     labels:
       - "dependencies"
       - "python"
-
-  # Monitor taskdog-core package
-  - package-ecosystem: "pip"
-    directory: "/packages/taskdog-core"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "taskdog-core"
-
-  # Monitor taskdog-server package
-  - package-ecosystem: "pip"
-    directory: "/packages/taskdog-server"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "taskdog-server"
-
-  # Monitor taskdog-ui package
-  - package-ecosystem: "pip"
-    directory: "/packages/taskdog-ui"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "taskdog-ui"
 
   # Monitor GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
- Dependabot の `package-ecosystem` を `pip` → `uv` に変更
- セキュリティアラート（例: cryptography CVE-2026-26007）の修正PRが作成できなかった問題を解決
- UV ワークスペースではルートだけで全パッケージをカバーするため、パッケージ個別エントリを削除

## Background
`pip` エコシステムでは `uv.lock` の脆弱性を検出できても、ロックファイルを更新するPRを作成できなかった。
`uv` エコシステムに切り替えることで、Dependabot が `uv lock` を使って正しくPRを生成可能になる。

## Test plan
- [ ] Dependabot がセキュリティアラート（cryptography #5）の修正PRを作成できることを確認
- [ ] 週次の定期更新PRが正常に作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)