### PR TITLE
refactor(ui): consolidate TUI note editing logic into NoteCommand

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/commands/note.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/note.py
@@ -1,11 +1,41 @@
 """Edit note command for TUI."""
 
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
 from taskdog.tui.commands.base import TUICommandBase
 from taskdog.utils.note_editor import edit_task_note
 
+if TYPE_CHECKING:
+    from taskdog.tui.app import TaskdogTUI
+    from taskdog.tui.context import TUIContext
+
 
 class NoteCommand(TUICommandBase):
-    """Command to edit the selected task's note in external editor."""
+    """Command to edit the selected task's note in external editor.
+
+    Can be used standalone (from the main table) or with an explicit task_id
+    and on_success callback (when invoked from other commands like ShowCommand).
+    """
+
+    def __init__(
+        self,
+        app: "TaskdogTUI",
+        context: "TUIContext",
+        task_id: int | None = None,
+        on_success: Callable[[str, int], None] | None = None,
+    ) -> None:
+        """Initialize the command.
+
+        Args:
+            app: The TaskdogTUI application instance
+            context: TUI context with dependencies
+            task_id: Explicit task ID to edit. If None, uses table selection.
+            on_success: Callback on successful save. If None, reloads task list.
+        """
+        super().__init__(app, context)
+        self._task_id = task_id
+        self._on_success = on_success
 
     def _on_note_saved(self, name: str, task_id: int) -> None:
         """Handle successful note save.
@@ -16,7 +46,7 @@ class NoteCommand(TUICommandBase):
 
     def execute_impl(self) -> None:
         """Execute the edit note command."""
-        task_id = self.get_selected_task_id()
+        task_id = self._task_id or self.get_selected_task_id()
         if task_id is None:
             self.notify_warning("No task selected")
             return
@@ -32,7 +62,8 @@ class NoteCommand(TUICommandBase):
             task=output.task,
             notes_provider=self.context.api_client,
             app=self.app,
-            on_success=lambda name, id_: self._on_note_saved(name, id_),
+            on_success=self._on_success
+            or (lambda name, id_: self._on_note_saved(name, id_)),
             on_error=self.notify_error,
             config=self.context.config,
         )

--- a/packages/taskdog-ui/src/taskdog/tui/commands/show.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/show.py
@@ -5,7 +5,6 @@ from typing import Any
 
 from taskdog.tui.commands.base import TUICommandBase
 from taskdog.tui.dialogs.task_detail_dialog import TaskDetailDialog
-from taskdog.utils.note_editor import edit_task_note
 
 
 class ShowCommand(TUICommandBase):
@@ -58,23 +57,20 @@ class ShowCommand(TUICommandBase):
     def _edit_note(self, task_id: int) -> None:
         """Open editor for the task's note and re-display detail screen.
 
+        Delegates to NoteCommand with an explicit task_id and callback.
+
         Args:
             task_id: ID of the task to edit notes for
         """
-        # Get task via API client
-        output = self.context.api_client.get_task_by_id(task_id)
-        if not output.task:
-            self.notify_warning(f"Task #{task_id} not found")
-            return
+        from taskdog.tui.commands.note import NoteCommand
 
-        # Edit note using shared helper (uses API client via NotesProvider protocol)
-        edit_task_note(
-            task=output.task,
-            notes_provider=self.context.api_client,
-            app=self.app,
+        cmd = NoteCommand(
+            self.app,
+            self.context,
+            task_id=task_id,
             on_success=lambda name, id_: self._on_edit_success(name, id_),
-            on_error=self.notify_error,
         )
+        cmd.execute()
 
     def _on_edit_success(self, task_name: str, task_id: int) -> None:
         """Handle successful note edit.


### PR DESCRIPTION
## Summary

- **Fix bug**: `ShowCommand._edit_note()` was missing the `config` parameter when calling `edit_task_note`, causing note editing from the detail screen to ignore user config (e.g. editor preference)
- **Eliminate duplication**: Add optional `task_id` and `on_success` parameters to `NoteCommand` (following `ExportCommand`'s `format_key` pattern), and delegate from `ShowCommand._edit_note()` instead of duplicating the logic
- **Update tests**: Replace monkey-patching tests with a cleaner mock that verifies `NoteCommand` is instantiated with the correct arguments

## Test plan

- [x] `make test-ui` — all 899 tests pass
- [x] `make lint` — no issues
- [x] `make typecheck-taskdog-ui` — no issues
- [ ] Manual: press `v` on main table to edit a note — should work as before
- [ ] Manual: press `v` on detail screen to edit a note — should now respect config (e.g. `$EDITOR`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)