### PR TITLE
refactor(mcp): replace broad except Exception with specific types

### DIFF
--- a/packages/taskdog-mcp/src/taskdog_mcp/__init__.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/__init__.py
@@ -4,9 +4,9 @@ This package provides a Model Context Protocol (MCP) server that enables
 Claude Desktop and other MCP-compatible AI clients to interact with Taskdog.
 """
 
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version("taskdog-mcp")
-except Exception:
+except PackageNotFoundError:
     __version__ = "unknown"

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_decomposition.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_decomposition.py
@@ -5,10 +5,13 @@ Tools for breaking down large tasks into smaller subtasks.
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from mcp.server.fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from taskdog_client import TaskdogApiClient
@@ -69,8 +72,8 @@ def _update_decomposition_notes(
 
         new_notes = (existing_notes or "") + note_addition
         client.update_task_notes(task_id, new_notes)
-    except Exception:
-        pass  # Notes update is optional
+    except Exception as e:
+        logger.warning(f"Failed to update notes for task {task_id}: {e}")
 
 
 def register_decomposition_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1171,7 +1171,7 @@ wheels = [
 
 [[package]]
 name = "taskdog-client"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-client" }
 dependencies = [
     { name = "httpx" },
@@ -1203,7 +1203,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-core"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-core" }
 dependencies = [
     { name = "alembic" },
@@ -1237,7 +1237,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-mcp"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -1269,7 +1269,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-server"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-server" }
 dependencies = [
     { name = "fastapi" },
@@ -1305,7 +1305,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-ui"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "packages/taskdog-ui" }
 dependencies = [
     { name = "click" },
@@ -1347,7 +1347,7 @@ provides-extras = ["dev", "server"]
 
 [[package]]
 name = "taskdog-workspace"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- `__init__.py`: `Exception` → `PackageNotFoundError` for version detection
- `task_decomposition.py`: Replace silent `pass` with `logger.warning` for notes update failure (catch-all kept as API errors are diverse)

## Test plan
- [x] All tests pass via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)