### PR TITLE
refactor(core): delegate is_schedulable() to get_unschedulable_reason()

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/domain/entities/task.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/entities/task.py
@@ -198,29 +198,7 @@ class Task:
             - Must not be fixed (always protected, even with force_override)
             - If force_override is False, must not have existing schedule
         """
-        # Skip archived tasks
-        if self.is_archived:
-            return False
-
-        # Skip finished tasks
-        if self.is_finished:
-            return False
-
-        # Skip IN_PROGRESS tasks (don't reschedule tasks already being worked on)
-        if self.status == TaskStatus.IN_PROGRESS:
-            return False
-
-        # Skip tasks without estimated duration
-        if not self.estimated_duration:
-            return False
-
-        # Skip fixed tasks (always, even with force_override)
-        # Fixed tasks represent immovable constraints (meetings, deadlines, etc.)
-        if self.is_fixed:
-            return False
-
-        # Allow scheduling if no existing schedule OR if force_override is True
-        return not (self.planned_start and not force_override)
+        return self.get_unschedulable_reason(force_override) is None
 
     def get_unschedulable_reason(self, force_override: bool = False) -> str | None:
         """Get the reason why a task is not schedulable.
@@ -230,10 +208,6 @@ class Task:
 
         Returns:
             Human-readable reason if task is not schedulable, None if schedulable
-
-        Note:
-            This method mirrors the logic in is_schedulable() to provide
-            detailed feedback for validation errors.
         """
         if self.is_archived:
             return "Task is archived"


### PR DESCRIPTION
## Summary

- Eliminate duplicated scheduling logic in `Task` entity by having `is_schedulable()` delegate to `get_unschedulable_reason() is None` instead of maintaining parallel condition checks
- Removes 26 lines of duplicated code (identical conditions checked in both methods) and establishes `get_unschedulable_reason()` as the single source of truth for schedulability logic

## Test plan

- [x] All 1097 core tests pass
- [x] Coverage remains at 93.40%
- [x] Pre-commit hooks (ruff, mypy, format) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)