### PR TITLE
fix: sync uv.lock after version bump

### DIFF
--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -9,6 +9,7 @@ Usage:
 
 import argparse
 import re
+import subprocess
 import sys
 import tomllib
 from pathlib import Path
@@ -159,6 +160,20 @@ def bump_version(new_version: str, dry_run: bool) -> int:
                     print(f"  - {problem}")
                 return 1
             print("Verification passed - no old version references found.")
+
+        # Sync uv.lock with updated pyproject.toml versions
+        print()
+        print("Syncing uv.lock...")
+        result = subprocess.run(
+            ["uv", "lock"],
+            cwd=ROOT_DIR,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            print(f"ERROR: uv lock failed:\n{result.stderr}")
+            return 1
+        print("uv.lock updated.")
 
     return 0
 


### PR DESCRIPTION
## Summary
- Run `uv lock` at the end of `bump_version.py` to keep `uv.lock` in sync with updated `pyproject.toml` versions
- Without this, `uv run` regenerates the lockfile on next invocation, producing unexpected diffs and failing pre-push hooks

## Test plan
- [x] Run `make bump-version VERSION=x.y.z --dry-run` and verify `uv lock` is NOT executed
- [x] Run `make bump-version VERSION=x.y.z` and verify `uv.lock` is updated with new versions
- [x] Verify no unstaged `uv.lock` diff remains after bumping

🤖 Generated with [Claude Code](https://claude.com/claude-code)