### PR TITLE
fix(ui): fix g/G keybindings in audit log screen

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/widgets/audit_log_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/audit_log_table.py
@@ -33,8 +33,8 @@ class AuditLogTable(DataTable, TUIWidget, ViNavigationMixin):  # type: ignore[ty
     BINDINGS: ClassVar = [
         Binding("j", "scroll_down", "Down", show=False),
         Binding("k", "scroll_up", "Up", show=False),
-        Binding("g", "scroll_home", "Top", show=False),
-        Binding("G", "scroll_end", "Bottom", show=False),
+        Binding("g", "goto_top", "Top", show=False),
+        Binding("G", "goto_bottom", "Bottom", show=False),
         Binding("ctrl+d", "page_down", "Page Down", show=False),
         Binding("ctrl+u", "page_up", "Page Up", show=False),
     ]
@@ -44,6 +44,14 @@ class AuditLogTable(DataTable, TUIWidget, ViNavigationMixin):  # type: ignore[ty
         super().__init__(**kwargs)
         self.cursor_type = "none"
         self.zebra_stripes = True
+
+    def action_goto_top(self) -> None:
+        """Scroll to the top of the table."""
+        self.scroll_home(animate=False)
+
+    def action_goto_bottom(self) -> None:
+        """Scroll to the bottom of the table."""
+        self.scroll_end(animate=False)
 
     def on_mount(self) -> None:
         """Set up table columns."""


### PR DESCRIPTION
## Summary
- Fix `g`/`G` Vi-style keybindings in the audit log screen that were non-functional
- DataTable overrides `action_scroll_home`/`action_scroll_end` for horizontal cursor movement, which becomes a no-op when `cursor_type="none"`
- Use custom `action_goto_top`/`action_goto_bottom` methods that call Widget-level `scroll_home`/`scroll_end` directly

## Test plan
- [x] Open TUI audit log screen with enough entries to scroll
- [x] Press `g` to verify scrolling to the top
- [x] Press `G` to verify scrolling to the bottom
- [x] Verify `j`/`k`/`Ctrl+d`/`Ctrl+u` still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)