### PR TITLE
refactor(test): consolidate duplicate test methods with parametrize

### DIFF
--- a/packages/taskdog-core/tests/application/queries/filters/test_tag_filter.py
+++ b/packages/taskdog-core/tests/application/queries/filters/test_tag_filter.py
@@ -38,43 +38,22 @@ class TestTagFilter:
         )
         self.tasks = [self.task1, self.task2, self.task3, self.task4]
 
-    def test_filter_or_logic_single_tag(self):
-        """Test filter with OR logic (match_all=False) and single tag."""
-        tag_filter = TagFilter(tags=["work"], match_all=False)
+    @pytest.mark.parametrize(
+        "tags,match_all,expected_ids",
+        [
+            (["work"], False, [1, 3]),
+            (["work", "personal"], False, [1, 2, 3]),
+            (["work"], True, [1, 3]),
+            (["work", "urgent"], True, [1]),
+        ],
+        ids=["or_single", "or_multiple", "and_single", "and_multiple"],
+    )
+    def test_filter_match_logic(self, tags, match_all, expected_ids):
+        """Test filter with various tags and match_all combinations."""
+        tag_filter = TagFilter(tags=tags, match_all=match_all)
         result = tag_filter.filter(self.tasks)
-
-        assert len(result) == 2
-        assert result[0].id == 1
-        assert result[1].id == 3
-
-    def test_filter_or_logic_multiple_tags(self):
-        """Test filter with OR logic (match_all=False) and multiple tags."""
-        tag_filter = TagFilter(tags=["work", "personal"], match_all=False)
-        result = tag_filter.filter(self.tasks)
-
-        # Should match tasks with tag "work" OR "personal"
-        assert len(result) == 3
-        assert result[0].id == 1
-        assert result[1].id == 2
-        assert result[2].id == 3
-
-    def test_filter_and_logic_single_tag(self):
-        """Test filter with AND logic (match_all=True) and single tag."""
-        tag_filter = TagFilter(tags=["work"], match_all=True)
-        result = tag_filter.filter(self.tasks)
-
-        assert len(result) == 2
-        assert result[0].id == 1
-        assert result[1].id == 3
-
-    def test_filter_and_logic_multiple_tags(self):
-        """Test filter with AND logic (match_all=True) and multiple tags."""
-        tag_filter = TagFilter(tags=["work", "urgent"], match_all=True)
-        result = tag_filter.filter(self.tasks)
-
-        # Should match only tasks with BOTH "work" AND "urgent"
-        assert len(result) == 1
-        assert result[0].id == 1
+        assert len(result) == len(expected_ids)
+        assert [t.id for t in result] == expected_ids
 
     def test_filter_and_logic_no_match(self):
         """Test filter with AND logic where no task has all tags."""

--- a/packages/taskdog-core/tests/application/use_cases/test_archive_task_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_archive_task_use_case.py
@@ -17,71 +17,26 @@ class TestArchiveTaskUseCase:
         self.repository = repository
         self.use_case = ArchiveTaskUseCase(self.repository)
 
-    def test_archive_completed_task(self):
-        """Test archiving a completed task sets is_archived flag and preserves status."""
-        # Create completed task
-        task = self.repository.create(
-            name="Test Task", priority=1, status=TaskStatus.COMPLETED
-        )
-
-        # Archive task
+    @pytest.mark.parametrize(
+        "status",
+        [
+            TaskStatus.COMPLETED,
+            TaskStatus.CANCELED,
+            TaskStatus.PENDING,
+            TaskStatus.IN_PROGRESS,
+        ],
+        ids=["completed", "canceled", "pending", "in_progress"],
+    )
+    def test_archive_preserves_status(self, status):
+        """Test archiving a task sets is_archived flag and preserves status."""
+        task = self.repository.create(name="Test Task", priority=1, status=status)
         input_dto = SingleTaskInput(task_id=task.id)
         result = self.use_case.execute(input_dto)
-
-        # Verify task archived (is_archived=True, status preserved)
         assert result.is_archived is True
-        assert result.status == TaskStatus.COMPLETED
-
-        # Verify persisted
+        assert result.status == status
         archived_task = self.repository.get_by_id(task.id)
-        assert archived_task is not None
         assert archived_task.is_archived is True
