### PR TITLE
feat: make Gantt workload thresholds configurable via cli.toml

### DIFF
--- a/examples/cli.toml
+++ b/examples/cli.toml
@@ -106,6 +106,32 @@ planned_end_time = "18:30"
 # template = "~/.config/taskdog/note_template.md"
 
 # =============================================================================
+# Gantt Chart Settings
+# =============================================================================
+#
+# Configure workload color thresholds for the Gantt chart's workload summary row.
+# The workload row shows daily total hours with color coding:
+#   - Green: at or below comfortable threshold
+#   - Yellow: above comfortable, at or below moderate threshold
+#   - Red: above moderate threshold
+
+[gantt]
+# Comfortable workload threshold in hours (default: 6.0)
+# Daily hours at or below this value are displayed in green.
+# Environment variable: TASKDOG_GANTT_WORKLOAD_COMFORTABLE_HOURS
+workload_comfortable_hours = 6.0
+
+# Moderate workload threshold in hours (default: 8.0)
+# Daily hours above comfortable but at or below this value are displayed in yellow.
+# Hours above this value are displayed in red.
+# Environment variable: TASKDOG_GANTT_WORKLOAD_MODERATE_HOURS
+workload_moderate_hours = 8.0
+
+# Examples:
+# - Part-time schedule: workload_comfortable_hours = 4.0, workload_moderate_hours = 6.0
+# - Longer workday: workload_comfortable_hours = 7.0, workload_moderate_hours = 10.0
+
+# =============================================================================
 # Environment Variables
 # =============================================================================
 #
@@ -120,6 +146,10 @@ planned_end_time = "18:30"
 # - TASKDOG_INPUT_DEADLINE_TIME: Default time for deadline input
 # - TASKDOG_INPUT_PLANNED_START_TIME: Default time for planned_start input
 # - TASKDOG_INPUT_PLANNED_END_TIME: Default time for planned_end input
+#
+# Gantt Chart:
+# - TASKDOG_GANTT_WORKLOAD_COMFORTABLE_HOURS: Comfortable workload threshold
+# - TASKDOG_GANTT_WORKLOAD_MODERATE_HOURS: Moderate workload threshold
 #
 # Examples:
 #

