### PR TITLE
refactor(ui): replace broad except Exception with specific types

### DIFF
--- a/packages/taskdog-ui/src/taskdog/__init__.py
+++ b/packages/taskdog-ui/src/taskdog/__init__.py
@@ -1,8 +1,8 @@
 """taskdog - CLI task management tool"""
 
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version("taskdog-ui")
-except Exception:
+except PackageNotFoundError:
     __version__ = "unknown"

--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from textual.app import App
+from textual.app import App, InvalidThemeError
 from textual.binding import Binding
 from textual.command import CommandPalette
 
@@ -316,7 +316,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         # Apply theme from config with fallback for invalid themes
         try:
             self.theme = self._theme
-        except Exception:
+        except InvalidThemeError:
             self.notify(
                 f"Invalid theme '{self._theme}'. Using default.",
                 severity="warning",

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/base_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/base_dialog.py
@@ -5,6 +5,7 @@ from typing import Any, ClassVar, TypeVar
 
 from textual.app import ComposeResult
 from textual.binding import Binding
+from textual.css.query import NoMatches
 from textual.screen import ModalScreen
 from textual.validation import Validator
 from textual.widgets import Input, Static
@@ -51,7 +52,7 @@ class BaseModalDialog(ModalScreen[T]):
         try:
             error_message = self.query_one("#error-message", Static)
             error_message.update(f"[red]Error: {message}[/red]")
-        except Exception:
+        except NoMatches:
             # If error-message widget doesn't exist, skip error display
             # This allows dialogs without validation to not require the widget
             pass
@@ -66,7 +67,7 @@ class BaseModalDialog(ModalScreen[T]):
         try:
             error_message = self.query_one("#error-message", Static)
             error_message.update("")
-        except Exception:
+        except NoMatches:
             # If error-message widget doesn't exist, skip error clearing
             pass
 

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/scrollable_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/scrollable_dialog.py
@@ -5,6 +5,7 @@ from typing import ClassVar, TypeVar
 
 from textual.binding import Binding
 from textual.containers import VerticalScroll
+from textual.css.query import NoMatches
 
 from taskdog.tui.dialogs.base_dialog import BaseModalDialog
 from taskdog.tui.widgets.vi_navigation_mixin import ViNavigationMixin
@@ -50,7 +51,7 @@ class ScrollableDialogBase(BaseModalDialog[T], ViNavigationMixin):
         """
         try:
             return self.query_one(self.scroll_container_id, VerticalScroll)
-        except Exception as e:
+        except NoMatches as e:
             raise RuntimeError(
                 f"Scroll container '{self.scroll_container_id}' not found or "
                 f"not a VerticalScroll widget in {self.__class__.__name__}"

--- a/packages/taskdog-ui/src/taskdog/tui/utils/css_loader.py
+++ b/packages/taskdog-ui/src/taskdog/tui/utils/css_loader.py
@@ -21,7 +21,7 @@ def get_css_paths() -> list[str | Path]:
             str(styles_dir / "main.tcss"),
             str(styles_dir / "dialogs.tcss"),
         ]
-    except Exception:
+    except (FileNotFoundError, ModuleNotFoundError):
         # Fallback to __file__ for development
         styles_dir = Path(__file__).parent.parent / "styles"
         return [

--- a/uv.lock
+++ b/uv.lock
@@ -1171,7 +1171,7 @@ wheels = [
 
 [[package]]
 name = "taskdog-client"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-client" }
 dependencies = [
     { name = "httpx" },
@@ -1203,7 +1203,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-core"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-core" }
 dependencies = [
     { name = "alembic" },
@@ -1237,7 +1237,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-mcp"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -1269,7 +1269,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-server"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-server" }
 dependencies = [
     { name = "fastapi" },
@@ -1305,7 +1305,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-ui"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-ui" }
 dependencies = [
     { name = "click" },
@@ -1347,7 +1347,7 @@ provides-extras = ["dev", "server"]
 
 [[package]]
 name = "taskdog-workspace"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- `__init__.py`: `Exception` → `PackageNotFoundError` for version detection
- `base_dialog.py`: `Exception` → `NoMatches` for Textual widget query (2 places)
- `scrollable_dialog.py`: `Exception` → `NoMatches` for Textual widget query
- `css_loader.py`: `Exception` → `(FileNotFoundError, ModuleNotFoundError)` for resource loading fallback
- `app.py`: `Exception` → `InvalidThemeError` for theme validation

Note: `note_editor.py` was kept as `except Exception` since it handles both API errors and file I/O errors.

## Test plan
- [x] `make test-ui` passes (898 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)