### PR TITLE
feat(ui): convert audit log in detail dialog from cards to DataTable

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/task_detail_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/task_detail_dialog.py
@@ -13,7 +13,7 @@ from textual.widgets import Label, Markdown, Static, TabbedContent, TabPane, Tab
 from taskdog.constants.colors import STATUS_COLORS_BOLD
 from taskdog.formatters.date_time_formatter import DateTimeFormatter
 from taskdog.tui.dialogs.base_dialog import BaseModalDialog
-from taskdog.tui.widgets.audit_log_entry_builder import create_audit_entry_widget
+from taskdog.tui.widgets.audit_log_entry_builder import create_audit_log_table
 from taskdog.tui.widgets.vi_navigation_mixin import ViNavigationMixin
 from taskdog_core.application.dto.task_detail_output import TaskDetailOutput
 from taskdog_core.application.dto.task_dto import TaskDetailDto
@@ -372,9 +372,8 @@ class TaskDetailDialog(BaseModalDialog[tuple[str, int] | None], ViNavigationMixi
             )
             return
 
-        for log in result.logs:
-            entry = create_audit_entry_widget(log)
-            scroll.mount(entry)
+        table = create_audit_log_table(result.logs)
+        scroll.mount(table)
 
     def _show_audit_error(self, message: str) -> None:
         """Show an error message in the audit tab."""

--- a/packages/taskdog-ui/src/taskdog/tui/styles/dialogs.tcss
+++ b/packages/taskdog-ui/src/taskdog/tui/styles/dialogs.tcss
@@ -138,6 +138,12 @@ StatsScreen {
     max-height: 80%;
 }
 
+/* Audit log DataTable in detail dialog */
+#audit-log-table {
+    height: auto;
+    border: none;
+}
+
 /* Help Screen */
 #help-screen {
     max-height: 80%;


### PR DESCRIPTION
## Summary

- Replace individual bordered card widgets with a compact `DataTable` for audit log entries in the task detail dialog
- Add `create_audit_log_table()` builder function alongside existing `create_audit_entry_widget()` (still used by sidebar panel)
- Columns: Timestamp, Operation, Changes, Client, Status — resource info omitted since the detail dialog already shows it

## Test plan

- [x] `make test-ui` — 917 passed
- [x] `make lint` — all checks passed
- [x] `make typecheck` (UI package) — no issues
- [ ] `taskdog tui` → select task → `i` → Audit Log tab: verify table layout renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)