--- a/packages/taskdog-ui/src/taskdog/cli/commands/gantt.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/gantt.py
@@ -125,5 +125,10 @@ def gantt_command(
 
     # Render using Presentation layer (display logic)
     console_writer = ctx_obj.console_writer
-    renderer = RichGanttRenderer(console_writer)
+    gantt_config = ctx_obj.config.gantt
+    renderer = RichGanttRenderer(
+        console_writer,
+        comfortable_hours=gantt_config.workload_comfortable_hours,
+        moderate_hours=gantt_config.workload_moderate_hours,
+    )
     renderer.render(gantt_view_model)

--- a/packages/taskdog-ui/src/taskdog/renderers/gantt_cell_formatter.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/gantt_cell_formatter.py
@@ -162,7 +162,11 @@ class GanttCellFormatter:
 
     @staticmethod
     def build_workload_timeline(
-        daily_workload: dict[date, float], start_date: date, end_date: date
+        daily_workload: dict[date, float],
+        start_date: date,
+        end_date: date,
+        comfortable_hours: float = WORKLOAD_COMFORTABLE_HOURS,
+        moderate_hours: float = WORKLOAD_MODERATE_HOURS,
     ) -> Text:
         """Build workload summary timeline showing daily total hours.
 
@@ -170,6 +174,8 @@ class GanttCellFormatter:
             daily_workload: Pre-computed daily workload totals
             start_date: Start date of the chart
             end_date: End date of the chart
+            comfortable_hours: Threshold for green zone (at or below = green)
+            moderate_hours: Threshold for yellow zone (above comfortable, at or below = yellow)
 
         Returns:
             Rich Text object with workload summary
@@ -190,9 +196,9 @@ class GanttCellFormatter:
             # Color based on workload level (use original hours for threshold)
             if hours == 0:
                 style = "dim"
-            elif hours <= WORKLOAD_COMFORTABLE_HOURS:
+            elif hours <= comfortable_hours:
                 style = "bold green"
-            elif hours <= WORKLOAD_MODERATE_HOURS:
+            elif hours <= moderate_hours:
                 style = "bold yellow"
             else:
                 style = "bold red"

--- a/packages/taskdog-ui/src/taskdog/renderers/rich_gantt_renderer.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/rich_gantt_renderer.py
@@ -22,6 +22,10 @@ from taskdog.constants.table_styles import (
 from taskdog.renderers.gantt_cell_formatter import GanttCellFormatter
 from taskdog.renderers.rich_renderer_base import RichRendererBase
 from taskdog.view_models.gantt_view_model import GanttViewModel, TaskGanttRowViewModel
+from taskdog_core.shared.constants import (
+    WORKLOAD_COMFORTABLE_HOURS,
+    WORKLOAD_MODERATE_HOURS,
+)
 
 
 class RichGanttRenderer(RichRendererBase):
@@ -40,13 +44,19 @@ class RichGanttRenderer(RichRendererBase):
     def __init__(
         self,
         console_writer: ConsoleWriter,
+        comfortable_hours: float = WORKLOAD_COMFORTABLE_HOURS,
+        moderate_hours: float = WORKLOAD_MODERATE_HOURS,
     ):
         """Initialize the renderer.
 
         Args:
             console_writer: Console writer for output
+            comfortable_hours: Workload threshold for green zone
+            moderate_hours: Workload threshold for yellow zone
         """
         self.console_writer = console_writer
+        self._comfortable_hours = comfortable_hours
+        self._moderate_hours = moderate_hours
 
     def build_table(self, gantt_view_model: GanttViewModel) -> Table | None:
         """Build and return a Gantt chart Table object from GanttViewModel.
@@ -330,5 +340,9 @@ class RichGanttRenderer(RichRendererBase):
             Rich Text object with workload summary
         """
         return GanttCellFormatter.build_workload_timeline(
-            daily_workload, start_date, end_date
+            daily_workload,
+            start_date,
+            end_date,
+            comfortable_hours=self._comfortable_hours,
+            moderate_hours=self._moderate_hours,
         )

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_data_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_data_table.py
@@ -15,6 +15,10 @@ from textual.widgets import DataTable
 from taskdog.constants.table_dimensions import TASK_NAME_COLUMN_WIDTH
 from taskdog.renderers.gantt_cell_formatter import GanttCellFormatter
 from taskdog.view_models.gantt_view_model import GanttViewModel, TaskGanttRowViewModel
+from taskdog_core.shared.constants import (
+    WORKLOAD_COMFORTABLE_HOURS,
+    WORKLOAD_MODERATE_HOURS,
+)
 
 # Constants
 GANTT_HEADER_ROW_COUNT = 3  # Number of header rows (Month, Week, Date)
@@ -81,7 +85,11 @@ class GanttDataTable(DataTable):  # type: ignore[type-arg]
         self.add_column(Text("Timeline", justify="center"))
 
     def load_gantt(
-        self, gantt_view_model: GanttViewModel, keep_scroll_position: bool = False
+        self,
+        gantt_view_model: GanttViewModel,
+        keep_scroll_position: bool = False,
+        comfortable_hours: float = WORKLOAD_COMFORTABLE_HOURS,
+        moderate_hours: float = WORKLOAD_MODERATE_HOURS,
     ) -> None:
         """Load Gantt data into the table.
 
@@ -89,6 +97,8 @@ class GanttDataTable(DataTable):  # type: ignore[type-arg]
             gantt_view_model: Presentation-ready Gantt data
             keep_scroll_position: Whether to preserve scroll position during refresh.
                                  Set to True for periodic updates to avoid scroll stuttering.
+            comfortable_hours: Workload threshold for green zone
+            moderate_hours: Workload threshold for yellow zone
         """
         # Save scroll position before refresh (both vertical and horizontal)
         # Note: scroll_y/scroll_x types from DataTable base class (type: ignore needed)
@@ -141,6 +151,8 @@ class GanttDataTable(DataTable):  # type: ignore[type-arg]
             gantt_view_model.start_date,
             gantt_view_model.end_date,
             gantt_view_model.total_estimated_duration,
+            comfortable_hours=comfortable_hours,
+            moderate_hours=moderate_hours,
         )
 
         # Restore scroll position to prevent stuttering
@@ -289,6 +301,8 @@ class GanttDataTable(DataTable):  # type: ignore[type-arg]
         start_date: date,
         end_date: date,
         total_estimated_duration: float = 0.0,
+        comfortable_hours: float = WORKLOAD_COMFORTABLE_HOURS,
+        moderate_hours: float = WORKLOAD_MODERATE_HOURS,
     ) -> None:
         """Add workload summary row.
 
@@ -297,10 +311,16 @@ class GanttDataTable(DataTable):  # type: ignore[type-arg]
             start_date: Start date of the chart
             end_date: End date of the chart
             total_estimated_duration: Sum of all estimated durations
+            comfortable_hours: Workload threshold for green zone
+            moderate_hours: Workload threshold for yellow zone
         """
         # Build workload timeline using the formatter
         workload_timeline = GanttCellFormatter.build_workload_timeline(
-            daily_workload, start_date, end_date
+            daily_workload,
+            start_date,
+            end_date,
+            comfortable_hours=comfortable_hours,
+            moderate_hours=moderate_hours,
         )
 
         # Format total estimated duration

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
@@ -221,8 +221,12 @@ class GanttWidget(Vertical, ViNavigationMixin, TUIWidget):
         try:
             gantt_view_model = self._get_gantt_from_state()
             if gantt_view_model and self._gantt_table:
+                gantt_config = self.app._cli_config.gantt  # type: ignore[attr-defined]
                 self._gantt_table.load_gantt(
-                    gantt_view_model, keep_scroll_position=self._keep_scroll_position
+                    gantt_view_model,
+                    keep_scroll_position=self._keep_scroll_position,
+                    comfortable_hours=gantt_config.workload_comfortable_hours,
+                    moderate_hours=gantt_config.workload_moderate_hours,
                 )
                 self._update_title()
                 self._update_legend()


### PR DESCRIPTION
## Summary

- Add `GanttConfig` dataclass with `workload_comfortable_hours` and `workload_moderate_hours` fields to `CliConfig`
- Add `[gantt]` section to `cli.toml` for configuring workload color thresholds (green/yellow/red zones) in the Gantt chart's workload summary row
- Support environment variable overrides: `TASKDOG_GANTT_WORKLOAD_COMFORTABLE_HOURS` / `TASKDOG_GANTT_WORKLOAD_MODERATE_HOURS`
- Propagate thresholds through both CLI (`RichGanttRenderer`) and TUI (`GanttDataTable` / `GanttWidget`) paths

## Motivation

The Gantt chart workload summary row uses hardcoded thresholds (`6.0h` = green, `8.0h` = yellow, `>8.0h` = red) which don't fit all working styles. For example, a part-time worker might want `4.0h` / `6.0h`, while someone with longer workdays might prefer `7.0h` / `10.0h`.

## Configuration Example

```toml
[gantt]
workload_comfortable_hours = 4.0  # green zone (default: 6.0)
workload_moderate_hours = 6.0     # yellow zone (default: 8.0)
```

## Changed Files

| File | Change |
|------|--------|
| `cli_config_manager.py` | Add `GanttConfig` dataclass, extend `CliConfig`, parse `[gantt]` section |
| `gantt_cell_formatter.py` | Add `comfortable_hours` / `moderate_hours` params to `build_workload_timeline()` |
| `rich_gantt_renderer.py` | Accept and pass thresholds to formatter |
| `gantt.py` (CLI command) | Read config and pass to renderer |
| `gantt_data_table.py` | Accept and pass thresholds in `load_gantt()` / `_add_workload_row()` |
| `gantt_widget.py` | Read config from `app._cli_config.gantt` and pass to data table |
| `examples/cli.toml` | Add documented `[gantt]` section |
| `test_cli_config_manager.py` | 5 new tests (defaults, custom, TOML parse, env override, partial) |
| `test_gantt_cell_formatter.py` | 2 new tests (custom thresholds, default thresholds) |

## Test plan

- [x] `make test-ui` — 898 tests pass
- [x] `make lint` — passes
- [x] `make typecheck` (taskdog-ui) — passes
- [ ] Manual: set custom thresholds in `cli.toml`, verify color changes in CLI `gantt` command
- [ ] Manual: verify TUI Gantt chart also reflects custom thresholds

🤖 Generated with [Claude Code](https://claude.com/claude-code)