### PR TITLE
feat(ui): convert help dialog to tabbed layout and reorder detail tabs

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/help_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/help_dialog.py
@@ -1,8 +1,12 @@
 """Help dialog displaying usage instructions and feature guide."""
 
+from typing import ClassVar
+
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import Container, VerticalScroll
-from textual.widgets import Markdown, Static
+from textual.css.query import NoMatches
+from textual.widgets import Markdown, Static, TabbedContent, TabPane, Tabs
 
 from taskdog import __version__
 from taskdog.tui.constants.keybindings import (
@@ -13,23 +17,33 @@ from taskdog.tui.constants.keybindings import (
     QUICK_TIPS,
     TASKDOG_OVERVIEW,
 )
-from taskdog.tui.dialogs.scrollable_dialog import ScrollableDialogBase
+from taskdog.tui.dialogs.base_dialog import BaseModalDialog
+from taskdog.tui.widgets.vi_navigation_mixin import ViNavigationMixin
+
+# Mapping from tab pane ID to its VerticalScroll child ID
+_TAB_SCROLL_MAP: dict[str, str] = {
+    "tab-getting-started": "help-getting-started-scroll",
+    "tab-features": "help-features-scroll",
+    "tab-tips": "help-tips-scroll",
+}
 
 
-class HelpDialog(ScrollableDialogBase[None]):
+class HelpDialog(BaseModalDialog[None], ViNavigationMixin):
     """Modal screen displaying help information and usage guide.
 
-    Shows:
-    - Basic workflow for new users
-    - Main features overview
-    - Command palette usage (including Keys command for keybindings)
-    - Quick tips
+    Organized into three tabs:
+    - Getting Started: Overview and basic workflow
+    - Features: Main features and command palette
+    - Tips: Quick tips and bug report info
     """
 
-    @property
-    def scroll_container_id(self) -> str:
-        """Return the ID of the scroll container."""
-        return "#help-content"
+    BINDINGS: ClassVar = [
+        *ViNavigationMixin.VI_VERTICAL_BINDINGS,
+        *ViNavigationMixin.VI_PAGE_BINDINGS,
+        Binding("q", "cancel", "Close", tooltip="Close the dialog"),
+        Binding("greater_than_sign", "next_tab", "Next Tab", show=False, priority=True),
+        Binding("less_than_sign", "prev_tab", "Prev Tab", show=False, priority=True),
+    ]
 
     def compose(self) -> ComposeResult:
         """Compose the help screen layout."""
@@ -38,41 +52,120 @@ class HelpDialog(ScrollableDialogBase[None]):
         ) as container:
             container.border_title = f"Taskdog TUI v{__version__} - Getting Started"
 
-            with VerticalScroll(id="help-content"):
-                # Taskdog Overview
-                yield Markdown(TASKDOG_OVERVIEW, classes="help-section")
+            with TabbedContent(id="help-tabs"):
+                # Tab 1: Getting Started
+                with (
+                    TabPane("Getting Started", id="tab-getting-started"),
+                    VerticalScroll(
+                        id="help-getting-started-scroll",
+                        classes="help-tab-scroll",
+                    ),
+                ):
+                    yield Markdown(TASKDOG_OVERVIEW, classes="help-section")
+                    yield Static("", classes="help-spacer")
+                    yield Markdown(BASIC_WORKFLOW, classes="help-section")
 
-                # Spacer
-                yield Static("", classes="help-spacer")
+                # Tab 2: Features
+                with (
+                    TabPane("Features", id="tab-features"),
+                    VerticalScroll(
+                        id="help-features-scroll",
+                        classes="help-tab-scroll",
+                    ),
+                ):
+                    yield Markdown(MAIN_FEATURES, classes="help-section")
+                    yield Static("", classes="help-spacer")
+                    yield Markdown(COMMAND_PALETTE_INFO, classes="help-section")
 
