### PR TITLE
perf: move unit tests from pre-commit to pre-push stage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,5 +66,5 @@ repos:
         entry: make test
         language: system
         pass_filenames: false
-        stages: [pre-commit]
+        stages: [pre-push]
         types_or: [python]


### PR DESCRIPTION
## Summary

- Move the full test suite (`make test`) from `pre-commit` to `pre-push` stage in `.pre-commit-config.yaml`
- Commits are now fast (only linting, formatting, and type checking run)
- Tests still run before code reaches CI, catching issues at push time

## Test plan

- [ ] Verify `git commit` no longer runs the full test suite
- [ ] Verify `git push` triggers `make test`
- [ ] Verify CI pipeline still runs all tests on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)