### PR TITLE
refactor(test): consolidate server test methods with parametrize

### DIFF
--- a/packages/taskdog-server/tests/websocket/test_event_broadcaster.py
+++ b/packages/taskdog-server/tests/websocket/test_event_broadcaster.py
@@ -257,21 +257,17 @@ class TestWebSocketEventBroadcaster:
         }
         assert call_args[0][3] == "test-client-6"
 
-    def test_schedule_optimized_with_different_algorithms(self):
+    @pytest.mark.parametrize(
+        "algorithm",
+        ["greedy", "balanced", "backward", "priority_first", "genetic"],
+    )
+    def test_schedule_optimized_with_different_algorithms(self, algorithm):
         """Test schedule_optimized with various algorithms."""
-        algorithms = ["greedy", "balanced", "backward", "priority_first", "genetic"]
+        self.broadcaster.schedule_optimized(10, 0, algorithm)
 
-        for algorithm in algorithms:
-            # Reset mock for each iteration
-            self.mock_background_tasks.reset_mock()
-
-            # Act
-            self.broadcaster.schedule_optimized(10, 0, algorithm)
-
-            # Assert
-            self.mock_background_tasks.add_task.assert_called_once()
-            call_args = self.mock_background_tasks.add_task.call_args
-            assert call_args[0][2]["algorithm"] == algorithm
+        self.mock_background_tasks.add_task.assert_called_once()
+        call_args = self.mock_background_tasks.add_task.call_args
+        assert call_args[0][2]["algorithm"] == algorithm
 
     def test_multiple_broadcasts_in_sequence(self):
         """Test multiple broadcast calls are scheduled correctly."""


### PR DESCRIPTION
## Summary

- Consolidate duplicate auth dependency tests (HTTP + WebSocket) into parametrized variants (-7 methods)
- Merge auth integration 401 response tests into single parametrized test (-1 method)
- Merge server config env var override tests into single parametrized test (-1 method)
- Replace `for`-loop in event broadcaster algorithm test with `pytest.mark.parametrize` (style fix)

## Test plan

- [x] `make test-server` — 284 passed (89% coverage)
- [x] Pre-commit hooks (ruff, mypy, format) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)