-                # Basic Workflow
-                yield Markdown(BASIC_WORKFLOW, classes="help-section")
+                # Tab 3: Tips
+                with (
+                    TabPane("Tips", id="tab-tips"),
+                    VerticalScroll(
+                        id="help-tips-scroll",
+                        classes="help-tab-scroll",
+                    ),
+                ):
+                    yield Markdown("## Quick Tips", classes="help-section")
+                    for tip in QUICK_TIPS:
+                        yield Static(tip, classes="help-tip")
+                    yield Static("", classes="help-spacer")
+                    yield Markdown(BUG_REPORT_INFO, classes="help-section")
 
-                # Spacer
-                yield Static("", classes="help-spacer")
+            # Footer instruction
+            yield Static(
+                "[dim]Press 'q' or Escape to close • '<' / '>' to switch tabs • Press Ctrl+P → 'Keys' for all keybindings[/dim]",
+                classes="help-footer",
+            )
 
-                # Main Features
-                yield Markdown(MAIN_FEATURES, classes="help-section")
+    def _get_active_scroll_widget(self) -> VerticalScroll | None:
+        """Get the VerticalScroll widget for the currently active tab.
 
-                # Spacer
-                yield Static("", classes="help-spacer")
+        Returns:
+            The active tab's VerticalScroll widget, or None if not found.
+        """
+        try:
+            tabs = self.query_one("#help-tabs", TabbedContent)
+        except NoMatches:
+            return None
 
-                # Command Palette Info (includes Keys command)
-                yield Markdown(COMMAND_PALETTE_INFO, classes="help-section")
+        active_pane = tabs.active
+        scroll_id = _TAB_SCROLL_MAP.get(active_pane, "")
+        if not scroll_id:
+            return None
 
-                # Quick Tips
-                yield Static("", classes="help-spacer")
-                yield Markdown("## Quick Tips", classes="help-section")
-                for tip in QUICK_TIPS:
-                    yield Static(tip, classes="help-tip")
+        try:
+            return self.query_one(f"#{scroll_id}", VerticalScroll)
+        except NoMatches:
+            return None
 
-                # Bug Reports & Feature Requests
-                yield Static("", classes="help-spacer")
-                yield Markdown(BUG_REPORT_INFO, classes="help-section")
+    def action_vi_down(self) -> None:
+        """Scroll down one line (j key)."""
+        widget = self._get_active_scroll_widget()
+        if widget:
+            widget.scroll_relative(y=1, animate=False)
 
