### PR TITLE
fix(ui): refresh gantt widget after note edit from detail screen

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/commands/show.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/show.py
@@ -55,9 +55,11 @@ class ShowCommand(TUICommandBase):
                 self._edit_note(task_id)
 
     def _edit_note(self, task_id: int) -> None:
-        """Open editor for the task's note and re-display detail screen.
+        """Open editor for the task's note.
 
-        Delegates to NoteCommand with an explicit task_id and callback.
+        Delegates to NoteCommand with an explicit task_id.
+        After editing, returns to the main screen (no detail re-display)
+        so the gantt and task table can refresh without race conditions.
 
         Args:
             task_id: ID of the task to edit notes for
@@ -68,17 +70,5 @@ class ShowCommand(TUICommandBase):
             self.app,
             self.context,
             task_id=task_id,
-            on_success=lambda name, id_: self._on_edit_success(name, id_),
         )
         cmd.execute()
-
-    def _on_edit_success(self, task_name: str, task_id: int) -> None:
-        """Handle successful note edit.
-
-        Args:
-            task_name: Name of the task
-            task_id: ID of the task
-        """
-        # Notification is sent via WebSocket (task_updated event with "notes" field)
-        # Re-display detail screen with updated notes
-        self.execute()


### PR DESCRIPTION
## Summary

- Fix gantt widget not refreshing after editing notes from the TUI detail screen
- Remove `ShowCommand._on_edit_success()` and its custom `on_success` callback that re-displayed the detail dialog immediately after posting `TasksRefreshed`, causing a race condition where the dialog push could prevent the gantt from visually updating
- Let `NoteCommand`'s default behavior (`reload_tasks()`) handle the refresh, returning the user to the main screen

## Test plan

- [x] `test_show.py` tests pass (10/10)
- [x] Lint passes
- [x] Pre-commit hooks pass (ruff, mypy, unit tests)
- [ ] Manual: Open TUI → select task → `i` (detail) → `v` (edit note) → save and close editor → verify gantt and task table are refreshed

🤖 Generated with [Claude Code](https://claude.com/claude-code)