### PR TITLE
refactor: enable ruff PIE rule and remove unnecessary pass statements

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/queries/filters/task_filter.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/filters/task_filter.py
@@ -29,7 +29,6 @@ class TaskFilter(ABC):
         Returns:
             Filtered list of tasks matching the criteria
         """
-        pass
 
     def __rshift__(self, other: TaskFilter | None) -> TaskFilter:
         """Compose filters using the >> operator.

--- a/packages/taskdog-core/src/taskdog_core/application/queries/workload/_strategies/base.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/workload/_strategies/base.py
@@ -66,7 +66,6 @@ class WorkloadCalculationStrategy(ABC):
             Dictionary mapping date to hours {date: hours}.
             Empty dict if task is missing required fields.
         """
-        pass
 
     def is_working_day(self, check_date: date) -> bool:
         """Check if a date is a working day (weekday and not a holiday).

--- a/packages/taskdog-core/src/taskdog_core/application/services/optimization/optimization_strategy.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/optimization/optimization_strategy.py
@@ -53,4 +53,3 @@ class OptimizationStrategy(ABC):
         Returns:
             OptimizeResult containing modified tasks, daily allocations, and failures
         """
-        pass

--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/base.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/base.py
@@ -40,7 +40,6 @@ class UseCase[TInput, TOutput](ABC):
         Raises:
             Domain-specific exceptions as needed
         """
-        pass
 
     def _get_task_or_raise(self, repository: "TaskRepository", task_id: int) -> "Task":
         """Get task by ID or raise TaskNotFoundException.

--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/status_change_use_case.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/status_change_use_case.py
@@ -97,7 +97,6 @@ class StatusChangeUseCase[TInput: SingleTaskInput](
         Returns:
             The target TaskStatus (e.g., IN_PROGRESS, COMPLETED, CANCELED)
         """
-        pass
 
     def _should_validate(self) -> bool:
         """Determine if validation should be performed.
@@ -119,7 +118,6 @@ class StatusChangeUseCase[TInput: SingleTaskInput](
         Args:
             task: Task that will be updated
         """
-        pass
 
     def _after_status_change(self, task: Task) -> None:
         """Hook for post-processing after status change.
@@ -130,4 +128,3 @@ class StatusChangeUseCase[TInput: SingleTaskInput](
         Args:
             task: Task that was updated
         """
-        pass

--- a/packages/taskdog-core/src/taskdog_core/application/validators/field_validator.py
+++ b/packages/taskdog-core/src/taskdog_core/application/validators/field_validator.py
@@ -26,4 +26,3 @@ class FieldValidator(ABC):
         Raises:
             TaskValidationError: If validation fails
         """
-        pass

--- a/packages/taskdog-core/src/taskdog_core/domain/exceptions/task_exceptions.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/exceptions/task_exceptions.py
@@ -4,8 +4,6 @@
 class TaskError(Exception):
     """Base exception for all task-related errors."""
 
-    pass
-
 
 class TaskNotFoundException(TaskError):
     """Raised when a task with given ID is not found."""
@@ -23,8 +21,6 @@ class TaskNotFoundException(TaskError):
 
 class TaskValidationError(TaskError):
     """Raised when task validation fails."""
-
-    pass
 
 
 class TaskAlreadyFinishedError(TaskValidationError):

--- a/packages/taskdog-core/src/taskdog_core/domain/repositories/audit_log_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/repositories/audit_log_repository.py
@@ -29,7 +29,6 @@ class AuditLogRepository(ABC):
         Args:
             event: The audit event to save
         """
-        pass
 
     @abstractmethod
     def get_logs(self, query: AuditQuery) -> AuditLogListOutput:
@@ -41,7 +40,6 @@ class AuditLogRepository(ABC):
         Returns:
             AuditLogListOutput containing logs and pagination info
         """
-        pass
 
     @abstractmethod
     def get_by_id(self, log_id: int) -> AuditLogOutput | None:
@@ -53,7 +51,6 @@ class AuditLogRepository(ABC):
         Returns:
             The audit log if found, None otherwise
         """
-        pass
 
     @abstractmethod
     def count_logs(self, query: AuditQuery) -> int:
