### PR TITLE
refactor: add AuditLogRepository ABC and inject ITimeProvider into AuditLogController

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/controllers/audit_log_controller.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/audit_log_controller.py
@@ -5,7 +5,6 @@ following Clean Architecture by ensuring all access to the audit log
 repository goes through the application layer.
 """
 
-from datetime import datetime
 from typing import Any
 
 from taskdog_core.application.dto.audit_log_dto import (
@@ -14,10 +13,9 @@ from taskdog_core.application.dto.audit_log_dto import (
     AuditLogOutput,
     AuditQuery,
 )
+from taskdog_core.domain.repositories.audit_log_repository import AuditLogRepository
 from taskdog_core.domain.services.logger import Logger
-from taskdog_core.infrastructure.persistence.database.sqlite_audit_log_repository import (
-    SqliteAuditLogRepository,
-)
+from taskdog_core.domain.services.time_provider import ITimeProvider
 
 
 class AuditLogController:
@@ -35,17 +33,20 @@ class AuditLogController:
 
     def __init__(
         self,
-        repository: SqliteAuditLogRepository,
+        repository: AuditLogRepository,
         logger: Logger,
+        time_provider: ITimeProvider,
     ) -> None:
         """Initialize the audit log controller.
 
         Args:
             repository: Audit log repository for persistence
             logger: Logger for tracking operations
+            time_provider: Time provider for timestamps
         """
         self._repository = repository
         self._logger = logger
+        self._time_provider = time_provider
 
     def save(self, event: AuditEvent) -> None:
         """Save an audit event to the database.
@@ -89,7 +90,7 @@ class AuditLogController:
             error_message: Error message if the operation failed
         """
         event = AuditEvent(
-            timestamp=datetime.now(),
+            timestamp=self._time_provider.now(),
             operation=operation,
             resource_type=resource_type,
             success=success,

--- a/packages/taskdog-core/src/taskdog_core/domain/repositories/__init__.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/repositories/__init__.py
@@ -1,6 +1,7 @@
 """Domain layer repository interfaces."""
 
+from taskdog_core.domain.repositories.audit_log_repository import AuditLogRepository
 from taskdog_core.domain.repositories.notes_repository import NotesRepository
 from taskdog_core.domain.repositories.task_repository import TaskRepository
 
-__all__ = ["NotesRepository", "TaskRepository"]
+__all__ = ["AuditLogRepository", "NotesRepository", "TaskRepository"]

--- a/packages/taskdog-core/src/taskdog_core/domain/repositories/audit_log_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/repositories/audit_log_repository.py
@@ -1,0 +1,68 @@
+"""Abstract interface for audit log repository.
+
+This interface defines the contract for managing audit logs,
+abstracting away implementation details like database operations.
+"""
+
+from abc import ABC, abstractmethod
+
+from taskdog_core.application.dto.audit_log_dto import (
+    AuditEvent,
+    AuditLogListOutput,
+    AuditLogOutput,
+    AuditQuery,
+)
+
+
+class AuditLogRepository(ABC):
+    """Abstract interface for audit log persistence.
+
+    This interface provides implementation-agnostic methods for audit log management.
+    Implementation-specific methods (like clear/close for database cleanup)
+    should be defined in concrete implementations.
+    """
+
+    @abstractmethod
+    def save(self, event: AuditEvent) -> None:
+        """Persist an audit event.
+
+        Args:
+            event: The audit event to save
+        """
+        pass
+
+    @abstractmethod
+    def get_logs(self, query: AuditQuery) -> AuditLogListOutput:
+        """Query audit logs with filtering and pagination.
+
+        Args:
+            query: Query parameters for filtering
+
+        Returns:
+            AuditLogListOutput containing logs and pagination info
+        """
+        pass
+
+    @abstractmethod
+    def get_by_id(self, log_id: int) -> AuditLogOutput | None:
+        """Get a single audit log by ID.
+
+        Args:
+            log_id: The ID of the audit log to retrieve
+
+        Returns:
+            The audit log if found, None otherwise
+        """
+        pass
+
+    @abstractmethod
+    def count_logs(self, query: AuditQuery) -> int:
+        """Count audit logs matching the query.
+
+        Args:
+            query: Query parameters for filtering
+
+        Returns:
+            Number of logs matching the query
+        """
+        pass

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_audit_log_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_audit_log_repository.py
@@ -18,6 +18,7 @@ from taskdog_core.application.dto.audit_log_dto import (
     AuditLogOutput,
     AuditQuery,
 )
+from taskdog_core.domain.repositories.audit_log_repository import AuditLogRepository
 from taskdog_core.infrastructure.persistence.database.engine_factory import (
     create_session_factory,
     create_sqlite_engine,
@@ -27,7 +28,7 @@ from taskdog_core.infrastructure.persistence.database.models.audit_log_model imp
 )
 
 
-class SqliteAuditLogRepository:
+class SqliteAuditLogRepository(AuditLogRepository):
     """SQLite implementation of audit log repository using SQLAlchemy ORM.
 
     This repository:

--- a/packages/taskdog-server/src/taskdog_server/api/dependencies.py
+++ b/packages/taskdog-server/src/taskdog_server/api/dependencies.py
@@ -133,7 +133,9 @@ def initialize_api_context(
     crud_controller = TaskCrudController(
         repository, notes_repository, config, crud_logger, holiday_checker
     )
-    audit_log_controller = AuditLogController(audit_log_repository, audit_log_logger)
+    audit_log_controller = AuditLogController(
+        audit_log_repository, audit_log_logger, time_provider
+    )
 
     return ApiContext(
         repository=repository,

--- a/packages/taskdog-server/tests/conftest.py
+++ b/packages/taskdog-server/tests/conftest.py
@@ -229,7 +229,9 @@ def app(
     crud_controller = TaskCrudController(
         session_repository, session_notes_repository, mock_config, mock_logger
     )
-    audit_log_controller = AuditLogController(session_audit_log_repository, mock_logger)
+    audit_log_controller = AuditLogController(
+        session_audit_log_repository, mock_logger, SystemTimeProvider()
+    )
 
     # Create API context once
     api_context = ApiContext(


### PR DESCRIPTION
## Summary

- **AuditLogRepository ABC 追加**: `TaskRepository`/`NotesRepository` と同様のパターンで `AuditLogRepository` ABC を作成し、`AuditLogController` が具象クラス (`SqliteAuditLogRepository`) ではなく抽象インターフェースに依存するように修正。Clean Architecture の依存関係逆転を実現。
- **ITimeProvider 注入**: `AuditLogController.log_operation()` が `datetime.now()` を直接呼んでいたのを `ITimeProvider` 経由に変更。他の全コントローラーと統一され、タイムスタンプのテストが可能に。
- 純粋なリファクタリング（振る舞い変更なし）。既存テスト全件パス確認済み。

## Test plan

- [x] `make lint` — All checks passed
- [x] `make typecheck` — No issues found (400 source files)
- [x] `make test` — All tests passed (core + server + ui + mcp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)