### PR TITLE
refactor: unify form validation helpers in dialog base classes

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/algorithm_selection_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/algorithm_selection_dialog.py
@@ -176,42 +176,27 @@ class AlgorithmSelectionDialog(
             return
         selected_algo = str(algorithm_select.value)
 
-        # Validate max hours (required)
-        max_hours_str = max_hours_input.value.strip()
-        if not max_hours_str:
-            self._show_validation_error(
-                "Max hours per day is required", max_hours_input
-            )
+        # Validate required fields and input validity
+        if not self._validate_required(max_hours_input, "Max hours per day"):
             return
-
-        # Validate start date (required)
-        start_date_str = start_date_input.value.strip()
-        if not start_date_str:
-            self._show_validation_error("Start date is required", start_date_input)
+        if not self._validate_required(start_date_input, "Start date"):
             return
-
-        # Check if inputs are valid (Textual shows validation error automatically)
-        if not max_hours_input.is_valid:
-            max_hours_input.focus()
+        if not self._validate_input(max_hours_input):
             return
-
-        if not start_date_input.is_valid:
-            start_date_input.focus()
+        if not self._validate_input(start_date_input):
             return
 
         # Parse values
-        max_hours = float(max_hours_str)
-
-        start_date_validator = StartDateTextualValidator()
-        start_date = start_date_validator.parse(start_date_str)
-
-        # Get force override value
-        force_override = force_checkbox.value
-
-        # Get include_all_days value
-        include_all_days = include_all_days_checkbox.value
+        max_hours = float(max_hours_input.value.strip())
+        start_date = StartDateTextualValidator().parse(start_date_input.value.strip())
 
         # Submit algorithm, max_hours, start_date, force_override, and include_all_days
         self.dismiss(
-            (selected_algo, max_hours, start_date, force_override, include_all_days)
+            (
+                selected_algo,
+                max_hours,
+                start_date,
+                force_checkbox.value,
+                include_all_days_checkbox.value,
+            )
         )

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/base_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/base_dialog.py
@@ -109,6 +109,39 @@ class BaseModalDialog(ModalScreen[T]):
             return True  # Empty is valid when valid_empty=True
         return bool(input_widget.is_valid)
 
+    def _validate_input(self, input_widget: Input) -> bool:
+        """Validate an Input widget, focusing it if invalid.
+
+        Combines _is_input_valid check with focus-on-error behavior.
+
+        Args:
+            input_widget: Input widget to validate
+
+        Returns:
+            True if valid, False if invalid (widget is focused)
+        """
+        if not self._is_input_valid(input_widget):
+            input_widget.focus()
+            return False
+        return True
+
+    def _validate_required(self, input_widget: Input, field_name: str) -> bool:
+        """Validate that a required field has a non-empty value.
+
+        Shows a validation error and focuses the widget if empty.
+
+        Args:
+            input_widget: Input widget to check
+            field_name: Human-readable field name for the error message
+
+        Returns:
+            True if non-empty, False if empty (error shown, widget focused)
+        """
+        if not input_widget.value.strip():
+            self._show_validation_error(f"{field_name} is required", input_widget)
+            return False
+        return True
+
     @abstractmethod
     def compose(self) -> ComposeResult:
         """Compose the dialog layout.

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/fix_actual_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/fix_actual_dialog.py
@@ -200,17 +200,12 @@ class FixActualDialog(FormDialogBase[FixActualFormData | None]):
             actual_end_input,
             actual_duration_input,
         ]:
-            if not self._is_input_valid(input_widget):
-                input_widget.focus()
+            if not self._validate_input(input_widget):
                 return
 
         # Parse datetime fields using validators registered on Input widgets
-        actual_start = self._get_validator(actual_start_input, DateTimeValidator).parse(
-            actual_start_str
-        )
-        actual_end = self._get_validator(actual_end_input, DateTimeValidator).parse(
-            actual_end_str
-        )
+        actual_start = self._parse_datetime_field(actual_start_input)
+        actual_end = self._parse_datetime_field(actual_end_input)
 
         # Validate end is not before start (when both are provided)
         if actual_start and actual_end:

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/form_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/form_dialog.py
@@ -4,6 +4,7 @@ from abc import abstractmethod
 from typing import ClassVar, TypeVar
 
 from textual.binding import Binding
+from textual.widgets import Input
 
 from taskdog.tui.dialogs.base_dialog import BaseModalDialog
 
@@ -60,6 +61,21 @@ class FormDialogBase(BaseModalDialog[T]):
     def action_focus_previous(self) -> None:
         """Move focus to the previous field (Ctrl+K)."""
         self.focus_previous()
+
+    def _parse_datetime_field(self, input_widget: Input) -> str | None:
+        """Parse a datetime value from an Input widget using its DateTimeValidator.
+
+        Args:
+            input_widget: Input widget with a DateTimeValidator attached
+
+        Returns:
+            Parsed datetime string (YYYY-MM-DD HH:MM:SS) or None if empty
+        """
+        from taskdog.tui.forms.validators import DateTimeValidator
+
+        return self._get_validator(input_widget, DateTimeValidator).parse(
+            input_widget.value
+        )
 
     @abstractmethod
     def _submit_form(self) -> None:


### PR DESCRIPTION
## Summary

- Add `_validate_input()` and `_validate_required()` helpers to `BaseModalDialog` to eliminate the repeated validate-focus-return pattern
- Add `_parse_datetime_field()` helper to `FormDialogBase` to consolidate datetime parsing via `DateTimeValidator`
- Simplify `_submit_form()` in `TaskFormDialog` (7 validation blocks → 1 loop), `FixActualDialog` (loop body simplified), and `AlgorithmSelectionDialog` (4 validation blocks → 4 one-liners)

## Test plan

- [x] All 884 UI tests pass (`make test-ui`)
- [x] Lint passes (`make lint`)
- [x] Type check passes (`make typecheck`)
- [ ] Manual TUI test: add/edit tasks, fix actual times, run optimization dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)