### PR TITLE
refactor(ui): rename StatsScreen to StatsDialog and fix stats rendering

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/commands/stats.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/stats.py
@@ -1,13 +1,13 @@
 """Statistics command for TUI."""
 
 from taskdog.tui.commands.base import TUICommandBase
-from taskdog.tui.screens.stats_screen import StatsScreen
+from taskdog.tui.dialogs.stats_dialog import StatsDialog
 
 
 class StatsCommand(TUICommandBase):
-    """Command to show task statistics in a modal screen."""
+    """Command to show task statistics in a modal dialog."""
 
     def execute_impl(self) -> None:
         """Execute the statistics command."""
-        stats_screen = StatsScreen(api_client=self.context.api_client)
-        self.app.push_screen(stats_screen)
+        stats_dialog = StatsDialog(api_client=self.context.api_client)
+        self.app.push_screen(stats_dialog)

--- a/packages/taskdog-ui/src/taskdog/tui/styles/dialogs.tcss
+++ b/packages/taskdog-ui/src/taskdog/tui/styles/dialogs.tcss
@@ -12,7 +12,7 @@ TaskFormDialog,
 TaskDetailDialog,
 FixActualDialog,
 HelpDialog,
-StatsScreen {
+StatsDialog {
     align: center middle;
 }
 
@@ -177,11 +177,11 @@ StatsScreen {
 }
 
 /* =============================================================================
-   Statistics Screen
+   Statistics Dialog
    ============================================================================= */
 
 /* Stats Screen Container */
-#stats-screen {
+#stats-dialog {
     max-height: 80%;
 }
 
@@ -196,6 +196,7 @@ StatsScreen {
 }
 
 .stats-section {
+    height: auto;
     padding: 0 1;
     margin-bottom: 1;
 }


### PR DESCRIPTION
## Summary
- `StatsScreen` → `StatsDialog` にリネームし `screens/` → `dialogs/` に移動（HelpDialog, TaskDetailDialog との一貫性）
- `.stats-section` に `height: auto` を追加し、All タブで統計行がクリップされるバグを修正
- `_load_period` にガードを追加し、`on_mount` + `on_tabbed_content_tab_activated` による二重ワーカー起動を防止

## Test plan
- [x] `make lint` passed
- [x] `make typecheck-taskdog-ui` passed (0 issues in 170 files)
- [x] `make test-ui` passed (917 tests)
- [x] TUI の Stats ダイアログ All タブで全セクション（Basic, Time, Estimation, Deadline, Priority, Trends）が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)