@@ -65,4 +62,3 @@ class AuditLogRepository(ABC):
         Returns:
             Number of logs matching the query
         """
-        pass

--- a/packages/taskdog-core/src/taskdog_core/domain/repositories/notes_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/repositories/notes_repository.py
@@ -25,7 +25,6 @@ class NotesRepository(ABC):
         Returns:
             True if notes exist and have content
         """
-        pass
 
     @abstractmethod
     def read_notes(self, task_id: int) -> str | None:
@@ -37,7 +36,6 @@ class NotesRepository(ABC):
         Returns:
             Notes content as string, or None if not found or reading fails
         """
-        pass
 
     @abstractmethod
     def write_notes(self, task_id: int, content: str) -> None:
@@ -50,7 +48,6 @@ class NotesRepository(ABC):
         Raises:
             OSError: If writing fails
         """
-        pass
 
     @abstractmethod
     def ensure_notes_dir(self) -> None:
@@ -58,7 +55,6 @@ class NotesRepository(ABC):
 
         Creates necessary storage structure if it doesn't exist.
         """
-        pass
 
     @abstractmethod
     def delete_notes(self, task_id: int) -> None:
@@ -70,7 +66,6 @@ class NotesRepository(ABC):
         Note:
             Should not raise error if notes don't exist (idempotent operation)
         """
-        pass
 
     @abstractmethod
     def get_task_ids_with_notes(self, task_ids: list[int]) -> set[int]:
@@ -85,4 +80,3 @@ class NotesRepository(ABC):
         Returns:
             Set of task IDs that have notes
         """
-        pass

--- a/packages/taskdog-core/src/taskdog_core/domain/repositories/task_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/repositories/task_repository.py
@@ -15,7 +15,6 @@ class TaskRepository(ABC):
         Returns:
             List of all tasks
         """
-        pass
 
     @abstractmethod
     def get_by_id(self, task_id: int) -> Task | None:
@@ -27,7 +26,6 @@ class TaskRepository(ABC):
         Returns:
             The task if found, None otherwise
         """
-        pass
 
     @abstractmethod
     def get_by_ids(self, task_ids: list[int]) -> dict[int, Task]:
@@ -45,7 +43,6 @@ class TaskRepository(ABC):
             - Prevents N+1 query problems in database implementations
             - O(n) time complexity where n is len(task_ids)
         """