-        assert archived_task.status == TaskStatus.COMPLETED
-
-    def test_archive_canceled_task(self):
-        """Test archiving a canceled task sets is_archived flag and preserves status."""
-        # Create canceled task
-        task = self.repository.create(
-            name="Test Task", priority=1, status=TaskStatus.CANCELED
-        )
-
-        # Archive task
-        input_dto = SingleTaskInput(task_id=task.id)
-        result = self.use_case.execute(input_dto)
-
-        # Verify task archived
-        assert result.is_archived is True
-        assert result.status == TaskStatus.CANCELED
-
-    def test_archive_pending_task(self):
-        """Test archiving a pending task is allowed and preserves status."""
-        # Create pending task
-        task = self.repository.create(
-            name="Test Task", priority=1, status=TaskStatus.PENDING
-        )
-
-        # Archive task
-        input_dto = SingleTaskInput(task_id=task.id)
-        result = self.use_case.execute(input_dto)
-
-        # Verify task archived
-        assert result.is_archived is True
-        assert result.status == TaskStatus.PENDING
-
-    def test_archive_in_progress_task(self):
-        """Test archiving an in-progress task is allowed and preserves status."""
-        # Create in-progress task
-        task = self.repository.create(
-            name="Test Task", priority=1, status=TaskStatus.IN_PROGRESS
-        )
-
-        # Archive task
-        input_dto = SingleTaskInput(task_id=task.id)
-        result = self.use_case.execute(input_dto)
-
-        # Verify task archived
-        assert result.is_archived is True
-        assert result.status == TaskStatus.IN_PROGRESS
+        assert archived_task.status == status
 
     def test_archive_nonexistent_task(self):
         """Test archiving a task that doesn't exist."""

--- a/packages/taskdog-core/tests/application/use_cases/test_restore_task_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_restore_task_use_case.py
@@ -100,34 +100,17 @@ class TestRestoreTaskUseCase:
         assert result.priority == original_priority
         assert result.estimated_duration == original_duration
 
-    def test_execute_restores_archived_completed_task(self):
-        """Test execute restores archived COMPLETED task with original status."""
-        # Create an archived completed task
-        task = self.repository.create(
-            name="Test Task", priority=1, status=TaskStatus.COMPLETED
-        )
+    @pytest.mark.parametrize(
+        "status",
+        [TaskStatus.COMPLETED, TaskStatus.CANCELED],
+        ids=["completed", "canceled"],
+    )
+    def test_execute_restores_archived_task_with_status(self, status):
+        """Test execute restores archived task with original status preserved."""
+        task = self.repository.create(name="Test Task", priority=1, status=status)
         task.is_archived = True
         self.repository.save(task)
-
         input_dto = SingleTaskInput(task_id=task.id)
         result = self.use_case.execute(input_dto)
-
-        # Verify archived flag cleared and status preserved
         assert result.is_archived is False
-        assert result.status == TaskStatus.COMPLETED
-
-    def test_execute_restores_archived_canceled_task(self):
-        """Test execute restores archived CANCELED task with original status."""
-        # Create an archived canceled task
-        task = self.repository.create(
-            name="Test Task", priority=1, status=TaskStatus.CANCELED
-        )
-        task.is_archived = True
-        self.repository.save(task)
-
-        input_dto = SingleTaskInput(task_id=task.id)
-        result = self.use_case.execute(input_dto)
-
-        # Verify archived flag cleared and status preserved
-        assert result.is_archived is False
-        assert result.status == TaskStatus.CANCELED
+        assert result.status == status

--- a/packages/taskdog-ui/tests/tui/forms/validators/test_datetime_validator.py
+++ b/packages/taskdog-ui/tests/tui/forms/validators/test_datetime_validator.py
@@ -15,44 +15,32 @@ class TestDateTimeValidatorValidate:
         """Set up test fixtures."""
         self.validator = DateTimeValidator("deadline", time(18, 30, 0))
 
-    def test_empty_string_is_valid(self) -> None:
-        """Test that empty string is valid (optional field)."""
-        result = self.validator.validate("")
-        assert result.is_valid is True
-
-    def test_whitespace_only_is_valid(self) -> None:
-        """Test that whitespace-only string is valid."""
-        result = self.validator.validate("   ")
-        assert result.is_valid is True
-
-    def test_iso_format_is_valid(self) -> None:
-        """Test that ISO format datetime is valid."""
-        result = self.validator.validate("2025-12-31 18:30:00")
-        assert result.is_valid is True
-
-    def test_date_only_is_valid(self) -> None:
-        """Test that date-only string is valid."""
-        result = self.validator.validate("2025-12-31")
-        assert result.is_valid is True
-
-    def test_date_with_time_is_valid(self) -> None:
-        """Test that date with time is valid."""
-        result = self.validator.validate("2025-12-31 09:30")
-        assert result.is_valid is True
-
-    def test_natural_language_next_friday_is_valid(self) -> None:
-        """Test that 'next friday' is valid."""
-        result = self.validator.validate("next friday")
-        assert result.is_valid is True
-
-    def test_natural_language_with_time_is_valid(self) -> None:
-        """Test that 'tomorrow 6pm' is valid."""
-        result = self.validator.validate("tomorrow 6pm")
-        assert result.is_valid is True
-
-    def test_relative_date_in_two_weeks_is_valid(self) -> None:
-        """Test that 'in 2 weeks' is valid."""
-        result = self.validator.validate("in 2 weeks")
+    @pytest.mark.parametrize(
+        "input_str",
+        [
+            "",
+            "   ",
+            "2025-12-31 18:30:00",
+            "2025-12-31",
+            "2025-12-31 09:30",
+            "next friday",
+            "tomorrow 6pm",
+            "in 2 weeks",
+        ],
+        ids=[
+            "empty",
+            "whitespace",
+            "iso_datetime",
+            "date_only",
+            "date_with_time",
+            "next_friday",
+            "tomorrow_6pm",
+            "in_2_weeks",
+        ],
+    )
+    def test_valid_input(self, input_str: str) -> None:
+        """Test that valid datetime inputs are accepted."""
+        result = self.validator.validate(input_str)
         assert result.is_valid is True
 
     def test_invalid_date_format_fails(self) -> None:
