### PR TITLE
refactor(server): replace broad except Exception with specific types

### DIFF
--- a/packages/taskdog-server/src/taskdog_server/__init__.py
+++ b/packages/taskdog-server/src/taskdog_server/__init__.py
@@ -3,9 +3,9 @@
 FastAPI-based REST API server for task management.
 """
 
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version("taskdog-server")
-except Exception:
+except PackageNotFoundError:
     __version__ = "unknown"

--- a/packages/taskdog-server/src/taskdog_server/api/routers/lifecycle.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/lifecycle.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from fastapi import APIRouter
 
+from taskdog_core.domain.exceptions.task_exceptions import TaskNotFoundException
 from taskdog_server.api.dependencies import (
     AuditLogControllerDep,
     AuthenticatedClientDep,
@@ -115,7 +116,7 @@ async def fix_actual_times(
     try:
         old_task_output = query_controller.get_task_by_id(task_id)
         old_task = old_task_output.task if old_task_output else None
-    except Exception:
+    except TaskNotFoundException:
         old_task = None
 
     # Determine values to pass (Ellipsis = keep current)

--- a/packages/taskdog-server/src/taskdog_server/api/routers/tasks.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/tasks.py
@@ -223,7 +223,7 @@ async def update_task(
     try:
         old_task_output = query_controller.get_task_by_id(task_id)
         old_task = old_task_output.task if old_task_output else None
-    except Exception:
+    except TaskNotFoundException:
         old_task = None
 
     result = controller.update_task(

--- a/packages/taskdog-server/src/taskdog_server/api/routers/websocket.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/websocket.py
@@ -4,6 +4,7 @@ This module provides WebSocket endpoints for clients to receive
 real-time notifications about task changes.
 """
 
+import logging
 import uuid
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
@@ -13,6 +14,8 @@ from taskdog_server.api.dependencies import (
     ServerConfigWsDep,
     validate_api_key_for_websocket,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -87,5 +90,6 @@ async def websocket_endpoint(
 
     except WebSocketDisconnect:
         manager.disconnect(client_id)
-    except Exception:
+    except Exception as e:
+        logger.warning(f"WebSocket connection error for client {client_id}: {e}")
         manager.disconnect(client_id)

--- a/packages/taskdog-server/src/taskdog_server/websocket/connection_manager.py
+++ b/packages/taskdog-server/src/taskdog_server/websocket/connection_manager.py
@@ -65,7 +65,7 @@ class ConnectionManager:
         for client_id, connection in self.active_connections.items():
             try:
                 await connection.send_json(message)
-            except Exception as e:
+            except (ConnectionError, RuntimeError) as e:
                 # Connection is broken, mark for removal
                 logger.warning(
                     f"Failed to send message to client {client_id}: {e}. Marking for disconnection."
@@ -90,7 +90,7 @@ class ConnectionManager:
 
         try:
             await self.active_connections[client_id].send_json(message)
-        except Exception as e:
+        except (ConnectionError, RuntimeError) as e:
             # Connection is broken, remove it
             logger.warning(
                 f"Failed to send personal message to client {client_id}: {e}. Disconnecting."

--- a/packages/taskdog-server/tests/websocket/test_connection_manager.py
+++ b/packages/taskdog-server/tests/websocket/test_connection_manager.py
@@ -108,7 +108,7 @@ class TestConnectionManager:
         await self.manager.connect("client-3", mock_websocket3)
 
         # Simulate connection failure for client-2
-        mock_websocket2.send_json.side_effect = Exception("Connection broken")
+        mock_websocket2.send_json.side_effect = RuntimeError("Connection broken")
 
         message = {"type": "task_updated", "task_id": 123}
 
@@ -152,7 +152,7 @@ class TestConnectionManager:
         await self.manager.connect(client_id, mock_websocket)
 
         # Simulate connection failure
-        mock_websocket.send_json.side_effect = Exception("Connection broken")
+        mock_websocket.send_json.side_effect = RuntimeError("Connection broken")
 
         message = {"type": "task_detail", "task_id": 123}
 
@@ -246,7 +246,7 @@ class TestConnectionManager:
         """Test that broadcast failure logs a warning."""
         # Arrange
         mock_websocket = AsyncMock(spec=WebSocket)
-        mock_websocket.send_json.side_effect = Exception("Connection error")
+        mock_websocket.send_json.side_effect = RuntimeError("Connection error")
         client_id = "client-1"
         await self.manager.connect(client_id, mock_websocket)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1171,7 +1171,7 @@ wheels = [
 
 [[package]]
 name = "taskdog-client"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-client" }
 dependencies = [
     { name = "httpx" },
@@ -1203,7 +1203,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-core"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-core" }
 dependencies = [
     { name = "alembic" },
@@ -1237,7 +1237,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-mcp"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -1269,7 +1269,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-server"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-server" }
 dependencies = [
     { name = "fastapi" },
@@ -1305,7 +1305,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-ui"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-ui" }
 dependencies = [
     { name = "click" },
@@ -1347,7 +1347,7 @@ provides-extras = ["dev", "server"]
 
 [[package]]
 name = "taskdog-workspace"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- `__init__.py`: `Exception` → `PackageNotFoundError` for version detection
- `tasks.py`, `lifecycle.py`: `Exception` → `TaskNotFoundException` for audit trail old_task fetch
- `websocket.py`: Add `logger.warning` for WebSocket connection errors (catch-all kept as various exceptions possible)
- `connection_manager.py`: `Exception` → `(ConnectionError, RuntimeError)` for broadcast/send errors (2 places)
- Update tests to use `RuntimeError` instead of generic `Exception`

## Test plan
- [x] `make test-server` passes (280 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)