### PR TITLE
refactor(server): remove --workers option from taskdog-server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,6 @@ cd packages/taskdog-server && PYTHONPATH=src uv run python -m taskdog_server.mai
 taskdog-server                   # Start on default 127.0.0.1:8000
 taskdog-server --host 0.0.0.0 --port 3000  # Custom host/port
 taskdog-server --reload          # Auto-reload for development
-taskdog-server --workers 4       # Production with multiple workers
 # API docs: http://localhost:8000/docs
 # Health check: http://localhost:8000/health
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,5 +65,4 @@ ENV TERM=xterm-256color
 ENV COLORTERM=truecolor
 
 # Start taskdog-server
-# Note: --workers 1 is required for WebSocket real-time sync
-ENTRYPOINT ["taskdog-server", "--host", "0.0.0.0", "--port", "8000", "--workers", "1"]
+ENTRYPOINT ["taskdog-server", "--host", "0.0.0.0", "--port", "8000"]

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -4,10 +4,10 @@ This directory contains deployment configurations and infrastructure files for r
 
 ## Contents
 
-| Directory | Description | Platform |
-|-----------|-------------|----------|
-| [systemd/](systemd/) | Systemd user service | Linux |
-| [launchd/](launchd/) | Launchd property list | macOS |
+| Directory            | Description           | Platform |
+|----------------------|-----------------------|----------|
+| [systemd/](systemd/) | Systemd user service  | Linux    |
+| [launchd/](launchd/) | Launchd property list | macOS    |
 
 Docker files (`Dockerfile`, `docker-compose.yaml`, `.env.example`) are located at the repository root for convenience.
 
@@ -204,15 +204,12 @@ The default service configuration:
 
 - **Host**: 127.0.0.1 (local only)
 - **Port**: 8000
-- **Workers**: 1 (required for WebSocket real-time sync)
 - **Auto-restart**: Yes (on failure)
 - **Data directory**: `~/.local/share/taskdog/`
 
-**Note**: WebSocket real-time synchronization requires `--workers 1`. Multiple workers are not supported yet due to lack of inter-process communication (would require Redis Pub/Sub or similar).
-
 #### Customizing the Service
 
-To customize the service (host, port, workers, etc.), edit the service file:
+To customize the service (host, port, etc.), edit the service file:
 
 ```bash
 # Edit the service file
@@ -230,21 +227,13 @@ Example modifications:
 **Change host and port (listen on all interfaces):**
 
 ```ini
-ExecStart=%h/.local/bin/taskdog-server --host 0.0.0.0 --port 9000 --workers 1
+ExecStart=%h/.local/bin/taskdog-server --host 0.0.0.0 --port 9000
 ```
 
 **Enable development mode with auto-reload:**
 
 ```ini
 ExecStart=%h/.local/bin/taskdog-server --host 127.0.0.1 --port 8000 --reload
-```
-
-**WARNING: Multiple workers not supported with WebSocket**
-
-```ini
-# This will NOT work for WebSocket real-time sync:
-# ExecStart=%h/.local/bin/taskdog-server --host 127.0.0.1 --port 8000 --workers 4
-# Use --workers 1 for WebSocket support
 ```
 
 ### Troubleshooting

--- a/contrib/launchd/taskdog-server.plist
+++ b/contrib/launchd/taskdog-server.plist
@@ -12,8 +12,6 @@
         <string>127.0.0.1</string>
         <string>--port</string>
         <string>8000</string>
-        <string>--workers</string>
-        <string>1</string>
     </array>
 
     <key>RunAtLoad</key>

--- a/contrib/systemd/taskdog-server.service
+++ b/contrib/systemd/taskdog-server.service
@@ -5,7 +5,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=%h/.local/bin/taskdog-server --host 127.0.0.1 --port 8000 --workers 1
+ExecStart=%h/.local/bin/taskdog-server --host 127.0.0.1 --port 8000
 Restart=always
 RestartSec=5
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -29,7 +29,6 @@ taskdog-server                           # Default: http://127.0.0.1:8000
 taskdog-server --host 0.0.0.0            # Bind to all interfaces
 taskdog-server --port 3000               # Custom port
 taskdog-server --reload                  # Auto-reload for development
-taskdog-server --workers 4               # Production with multiple workers
 ```
 
 ### Interactive Documentation

--- a/packages/taskdog-server/README.md
+++ b/packages/taskdog-server/README.md
@@ -37,7 +37,7 @@ taskdog-server
 With custom options:
 
 ```bash
-taskdog-server --host 0.0.0.0 --port 3000 --workers 4
+taskdog-server --host 0.0.0.0 --port 3000
 ```
 
 Development mode with auto-reload:
@@ -98,7 +98,7 @@ ws.onmessage = (event) => {
 - `task_status_changed` - Task status changed
 - `schedule_optimized` - Schedule optimization completed
 
-**Note:** WebSocket requires `--workers 1` (default). Multiple workers are not supported for WebSocket.
+**Note:** WebSocket uses an in-memory connection manager, so the server always runs as a single process.
 
 ## Configuration
 

--- a/packages/taskdog-server/src/taskdog_server/main.py
+++ b/packages/taskdog-server/src/taskdog_server/main.py
@@ -17,7 +17,6 @@ Examples:
   taskdog-server --host 0.0.0.0         # Listen on all interfaces
   taskdog-server --port 3000            # Use custom port
   taskdog-server --reload               # Enable auto-reload for dev
-  taskdog-server --workers 4            # Use 4 worker processes
 
 The API will be available at:
   - Root: http://{host}:{port}/
@@ -46,13 +45,6 @@ The API will be available at:
         action="store_true",
         help="Enable auto-reload for development",
     )
-    parser.add_argument(
-        "--workers",
-        type=int,
-        default=1,
-        help="Number of worker processes (default: 1)",
-    )
-
     args = parser.parse_args()
 
     try:
@@ -69,18 +61,11 @@ The API will be available at:
     print(f"Health check: http://{args.host}:{args.port}/health")
     print()
 
-    if args.reload and args.workers > 1:
-        print(
-            "Warning: --reload and --workers cannot be used together. Using --reload only."
-        )
-        args.workers = 1
-
     uvicorn.run(
         "taskdog_server.api.app:app",
         host=args.host,
         port=args.port,
         reload=args.reload,
-        workers=args.workers,
         log_level="info",
     )
 


### PR DESCRIPTION
## Summary

- Remove the `--workers` CLI option from `taskdog-server` and all references across the codebase
- WebSocket broadcasts use an in-memory `ConnectionManager`, so multiple workers would silently break real-time sync
- Since taskdog is a personal tool, multiple workers are unnecessary — removing the option eliminates this footgun

## Changed files

- `packages/taskdog-server/src/taskdog_server/main.py` — remove `--workers` argument, epilog example, reload/workers conflict check, and `workers=` param from `uvicorn.run()`
- `Dockerfile` — remove `--workers 1` from ENTRYPOINT and associated comment
- `contrib/systemd/taskdog-server.service` — remove `--workers 1` from ExecStart
- `contrib/launchd/taskdog-server.plist` — remove `--workers` / `1` entries
- `CLAUDE.md` — remove `--workers 4` example
- `contrib/README.md` — remove workers config, notes, warnings, and examples
- `packages/taskdog-server/README.md` — remove `--workers 4` example, update WebSocket note
- `docs/API.md` — remove `--workers 4` example

## Test plan

- [x] `taskdog-server --help` no longer shows `--workers`
- [x] `make lint` passes
- [x] `make typecheck` passes (pre-existing error in `base_repository.py` unrelated)
- [x] All pre-commit hooks pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)