### PR TITLE
chore: auto-install pre-commit hooks via make install-dev

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,3 +68,10 @@ repos:
         pass_filenames: false
         stages: [pre-push]
         types_or: [python]
+      - id: reinstall-hooks
+        name: Install pre-commit hooks
+        entry: uv run pre-commit install --install-hooks
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages: [post-merge]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,9 @@ cd taskdog
 make install-dev
 ```
 
-This installs all packages with development dependencies in editable mode.
+This installs all packages with development dependencies in editable mode and
+automatically sets up pre-commit hooks (`pre-commit`, `commit-msg`, `pre-push`,
+`post-merge`) via `uv run pre-commit install`.
 
 3. **Verify installation:**
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help test test-core test-server test-ui test-client test-mcp test-all \
-        install install-dev install-core install-server install-ui install-client install-mcp \
+        install install-dev install-hooks install-core install-server install-ui install-client install-mcp \
         install-ui-only install-server-only reinstall \
         tool-install-ui tool-install-server check-deps \
         clean lint format typecheck check \
@@ -126,9 +126,16 @@ install-dev: ## Install all packages with development dependencies (for developm
 	cd packages/taskdog-server && uv pip install -e ".[dev]"
 	cd packages/taskdog-ui && uv pip install -e ".[dev]"
 	cd packages/taskdog-mcp && uv pip install -e ".[dev]"
+	$(MAKE) install-hooks
 	@echo ""
 	@echo "✓ Development environment ready!"
 	@echo ""
+
+install-hooks: ## Install pre-commit hooks via uv
+	uv run pre-commit install --install-hooks
+	uv run pre-commit install --hook-type commit-msg
+	uv run pre-commit install --hook-type pre-push
+	uv run pre-commit install --hook-type post-merge
 
 install-core: ## Install taskdog-core package only (for development)
 	@echo "Installing taskdog-core..."


### PR DESCRIPTION
## Summary

Closes #674

- Add `install-hooks` Makefile target that installs all pre-commit hook types (`pre-commit`, `commit-msg`, `pre-push`, `post-merge`) via `uv run pre-commit install`, ensuring `INSTALL_PYTHON` in generated hook scripts points to the uv venv Python instead of system Python
- Call `install-hooks` from `install-dev` so developers get hooks set up automatically without manual steps
- Add a `post-merge` local hook in `.pre-commit-config.yaml` that re-runs `pre-commit install --install-hooks` after `git pull`, keeping hook environments in sync when the config changes

## Test plan

- [ ] Run `make install-hooks` and verify all four hook files exist in `.git/hooks/`
- [ ] Confirm `INSTALL_PYTHON` in `.git/hooks/pre-commit` points to the uv venv Python (`.venv/bin/python3`), not `/usr/bin/python`
- [ ] Run `make install-dev` and verify hooks are installed as part of the process
- [ ] Make a commit and verify pre-commit hooks run successfully via uv

🤖 Generated with [Claude Code](https://claude.com/claude-code)