-                # Footer instruction
-                yield Static("", classes="help-spacer")
-                yield Static(
-                    "[dim]Press 'q' or Escape to close • Press Ctrl+P → 'Keys' for all keybindings[/dim]",
-                    classes="help-footer",
-                )
+    def action_vi_up(self) -> None:
+        """Scroll up one line (k key)."""
+        widget = self._get_active_scroll_widget()
+        if widget:
+            widget.scroll_relative(y=-1, animate=False)
+
+    def action_vi_page_down(self) -> None:
+        """Scroll down half page (Ctrl+D)."""
+        widget = self._get_active_scroll_widget()
+        if widget:
+            widget.scroll_relative(y=widget.size.height // 2, animate=False)
+
+    def action_vi_page_up(self) -> None:
+        """Scroll up half page (Ctrl+U)."""
+        widget = self._get_active_scroll_widget()
+        if widget:
+            widget.scroll_relative(y=-(widget.size.height // 2), animate=False)
+
+    def action_vi_home(self) -> None:
+        """Scroll to top (g key)."""
+        widget = self._get_active_scroll_widget()
+        if widget:
+            widget.scroll_home(animate=False)
+
+    def action_vi_end(self) -> None:
+        """Scroll to bottom (G key)."""
+        widget = self._get_active_scroll_widget()
+        if widget:
+            widget.scroll_end(animate=False)
+
+    def action_next_tab(self) -> None:
+        """Switch to the next tab (> key)."""
+        try:
+            tabs = self.query_one("#help-tabs", TabbedContent).query_one(Tabs)
+            tabs.action_next_tab()
+        except NoMatches:
+            pass
+
+    def action_prev_tab(self) -> None:
+        """Switch to the previous tab (< key)."""
+        try:
+            tabs = self.query_one("#help-tabs", TabbedContent).query_one(Tabs)
+            tabs.action_previous_tab()
+        except NoMatches:
+            pass

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/task_detail_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/task_detail_dialog.py
@@ -31,8 +31,8 @@ class TaskDetailDialog(BaseModalDialog[tuple[str, int] | None], ViNavigationMixi
     """Modal screen for displaying task details with tabs.
 
     Shows comprehensive information about a task across three tabs:
-    - Detail: Basic info (ID, name, priority, status), schedule, tracking
     - Notes: Markdown notes
+    - Detail: Basic info (ID, name, priority, status), schedule, tracking
     - Audit Log: Task-specific operation history (lazy-loaded)
     """
 
@@ -90,18 +90,18 @@ class TaskDetailDialog(BaseModalDialog[tuple[str, int] | None], ViNavigationMixi
 
             with TabbedContent(id="detail-tabs"):
                 with (
+                    TabPane("Notes", id="tab-notes"),
+                    VerticalScroll(id="notes-tab-scroll", classes="detail-tab-scroll"),
+                ):
+                    yield from self._compose_notes_tab()
+
+                with (
                     TabPane("Detail", id="tab-detail"),
                     VerticalScroll(id="detail-tab-scroll", classes="detail-tab-scroll"),
                 ):
                     yield from self._compose_basic_info_section()
                     yield from self._compose_schedule_section()
                     yield from self._compose_tracking_section()
-
-                with (
-                    TabPane("Notes", id="tab-notes"),
-                    VerticalScroll(id="notes-tab-scroll", classes="detail-tab-scroll"),
-                ):
-                    yield from self._compose_notes_tab()
 
                 with (
                     TabPane("Audit Log", id="tab-audit"),

--- a/packages/taskdog-ui/src/taskdog/tui/styles/dialogs.tcss
+++ b/packages/taskdog-ui/src/taskdog/tui/styles/dialogs.tcss
@@ -143,7 +143,11 @@ StatsScreen {
     max-height: 80%;
 }
 
-#help-content {
+#help-tabs {
+    height: 1fr;
+}
+
+.help-tab-scroll {
     padding: 1;
     margin: 0;
     overflow-y: auto;

--- a/packages/taskdog-ui/tests/tui/dialogs/test_help_dialog.py
+++ b/packages/taskdog-ui/tests/tui/dialogs/test_help_dialog.py
@@ -12,7 +12,6 @@ class TestHelpDialogClassAttributes:
 
     def test_has_vi_vertical_bindings(self) -> None:
         """Test that VI vertical navigation bindings are included."""
-        # Check that j/k bindings are present
         keys = [b.key for b in HelpDialog.BINDINGS if isinstance(b, Binding)]
         assert "j" in keys
         assert "k" in keys
@@ -35,6 +34,12 @@ class TestHelpDialogClassAttributes:
         assert q_binding.action == "cancel"
         assert "close" in q_binding.description.lower()
 
+    def test_has_tab_switch_bindings(self) -> None:
+        """Test that tab switching bindings are included."""
+        keys = [b.key for b in HelpDialog.BINDINGS if isinstance(b, Binding)]
+        assert "greater_than_sign" in keys
+        assert "less_than_sign" in keys
+
 
 class TestHelpDialogViDownAction:
     """Test cases for action_vi_down method."""
@@ -43,23 +48,18 @@ class TestHelpDialogViDownAction:
         """Test that vi_down scrolls content down by 1."""
         dialog = HelpDialog()
         mock_scroll = MagicMock()
-        dialog.query_one = MagicMock(return_value=mock_scroll)
+        dialog._get_active_scroll_widget = MagicMock(return_value=mock_scroll)
 
         dialog.action_vi_down()
 
         mock_scroll.scroll_relative.assert_called_once_with(y=1, animate=False)
 
-    def test_queries_correct_widget(self) -> None:
-        """Test that action queries the correct widget."""
-        from textual.containers import VerticalScroll
-
+    def test_does_nothing_when_no_active_scroll(self) -> None:
+        """Test that vi_down does nothing when no scroll widget is active."""
         dialog = HelpDialog()
-        mock_scroll = MagicMock()
-        dialog.query_one = MagicMock(return_value=mock_scroll)
+        dialog._get_active_scroll_widget = MagicMock(return_value=None)
 
-        dialog.action_vi_down()
-
-        dialog.query_one.assert_called_once_with("#help-content", VerticalScroll)
+        dialog.action_vi_down()  # Should not raise
 
 
 class TestHelpDialogViUpAction:
@@ -69,11 +69,18 @@ class TestHelpDialogViUpAction:
         """Test that vi_up scrolls content up by 1."""
         dialog = HelpDialog()
         mock_scroll = MagicMock()
-        dialog.query_one = MagicMock(return_value=mock_scroll)
+        dialog._get_active_scroll_widget = MagicMock(return_value=mock_scroll)
 
         dialog.action_vi_up()
 
         mock_scroll.scroll_relative.assert_called_once_with(y=-1, animate=False)
+
+    def test_does_nothing_when_no_active_scroll(self) -> None:
+        """Test that vi_up does nothing when no scroll widget is active."""
+        dialog = HelpDialog()
+        dialog._get_active_scroll_widget = MagicMock(return_value=None)
+
+        dialog.action_vi_up()  # Should not raise
 
 
 class TestHelpDialogViPageDownAction:
@@ -83,8 +90,8 @@ class TestHelpDialogViPageDownAction:
         """Test that vi_page_down scrolls by half the container height."""
         dialog = HelpDialog()
         mock_scroll = MagicMock()
-        mock_scroll.size.height = 20  # Simulate 20 rows height
-        dialog.query_one = MagicMock(return_value=mock_scroll)
+        mock_scroll.size.height = 20
+        dialog._get_active_scroll_widget = MagicMock(return_value=mock_scroll)
 
         dialog.action_vi_page_down()
 
@@ -95,11 +102,18 @@ class TestHelpDialogViPageDownAction:
         dialog = HelpDialog()
         mock_scroll = MagicMock()
         mock_scroll.size.height = 15  # 15 // 2 = 7
-        dialog.query_one = MagicMock(return_value=mock_scroll)
+        dialog._get_active_scroll_widget = MagicMock(return_value=mock_scroll)
 
         dialog.action_vi_page_down()
 
         mock_scroll.scroll_relative.assert_called_once_with(y=7, animate=False)
+
+    def test_does_nothing_when_no_active_scroll(self) -> None:
+        """Test that vi_page_down does nothing when no scroll widget is active."""
+        dialog = HelpDialog()
+        dialog._get_active_scroll_widget = MagicMock(return_value=None)
+
+        dialog.action_vi_page_down()  # Should not raise
 
 
 class TestHelpDialogViPageUpAction:
@@ -110,11 +124,18 @@ class TestHelpDialogViPageUpAction:
         dialog = HelpDialog()
         mock_scroll = MagicMock()
         mock_scroll.size.height = 20
-        dialog.query_one = MagicMock(return_value=mock_scroll)
+        dialog._get_active_scroll_widget = MagicMock(return_value=mock_scroll)
 
         dialog.action_vi_page_up()
 
         mock_scroll.scroll_relative.assert_called_once_with(y=-10, animate=False)
+
+    def test_does_nothing_when_no_active_scroll(self) -> None:
+        """Test that vi_page_up does nothing when no scroll widget is active."""
+        dialog = HelpDialog()
+        dialog._get_active_scroll_widget = MagicMock(return_value=None)
+
+        dialog.action_vi_page_up()  # Should not raise
 
 
 class TestHelpDialogViHomeAction:
@@ -124,11 +145,18 @@ class TestHelpDialogViHomeAction:
         """Test that vi_home scrolls to the top."""
         dialog = HelpDialog()
         mock_scroll = MagicMock()
-        dialog.query_one = MagicMock(return_value=mock_scroll)
+        dialog._get_active_scroll_widget = MagicMock(return_value=mock_scroll)
 
         dialog.action_vi_home()
 
         mock_scroll.scroll_home.assert_called_once_with(animate=False)
+
+    def test_does_nothing_when_no_active_scroll(self) -> None:
+        """Test that vi_home does nothing when no scroll widget is active."""
+        dialog = HelpDialog()
+        dialog._get_active_scroll_widget = MagicMock(return_value=None)
+
+        dialog.action_vi_home()  # Should not raise
 
 
 class TestHelpDialogViEndAction:
@@ -138,11 +166,18 @@ class TestHelpDialogViEndAction:
         """Test that vi_end scrolls to the bottom."""
         dialog = HelpDialog()
         mock_scroll = MagicMock()
-        dialog.query_one = MagicMock(return_value=mock_scroll)
+        dialog._get_active_scroll_widget = MagicMock(return_value=mock_scroll)
 
         dialog.action_vi_end()
 
         mock_scroll.scroll_end.assert_called_once_with(animate=False)
+
+    def test_does_nothing_when_no_active_scroll(self) -> None:
+        """Test that vi_end does nothing when no scroll widget is active."""
+        dialog = HelpDialog()
+        dialog._get_active_scroll_widget = MagicMock(return_value=None)
+
+        dialog.action_vi_end()  # Should not raise
 
 
 class TestHelpDialogInheritance:
@@ -159,3 +194,126 @@ class TestHelpDialogInheritance:
         from taskdog.tui.widgets.vi_navigation_mixin import ViNavigationMixin
 
         assert issubclass(HelpDialog, ViNavigationMixin)
+
+    def test_does_not_inherit_from_scrollable_dialog_base(self) -> None:
+        """Test that HelpDialog no longer inherits from ScrollableDialogBase."""
+        from taskdog.tui.dialogs.scrollable_dialog import ScrollableDialogBase
+
+        assert not issubclass(HelpDialog, ScrollableDialogBase)
+
+
+class TestHelpDialogGetActiveScrollWidget:
+    """Test cases for _get_active_scroll_widget method."""
+
+    def test_returns_none_when_tabs_not_found(self) -> None:
+        """Test that None is returned when TabbedContent is not found."""
+        from textual.css.query import NoMatches
+
+        dialog = HelpDialog()
+        dialog.query_one = MagicMock(side_effect=NoMatches())
+
+        result = dialog._get_active_scroll_widget()
+
+        assert result is None
+
+    def test_returns_none_for_unknown_tab(self) -> None:
+        """Test that None is returned for an unknown tab pane ID."""
+        dialog = HelpDialog()
+        mock_tabs = MagicMock()
+        mock_tabs.active = "tab-unknown"
+        dialog.query_one = MagicMock(return_value=mock_tabs)
+
+        result = dialog._get_active_scroll_widget()
+
+        assert result is None
+
+    def test_returns_scroll_widget_for_active_tab(self) -> None:
+        """Test that the correct scroll widget is returned for active tab."""
+        from textual.containers import VerticalScroll
+
+        dialog = HelpDialog()
+        mock_tabs = MagicMock()
+        mock_tabs.active = "tab-getting-started"
+        mock_scroll = MagicMock(spec=VerticalScroll)
+
+        def mock_query_one(selector: str, widget_type: type | None = None) -> MagicMock:
+            if selector == "#help-tabs":
+                return mock_tabs
+            if selector == "#help-getting-started-scroll":
+                return mock_scroll
+            raise Exception(f"Unexpected selector: {selector}")
+
+        dialog.query_one = MagicMock(side_effect=mock_query_one)
+
+        result = dialog._get_active_scroll_widget()
+
+        assert result is mock_scroll
+
+    def test_returns_none_when_scroll_widget_not_found(self) -> None:
+        """Test that None is returned when scroll widget raises NoMatches."""
+        from textual.css.query import NoMatches
+
+        dialog = HelpDialog()
+        mock_tabs = MagicMock()
+        mock_tabs.active = "tab-features"
+
+        call_count = 0
+
+        def mock_query_one(selector: str, widget_type: type | None = None) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:  # First call: TabbedContent
+                return mock_tabs
+            raise NoMatches()  # Second call: scroll widget not found
+
+        dialog.query_one = MagicMock(side_effect=mock_query_one)
+
+        result = dialog._get_active_scroll_widget()
+
+        assert result is None
+
+
+class TestHelpDialogTabSwitchActions:
+    """Test cases for tab switching actions."""
+
+    def test_action_next_tab(self) -> None:
+        """Test that action_next_tab calls Tabs.action_next_tab."""
+        dialog = HelpDialog()
+        mock_tabs_widget = MagicMock()
+        mock_tabbed_content = MagicMock()
+        mock_tabbed_content.query_one.return_value = mock_tabs_widget
+        dialog.query_one = MagicMock(return_value=mock_tabbed_content)
+
+        dialog.action_next_tab()
+
+        mock_tabs_widget.action_next_tab.assert_called_once()
+
+    def test_action_prev_tab(self) -> None:
+        """Test that action_prev_tab calls Tabs.action_previous_tab."""
+        dialog = HelpDialog()
+        mock_tabs_widget = MagicMock()
+        mock_tabbed_content = MagicMock()
+        mock_tabbed_content.query_one.return_value = mock_tabs_widget
+        dialog.query_one = MagicMock(return_value=mock_tabbed_content)
+
+        dialog.action_prev_tab()
+
+        mock_tabs_widget.action_previous_tab.assert_called_once()
+
+    def test_action_next_tab_does_nothing_when_no_tabs(self) -> None:
+        """Test that action_next_tab does nothing when TabbedContent not found."""
+        from textual.css.query import NoMatches
+
+        dialog = HelpDialog()
+        dialog.query_one = MagicMock(side_effect=NoMatches())
+
+        dialog.action_next_tab()  # Should not raise
+
+    def test_action_prev_tab_does_nothing_when_no_tabs(self) -> None:
+        """Test that action_prev_tab does nothing when TabbedContent not found."""
+        from textual.css.query import NoMatches
+
+        dialog = HelpDialog()
+        dialog.query_one = MagicMock(side_effect=NoMatches())
+
+        dialog.action_prev_tab()  # Should not raise


### PR DESCRIPTION
## Summary
- Reorganize HelpDialog from a single long scrollable view into 3 tabs (Getting Started, Features, Tips) using the same `TabbedContent` pattern established in StatsScreen
- Move Notes tab to the first position in TaskDetailDialog for quicker access
- Add `>` / `<` keybindings for tab switching in HelpDialog

## Changes
- **`help_dialog.py`**: Change inheritance from `ScrollableDialogBase` to `BaseModalDialog + ViNavigationMixin`, add `TabbedContent` with 3 `TabPane`s, implement `_get_active_scroll_widget()` delegation pattern for Vi navigation
- **`task_detail_dialog.py`**: Reorder tabs so Notes appears first (before Detail and Audit Log)
- **`dialogs.tcss`**: Replace `#help-content` rule with `#help-tabs` + `.help-tab-scroll` styles
- **`test_help_dialog.py`**: Update Vi navigation tests to mock `_get_active_scroll_widget`, add no-scroll safety tests, tab switching tests, and `_get_active_scroll_widget` unit tests

## Test plan
- [x] `make test-ui` — 917 tests pass
- [x] `make lint` — clean
- [x] `make typecheck` — no new errors
- [ ] Manual: open TUI, `Ctrl+P` → Help, verify 3 tabs render, `>` / `<` switch tabs, `j` / `k` scroll
- [ ] Manual: open task detail (`i`), verify Notes tab is first


🤖 Generated with [Claude Code](https://claude.com/claude-code)