### PR TITLE
refactor(client): replace broad except Exception with specific types

### DIFF
--- a/packages/taskdog-client/src/taskdog_client/base_client.py
+++ b/packages/taskdog-client/src/taskdog_client/base_client.py
@@ -86,7 +86,7 @@ class BaseApiClient:
                 return "; ".join(messages)
 
             return str(detail)
-        except Exception:
+        except (KeyError, TypeError, ValueError):
             return "Validation error"
 
     def _handle_error(self, response: httpx.Response) -> None:

--- a/packages/taskdog-client/src/taskdog_client/taskdog_api_client.py
+++ b/packages/taskdog-client/src/taskdog_client/taskdog_api_client.py
@@ -119,7 +119,7 @@ class TaskdogApiClient:
         try:
             response = self._base._safe_request("get", "/health")
             return response.status_code == 200
-        except Exception:
+        except httpx.HTTPError:
             return False
 
     # CRUD Controller methods - delegate to TaskClient

--- a/packages/taskdog-client/tests/test_taskdog_api_client.py
+++ b/packages/taskdog-client/tests/test_taskdog_api_client.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 from taskdog_client.taskdog_api_client import TaskdogApiClient
 
@@ -118,7 +119,7 @@ class TestTaskdogApiClientLifecycle:
 
     def test_check_health_failure(self, client):
         """Test check_health returns False on failure."""
-        client._base._safe_request.side_effect = Exception("Connection error")
+        client._base._safe_request.side_effect = httpx.ConnectError("Connection error")
 
         assert client.check_health() is False
 

--- a/uv.lock
+++ b/uv.lock
@@ -1171,7 +1171,7 @@ wheels = [
 
 [[package]]
 name = "taskdog-client"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-client" }
 dependencies = [
     { name = "httpx" },
@@ -1203,7 +1203,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-core"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-core" }
 dependencies = [
     { name = "alembic" },
@@ -1237,7 +1237,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-mcp"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -1269,7 +1269,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-server"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-server" }
 dependencies = [
     { name = "fastapi" },
@@ -1305,7 +1305,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-ui"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-ui" }
 dependencies = [
     { name = "click" },
@@ -1347,7 +1347,7 @@ provides-extras = ["dev", "server"]
 
 [[package]]
 name = "taskdog-workspace"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- `base_client.py`: `Exception` → `(KeyError, TypeError, ValueError)` for validation error extraction from API responses
- `taskdog_api_client.py`: `Exception` → `httpx.HTTPError` for health check failure handling
- Update test to use `httpx.ConnectError` instead of generic `Exception`

## Test plan
- [x] Client tests pass (50 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)