### PR TITLE
fix(ui): make TUI dialog max-height responsive

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/styles/dialogs.tcss
+++ b/packages/taskdog-ui/src/taskdog/tui/styles/dialogs.tcss
@@ -29,7 +29,7 @@ StatsScreen {
     width: auto;  /* Auto-adjust width based on content */
     min-width: 55;  /* Minimum width for simple yes/no confirmations */
     max-width: 90;  /* Maximum width to prevent too-wide dialogs */
-    max-height: 20;
+    max-height: 40%;
 }
 
 .dialog-standard {
@@ -96,12 +96,12 @@ StatsScreen {
 
 /* Algorithm Selection Dialog */
 #algorithm-dialog {
-    max-height: 28;
+    max-height: 60%;
 }
 
 /* Sort Selection Dialog */
 #sort-dialog {
-    max-height: 25;  /* Smaller than algorithm dialog (no input fields) */
+    max-height: 50%;  /* Smaller than algorithm dialog (no input fields) */
 }
 
 /* Confirmation Dialog */
@@ -112,7 +112,7 @@ StatsScreen {
 /* Fix Actual Dialog - special operation */
 #fix-actual-dialog {
     border: round $error;  /* Colored border for emphasis on timestamp correction */
-    max-height: 30;  /* 3 fields */
+    max-height: 60%;  /* 3 fields */
 }
 
 /* Warning message in fix actual dialog */
@@ -126,17 +126,17 @@ StatsScreen {
 /* Task Form Dialog (Add/Edit) */
 #add-task-dialog,
 #edit-task-dialog {
-    max-height: 50;  /* Accommodate planned_start/planned_end fields */
+    max-height: 80%;  /* Accommodate planned_start/planned_end fields */
 }
 
 /* Task Detail Screen */
 #detail-screen {
-    max-height: 50;
+    max-height: 80%;
 }
 
 /* Help Screen */
 #help-screen {
-    max-height: 50;
+    max-height: 80%;
 }
 
 #help-content {
@@ -168,7 +168,7 @@ StatsScreen {
 
 /* Stats Screen Container */
 #stats-screen {
-    max-height: 50;
+    max-height: 80%;
 }
 
 #stats-content {


### PR DESCRIPTION
## Summary

- Replace hardcoded fixed-row `max-height` values with percentage-based values in `dialogs.tcss` so TUI dialogs scale with terminal size
- Compact dialogs use 40-50%, standard dialogs use 60%, and wide/form dialogs use 80%
- Width settings remain unchanged as their fixed min/max constraints are intentional for readability

## Changes

| Dialog | Before | After |
|---|---|---|
| `.dialog-compact` | `max-height: 20` | `max-height: 40%` |
| `#algorithm-dialog` | `max-height: 28` | `max-height: 60%` |
| `#sort-dialog` | `max-height: 25` | `max-height: 50%` |
| `#fix-actual-dialog` | `max-height: 30` | `max-height: 60%` |
| `#add-task-dialog` / `#edit-task-dialog` | `max-height: 50` | `max-height: 80%` |
| `#detail-screen` | `max-height: 50` | `max-height: 80%` |
| `#help-screen` | `max-height: 50` | `max-height: 80%` |
| `#stats-screen` | `max-height: 50` | `max-height: 80%` |

## Test plan

- [ ] Launch TUI and open Detail (`i`), Help (`?`), Add (`a`), Stats screens
- [ ] Verify dialogs scale with terminal height (larger terminal → larger dialog)
- [ ] Verify dialogs don't break when terminal is small
- [ ] Verify scrollable content still works within dialogs

🤖 Generated with [Claude Code](https://claude.com/claude-code)