-        pass
 
     def get_filtered(
         self,
@@ -144,7 +141,6 @@ class TaskRepository(ABC):
         Args:
             task: The task to save
         """
-        pass
 
     @abstractmethod
     def save_all(self, tasks: list[Task]) -> None:
@@ -158,7 +154,6 @@ class TaskRepository(ABC):
             - More efficient than multiple save() calls
             - Implementation-specific optimization possible
         """
-        pass
 
     @abstractmethod
     def delete(self, task_id: int) -> None:
@@ -167,7 +162,6 @@ class TaskRepository(ABC):
         Args:
             task_id: The ID of the task to delete
         """
-        pass
 
     @abstractmethod
     def create(self, name: str, priority: int | None = None, **kwargs: Any) -> Task:
@@ -181,7 +175,6 @@ class TaskRepository(ABC):
         Returns:
             Created task with ID assigned
         """
-        pass
 
     def delete_tag(self, tag_name: str) -> int:
         """Delete a tag from the system by name.

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/models/task_model.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/models/task_model.py
@@ -20,8 +20,6 @@ from sqlalchemy.orm import (  # type: ignore[attr-defined]
 class Base(DeclarativeBase):
     """Base class for all ORM models."""
 
-    pass
-
 
 class TaskModel(Base):
     """SQLAlchemy ORM model for Task entity.

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_notes_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_notes_repository.py
@@ -123,7 +123,6 @@ class SqliteNotesRepository(SqliteBaseRepository, NotesRepository):
         This method exists for interface compatibility with file-based storage.
         Database storage doesn't need directory initialization.
         """
-        pass
 
     def delete_notes(self, task_id: int) -> None:
         """Delete notes for a task.

--- a/packages/taskdog-core/tests/application/use_cases/test_pause_task_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_pause_task_use_case.py
@@ -69,4 +69,3 @@ class TestPauseTaskUseCase(BaseStatusChangeUseCaseTest):
         """Override: PauseTask raises error for finished tasks, so this test is not applicable."""
         # PauseTask validates against finished tasks and raises error before any modifications
         # The base class test for this scenario is covered by test_execute_raises_error_for_finished_tasks
-        pass

--- a/packages/taskdog-core/tests/fixtures/repositories.py
+++ b/packages/taskdog-core/tests/fixtures/repositories.py
@@ -236,7 +236,6 @@ class InMemoryNotesRepository:
 
     def ensure_notes_dir(self) -> None:
         """No-op for in-memory implementation."""
-        pass
 
     def get_task_ids_with_notes(self, task_ids: list[int]) -> set[int]:
         """Get task IDs that have notes from a list of task IDs."""

--- a/packages/taskdog-ui/src/taskdog/console/console_writer.py
+++ b/packages/taskdog-ui/src/taskdog/console/console_writer.py
@@ -22,7 +22,6 @@ class ConsoleWriter(ABC):
             action: Action verb (e.g., "Added", "Started", "Completed", "Updated")
             output: Task operation output DTO
         """
-        pass
 
     @abstractmethod
     def error(self, action: str, error: Exception) -> None:
@@ -32,7 +31,6 @@ class ConsoleWriter(ABC):
             action: Action being performed (e.g., "adding task", "starting task")
             error: Exception object
         """
-        pass
 
     @abstractmethod
     def validation_error(self, message: str) -> None:
@@ -41,7 +39,6 @@ class ConsoleWriter(ABC):
         Args:
             message: Error message to display
         """
-        pass
 
     @abstractmethod
     def warning(self, message: str) -> None:
@@ -50,7 +47,6 @@ class ConsoleWriter(ABC):
         Args:
             message: Warning message to display
         """
-        pass
 
     @abstractmethod
     def info(self, message: str) -> None:
@@ -59,7 +55,6 @@ class ConsoleWriter(ABC):
         Args:
             message: Information message to display
         """
-        pass
 
     @abstractmethod
     def success(self, message: str) -> None:
@@ -68,7 +63,6 @@ class ConsoleWriter(ABC):
         Args:
             message: Success message to display
         """
-        pass
 
     @abstractmethod
     def update_success(
@@ -86,7 +80,6 @@ class ConsoleWriter(ABC):
             value: New value of the field
             format_func: Optional function to format the value for display
         """
-        pass
 
     @abstractmethod
     def print(self, message: Any = "", **kwargs: Any) -> None:
@@ -99,12 +92,10 @@ class ConsoleWriter(ABC):
             message: Message to print (str or Rich renderable)
             **kwargs: Additional formatting options (implementation-specific)
         """
-        pass
 
     @abstractmethod
     def empty_line(self) -> None:
         """Print an empty line."""
-        pass
 
     @abstractmethod
     def get_width(self) -> int:
@@ -113,7 +104,6 @@ class ConsoleWriter(ABC):
         Returns:
             Console width in characters
         """
-        pass
 
     @abstractmethod
     def task_start_time(
@@ -125,7 +115,6 @@ class ConsoleWriter(ABC):
             output: Task operation output DTO
             was_already_in_progress: Whether the task was already in progress
         """
-        pass
 
     @abstractmethod
     def task_completion_details(self, output: TaskOperationOutput) -> None:
@@ -137,7 +126,6 @@ class ConsoleWriter(ABC):
         Args:
             output: Completed task output DTO
         """
-        pass
 
     @abstractmethod
     def task_fields_updated(
@@ -149,4 +137,3 @@ class ConsoleWriter(ABC):
             output: Task operation output of the updated task
             updated_fields: List of field names that were updated
         """
-        pass

--- a/packages/taskdog-ui/src/taskdog/exporters/task_exporter.py
+++ b/packages/taskdog-ui/src/taskdog/exporters/task_exporter.py
@@ -31,7 +31,6 @@ class TaskExporter(ABC):
         Returns:
             String representation of tasks in the target format
         """
-        pass
 
     def _filter_fields(self, task_dict: dict[str, Any]) -> dict[str, Any]:
         """Filter task dictionary to include only specified fields.

--- a/packages/taskdog-ui/src/taskdog/tui/commands/base.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/base.py
@@ -65,7 +65,6 @@ class TUICommandBase(ABC):  # noqa: B024
         """
         # Default implementation for backwards compatibility
         # Subclasses should override this method
-        pass
 
     def handle_error(self, callback_fn: F) -> F:
         """Wrap a callback function with error handling.

--- a/packages/taskdog-ui/src/taskdog/tui/commands/batch_confirmation_base.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/batch_confirmation_base.py
@@ -24,7 +24,6 @@ class BatchConfirmationCommandBase(TUICommandBase):
         Returns:
             Title text for the confirmation dialog
         """
-        pass
 
     @abstractmethod
     def get_single_task_confirmation(self) -> str:
@@ -33,7 +32,6 @@ class BatchConfirmationCommandBase(TUICommandBase):
         Returns:
             Message text for confirming operation on one task
         """
-        pass
 
     @abstractmethod
     def get_multiple_tasks_confirmation_template(self) -> str:
@@ -47,7 +45,6 @@ class BatchConfirmationCommandBase(TUICommandBase):
         Example:
             "Archive {count} tasks?\\n\\nTasks will be soft-deleted..."
         """
-        pass
 
     def get_confirmation_message(self, task_count: int) -> str:
         """Return the confirmation dialog message for batch operation.
@@ -83,7 +80,6 @@ class BatchConfirmationCommandBase(TUICommandBase):
         Raises:
             Various exceptions depending on the operation
         """
-        pass
 
     def execute(self) -> None:
         """Execute batch operation with confirmation.

--- a/packages/taskdog-ui/src/taskdog/tui/commands/batch_status_change_base.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/batch_status_change_base.py
@@ -27,7 +27,6 @@ class BatchStatusChangeCommandBase(TUICommandBase):
         Returns:
             TaskOperationOutput with task details after operation
         """
-        pass
 
     def execute(self) -> None:
         """Execute status change on all selected tasks.

--- a/packages/taskdog-ui/src/taskdog/tui/events.py
+++ b/packages/taskdog-ui/src/taskdog/tui/events.py
@@ -51,8 +51,6 @@ class TasksRefreshed(Message):
     of tasks from the repository.
     """
 
-    pass
-
 
 class TaskCreated(Message):
     """Event sent when a new task is created.

--- a/packages/taskdog-ui/src/taskdog/view_models/base.py
+++ b/packages/taskdog-ui/src/taskdog/view_models/base.py
@@ -23,5 +23,3 @@ class BaseViewModel:
     2. Contain only presentation-ready data
     3. Not reference domain entities
     """
-
-    pass

--- a/packages/taskdog-ui/tests/presentation/tui/commands/test_base.py
+++ b/packages/taskdog-ui/tests/presentation/tui/commands/test_base.py
@@ -13,7 +13,6 @@ class ConcreteCommand(TUICommandBase):
 
     def execute(self) -> None:
         """Dummy execute implementation."""
-        pass
 
 
 class ConcreteCommandWithImpl(TUICommandBase):

--- a/packages/taskdog-ui/tests/tui/commands/test_batch_confirmation_base.py
+++ b/packages/taskdog-ui/tests/tui/commands/test_batch_confirmation_base.py
@@ -28,7 +28,7 @@ class ConcreteBatchConfirmCommand(BatchConfirmationCommandBase):
 
     def execute_confirmed_action(self, task_id: int) -> None:
         """Execute the action."""
-        pass  # Will be mocked
+        # Will be mocked
 
 
 class TestBatchConfirmationCommandBase:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ select = [
   "C90",  # mccabe
   "N",  # pep8-naming
   "SIM",  # simplify
+  "PIE",  # misc lints (unnecessary pass, etc.)
   "RUF",  # ruff-specific rules
 ]
 ignore = [


### PR DESCRIPTION
## Summary

- Add `PIE` (misc lints) to the ruff lint rule selection in `pyproject.toml`
- Auto-fix all 55 `PIE790` violations: unnecessary `pass` statements in abstract methods, exception classes, and empty method bodies that already have docstrings

## Changes

- 24 files changed across `taskdog-core`, `taskdog-ui`, and test files
- Net result: 60 lines removed (all `pass` statements that served no purpose)

## Test plan

- [x] `make lint` passes across all packages
- [x] `make typecheck` passes across all packages
- [x] `make test` passes (2611 tests, 0 failures)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)