### PR TITLE
refactor(core): replace broad except Exception with SQLAlchemyError

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_notes_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_notes_repository.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from sqlalchemy import delete, select
 from sqlalchemy.engine import Engine
+from sqlalchemy.exc import SQLAlchemyError
 
 from taskdog_core.domain.repositories.notes_repository import NotesRepository
 from taskdog_core.domain.services.time_provider import ITimeProvider
@@ -232,7 +233,7 @@ class SqliteNotesRepository(SqliteBaseRepository, NotesRepository):
                     session.add(note)
                     session.commit()
                 migrated += 1
-            except Exception as e:
+            except SQLAlchemyError as e:
                 errors += 1
                 error_messages.append(f"Failed to insert note for task {task_id}: {e}")
 

--- a/uv.lock
+++ b/uv.lock
@@ -1171,7 +1171,7 @@ wheels = [
 
 [[package]]
 name = "taskdog-client"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-client" }
 dependencies = [
     { name = "httpx" },
@@ -1203,7 +1203,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-core"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-core" }
 dependencies = [
     { name = "alembic" },
@@ -1237,7 +1237,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-mcp"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -1269,7 +1269,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-server"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-server" }
 dependencies = [
     { name = "fastapi" },
@@ -1305,7 +1305,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-ui"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-ui" }
 dependencies = [
     { name = "click" },
@@ -1347,7 +1347,7 @@ provides-extras = ["dev", "server"]
 
 [[package]]
 name = "taskdog-workspace"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Replace `except Exception` with `except SQLAlchemyError` in `sqlite_notes_repository.py` migration method
- More specific exception handling ensures only database-related errors are caught during note migration

## Test plan
- [x] `make test-core` passes (1048 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)