@@ -76,25 +64,20 @@ class TestDateTimeValidatorParse:
         """Set up test fixtures."""
         self.validator = DateTimeValidator("deadline", time(18, 30, 0))
 
-    def test_parse_empty_string_returns_none(self) -> None:
-        """Test that empty string returns None."""
-        result = self.validator.parse("")
-        assert result is None
-
-    def test_parse_whitespace_returns_none(self) -> None:
-        """Test that whitespace-only string returns None."""
-        result = self.validator.parse("   ")
-        assert result is None
-
-    def test_parse_full_datetime(self) -> None:
-        """Test parsing full datetime string."""
-        result = self.validator.parse("2025-12-31 09:30:00")
-        assert result == "2025-12-31 09:30:00"
-
-    def test_parse_date_only_applies_default_hour(self) -> None:
-        """Test that date-only string applies default hour."""
-        result = self.validator.parse("2025-12-31")
-        assert result == "2025-12-31 18:30:00"
+    @pytest.mark.parametrize(
+        "input_str,expected",
+        [
+            ("", None),
+            ("   ", None),
+            ("2025-12-31 09:30:00", "2025-12-31 09:30:00"),
+            ("2025-12-31", "2025-12-31 18:30:00"),
+        ],
+        ids=["empty", "whitespace", "full_datetime", "date_only_default_time"],
+    )
+    def test_parse(self, input_str: str, expected: str | None) -> None:
+        """Test parsing datetime input strings."""
+        result = self.validator.parse(input_str)
+        assert result == expected
 
     def test_parse_date_with_different_default_time(self) -> None:
         """Test parsing with different default time."""
@@ -120,28 +103,31 @@ class TestDateTimeValidatorParse:
 class TestDateTimeValidatorDefaultTime:
     """Test cases for default time behavior."""
 
-    def test_default_time_18_for_deadline(self) -> None:
-        """Test that deadline validator uses 18:00 as default time."""
-        validator = DateTimeValidator("deadline", time(18, 30, 0))
-        result = validator.parse("2025-12-31")
-        assert "18:30:00" in result
-
-    def test_default_time_9_for_start(self) -> None:
-        """Test that start validator uses 09:00 as default time."""
-        validator = DateTimeValidator("planned start", time(9, 30, 0))
-        result = validator.parse("2025-12-31")
-        assert "09:30:00" in result
-
-    def test_explicit_time_overrides_default(self) -> None:
-        """Test that explicit time overrides default time."""
-        validator = DateTimeValidator("deadline", time(18, 30, 0))
-        result = validator.parse("2025-12-31 10:30")
-        assert "10:30" in result
-        assert "18:00" not in result
-
-    def test_midnight_explicit_is_preserved(self) -> None:
-        """Test that explicit midnight is preserved."""
-        validator = DateTimeValidator("deadline", time(18, 30, 0))
-        result = validator.parse("2025-12-31 00:00:00")
-        # When time is explicitly specified (has colon), it should be preserved
+    @pytest.mark.parametrize(
+        "field,default_time,input_str,expected_substring",
+        [
+            ("deadline", time(18, 30, 0), "2025-12-31", "18:30:00"),
+            ("planned start", time(9, 30, 0), "2025-12-31", "09:30:00"),
+            ("deadline", time(18, 30, 0), "2025-12-31 10:30", "10:30"),
+            ("deadline", time(18, 30, 0), "2025-12-31 00:00:00", None),
+        ],
+        ids=[
+            "deadline_default",
+            "start_default",
+            "explicit_override",
+            "midnight_preserved",
+        ],
+    )
+    def test_default_time_behavior(
+        self,
+        field: str,
+        default_time: time,
+        input_str: str,
+        expected_substring: str | None,
+    ) -> None:
+        """Test default time application behavior."""
+        validator = DateTimeValidator(field, default_time)
+        result = validator.parse(input_str)
         assert result is not None
+        if expected_substring:
+            assert expected_substring in result


### PR DESCRIPTION
## Summary

- Replace repetitive test methods that differ only in input values with `pytest.mark.parametrize`, reducing total method count by 22 across 6 test files while preserving all test cases (parametrize expansion)
- Follows existing codebase convention of using `ids=[]` for readable test output
- Files changed: `test_archive_task_use_case.py`, `test_restore_task_use_case.py`, `test_tag_filter.py`, `test_datetime_validator.py`, `test_analytics.py`, `test_lifecycle.py`

## Test plan

- [x] `make test-core` — 1095 passed
- [x] `make test-server` — 280 passed
- [x] `make test-ui` — 902 passed
- [x] Pre-commit hooks (ruff, mypy, format) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)