### PR TITLE
refactor: enable strict mypy checking for server API modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,8 +153,8 @@ journalctl --user -u taskdog-server -f   # View logs in real-time
 
 **Type Checking:**
 
-- Mypy configured with progressive type checking (Phase 4)
-- Some modules temporarily ignored (see pyproject.toml `[[tool.mypy.overrides]]`)
+- Mypy configured with progressive type checking (Phase 4) - strict checking on all production code
+- Only `tests.*` excluded from `disallow_untyped_defs` (intentional flexibility for test code)
 - Run `make typecheck` before committing
 
 **Import Conventions:**

--- a/packages/taskdog-server/src/taskdog_server/api/models/responses.py
+++ b/packages/taskdog-server/src/taskdog_server/api/models/responses.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -412,8 +412,8 @@ class AuditLogResponse(BaseModel):
     resource_type: str
     resource_id: int | None = None
     resource_name: str | None = None
-    old_values: dict | None = None
-    new_values: dict | None = None
+    old_values: dict[str, Any] | None = None
+    new_values: dict[str, Any] | None = None
     success: bool
     error_message: str | None = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,13 +64,6 @@ show_error_context = true
 module = "tests.*"
 disallow_untyped_defs = false
 
-[[tool.mypy.overrides]]
-module = ["taskdog_server.api.*", "taskdog_server.main", "taskdog.shared.server_manager"]
-disallow_untyped_defs = false
-disallow_any_generics = false
-disallow_untyped_calls = false
-check_untyped_defs = false
-
 # Ignore third-party library without type stubs
 [[tool.mypy.overrides]]
 module = "textual.*"


### PR DESCRIPTION
## Summary

- Remove the `[[tool.mypy.overrides]]` block that exempted `taskdog_server.api.*`, `taskdog_server.main`, and `taskdog.shared.server_manager` from strict type checking
- Fix the only 2 type errors found: add generic params to `dict` fields in `AuditLogResponse` (`dict` → `dict[str, Any]`)
- Clean up stale `taskdog.shared.server_manager` exclusion (module was already deleted)
- Update CLAUDE.md to reflect that all production code now has strict mypy checking

All 412 source files now pass mypy with full Phase 4 strictness. The only remaining override is `tests.*` (intentional flexibility for test code).

## Test plan

- [x] `make typecheck` passes across all 5 packages (412 files, 0 errors)
- [x] `make test-server` passes (285 tests, 89.29% coverage)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)