### PR TITLE
refactor: enable ruff RET rule for return statement simplification

### DIFF
--- a/packages/taskdog-client/src/taskdog_client/base_client.py
+++ b/packages/taskdog-client/src/taskdog_client/base_client.py
@@ -103,18 +103,17 @@ class BaseApiClient:
         if response.status_code == 404:
             detail = response.json().get("detail", "Task not found")
             raise TaskNotFoundException(detail)
-        elif response.status_code in (400, 422):
+        if response.status_code in (400, 422):
             detail = self._extract_validation_error_detail(response)
             raise TaskValidationError(detail)
-        elif response.status_code == 401:
+        if response.status_code == 401:
             raise AuthenticationError("Authentication failed. Check your API key.")
-        elif response.status_code >= 500:
+        if response.status_code >= 500:
             detail = "Server error occurred"
             with contextlib.suppress(Exception):
                 detail = response.json().get("detail", detail)
             raise ServerError(response.status_code, detail)
-        else:
-            response.raise_for_status()
+        response.raise_for_status()
 
     def _request_json(self, method: str, *args: Any, **kwargs: Any) -> Any:
         """Execute HTTP request and return JSON response, handling errors.

--- a/packages/taskdog-core/src/taskdog_core/application/queries/filters/tag_filter.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/filters/tag_filter.py
@@ -38,8 +38,5 @@ class TagFilter(TaskFilter):
             return [
                 task for task in tasks if all(tag in task.tags for tag in self.tags)
             ]
-        else:
-            # OR logic: task must have at least one specified tag
-            return [
-                task for task in tasks if any(tag in task.tags for tag in self.tags)
-            ]
+        # OR logic: task must have at least one specified tag
+        return [task for task in tasks if any(tag in task.tags for tag in self.tags)]

--- a/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
@@ -278,7 +278,7 @@ class TaskQueryService(QueryService):
 
             if len(complex_filters) == 1:
                 return complex_filters[0]
-            elif len(complex_filters) > 1:
+            if len(complex_filters) > 1:
                 return CompositeFilter(complex_filters)
 
         return None

--- a/packages/taskdog-core/src/taskdog_core/application/queries/workload/_strategies/actual_schedule.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/workload/_strategies/actual_schedule.py
@@ -166,15 +166,14 @@ class ActualScheduleStrategy(WorkloadCalculationStrategy):
                     result[current_date] = hours_per_day
                 current_date += timedelta(days=1)
             return result
-        else:
-            # Period has only non-working days -> distribute across all days
-            total_days = (planned_end - planned_start).days + 1
-            if total_days == 0:
-                return {}
-            hours_per_day = task.estimated_duration / total_days
-            result = {}
-            current_date = planned_start
-            while current_date <= planned_end:
-                result[current_date] = hours_per_day
-                current_date += timedelta(days=1)
-            return result
+        # Period has only non-working days -> distribute across all days
+        total_days = (planned_end - planned_start).days + 1
+        if total_days == 0:
+            return {}
+        hours_per_day = task.estimated_duration / total_days
+        result = {}
+        current_date = planned_start
+        while current_date <= planned_end:
+            result[current_date] = hours_per_day
+            current_date += timedelta(days=1)
+        return result

--- a/packages/taskdog-core/src/taskdog_core/application/services/optimization/backward_optimization_strategy.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/optimization/backward_optimization_strategy.py
@@ -58,8 +58,7 @@ class BackwardOptimizationStrategy(OptimizationStrategy):
             if task.deadline:
                 days_until = (task.deadline - start_date).days
                 return (0, -days_until, task.id)
-            else:
-                return (1, 0, task.id)
+            return (1, 0, task.id)
 
         return sorted(tasks, key=deadline_key)
 

--- a/packages/taskdog-core/src/taskdog_core/application/sorters/task_sorter.py
+++ b/packages/taskdog-core/src/taskdog_core/application/sorters/task_sorter.py
@@ -61,8 +61,7 @@ class TaskSorter:
             # Priority defaults to descending (reverse=True)
             # If user passes reverse=True, we want ascending (reverse=False)
             return sorted(tasks, key=key_func, reverse=not reverse)
-        else:
-            return sorted(tasks, key=key_func, reverse=reverse)
+        return sorted(tasks, key=key_func, reverse=reverse)
 
     def _get_sort_key_function(self, sort_by: str) -> Callable[[Task], Any]:
         """Get the sort key function for the specified sort key.
@@ -76,32 +75,31 @@ class TaskSorter:
         if sort_by == "id":
             return lambda task: task.id
 
-        elif sort_by == "priority":
+        if sort_by == "priority":
             # Tasks with None priority are sorted last using tuple key
             # (0, priority) for tasks with priority, (1, 0) for tasks without
             # This ensures None-priority tasks always sort after prioritized tasks
-            return (
-                lambda task: (0, task.priority) if task.priority is not None else (1, 0)
+            return lambda task: (
+                (0, task.priority) if task.priority is not None else (1, 0)
             )
 
-        elif sort_by == "deadline":
+        if sort_by == "deadline":
             return lambda task: self._parse_date_for_sort(task.deadline)
 
-        elif sort_by == "name":
+        if sort_by == "name":
             return lambda task: task.name.lower()  # Case-insensitive sort
 
-        elif sort_by == "status":
+        if sort_by == "status":
             return lambda task: task.status.value
 
-        elif sort_by == "planned_start":
+        if sort_by == "planned_start":
             return lambda task: self._parse_date_for_sort(task.planned_start)
 
-        elif sort_by == "estimated_duration":
+        if sort_by == "estimated_duration":
             return lambda task: self._parse_numeric_for_sort(task.estimated_duration)
 
-        else:
-            # This should never happen due to validation in sort(), but required for type checking
-            raise ValueError(f"Unsupported sort_by value: {sort_by}")
+        # This should never happen due to validation in sort(), but required for type checking
+        raise ValueError(f"Unsupported sort_by value: {sort_by}")
 
     def _parse_date_for_sort(self, dt: datetime | None) -> datetime:
         """Prepare datetime for sorting, with None values sorted last.

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/repository_factory.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/repository_factory.py
@@ -45,11 +45,10 @@ class RepositoryFactory:
             return RepositoryFactory._create_sqlite_repository(
                 storage_config, engine=engine
             )
-        else:
-            raise ValueError(
-                f"Unsupported storage backend: {storage_config.backend}. "
-                f"Only 'sqlite' backend is supported."
-            )
+        raise ValueError(
+            f"Unsupported storage backend: {storage_config.backend}. "
+            f"Only 'sqlite' backend is supported."
+        )
 
     @staticmethod
     def _create_sqlite_repository(

--- a/packages/taskdog-core/tests/controllers/test_task_relationship_controller.py
+++ b/packages/taskdog-core/tests/controllers/test_task_relationship_controller.py
@@ -52,7 +52,7 @@ class TestTaskRelationshipController:
         def get_by_id_side_effect(task_id_arg):
             if task_id_arg == task_id:
                 return task
-            elif task_id_arg == depends_on_id:
+            if task_id_arg == depends_on_id:
                 return dependency_task
             return None
 

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_crud.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_crud.py
@@ -232,12 +232,11 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
         if hard:
             client.remove_task(task_id)
             return {"message": f"Task {task_id} permanently deleted"}
-        else:
-            result = client.archive_task(task_id)
-            return {
-                "id": result.id,
-                "message": f"Task '{result.name}' archived",
-            }
+        result = client.archive_task(task_id)
+        return {
+            "id": result.id,
+            "message": f"Task '{result.name}' archived",
+        }
 
     @mcp.tool()
     def restore_task(task_id: int) -> dict[str, Any]:

--- a/packages/taskdog-ui/src/taskdog/renderers/gantt_cell_formatter.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/gantt_cell_formatter.py
@@ -283,12 +283,12 @@ class GanttCellFormatter:
         """
         if status == TaskStatus.IN_PROGRESS:
             return SYMBOL_IN_PROGRESS
-        elif status == TaskStatus.COMPLETED:
+        if status == TaskStatus.COMPLETED:
             return SYMBOL_COMPLETED
-        elif status == TaskStatus.CANCELED:
+        if status == TaskStatus.CANCELED:
             return SYMBOL_CANCELED
-        else:  # PENDING (should not appear in actual period normally)
-            return SYMBOL_PENDING
+        # PENDING (should not appear in actual period normally)
+        return SYMBOL_PENDING
 
     @staticmethod
     def _is_in_date_range(
@@ -331,14 +331,13 @@ class GanttCellFormatter:
             # Case 1: IN_PROGRESS - show from actual_start to today
             today = date.today()
             return bool(actual_start <= current_date <= today)
-        elif actual_start and actual_end:
+        if actual_start and actual_end:
             # Case 2: Both dates exist - show the complete range
             return bool(actual_start <= current_date <= actual_end)
-        elif actual_end and not actual_start:
+        if actual_end and not actual_start:
             # Case 3: Only actual_end (CANCELED without starting)
             return bool(current_date == actual_end)
-        else:
-            return False
+        return False
 
     @staticmethod
     def _determine_cell_background_color(
@@ -416,8 +415,7 @@ class GanttCellFormatter:
         if hours > 0:
             # Format: "4  " or "2.5" (right-aligned, 3 chars)
             return f"{int(hours):2d} " if hours == int(hours) else f"{hours:3.1f}"
-        else:
-            return SYMBOL_EMPTY
+        return SYMBOL_EMPTY
 
     @staticmethod
     def _get_weekend_holiday_background_color(
@@ -444,8 +442,7 @@ class GanttCellFormatter:
         weekday = current_date.weekday()
         if weekday == SATURDAY:
             return BACKGROUND_COLOR_SATURDAY
-        elif weekday == SUNDAY:
+        if weekday == SUNDAY:
             return BACKGROUND_COLOR_SUNDAY
-        else:
-            # Should not reach here (this method is only called for weekends/holidays)
-            return BACKGROUND_COLOR
+        # Should not reach here (this method is only called for weekends/holidays)
+        return BACKGROUND_COLOR

--- a/packages/taskdog-ui/src/taskdog/renderers/rich_statistics_renderer.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/rich_statistics_renderer.py
@@ -390,10 +390,9 @@ class RichStatisticsRenderer:
         """
         if rate >= 0.8:
             return "green"
-        elif rate >= 0.5:
+        if rate >= 0.5:
             return "yellow"
-        else:
-            return "red"
+        return "red"
 
     def _get_estimation_accuracy_color(self, accuracy: float) -> str:
         """Get color for estimation accuracy.
@@ -408,8 +407,7 @@ class RichStatisticsRenderer:
         if 0.9 <= accuracy <= 1.1:
             return "green"
         # Moderate: 0.7 to 1.3
-        elif 0.7 <= accuracy <= 1.3:
+        if 0.7 <= accuracy <= 1.3:
             return "yellow"
         # Poor: outside that range
-        else:
-            return "red"
+        return "red"

--- a/packages/taskdog-ui/src/taskdog/renderers/rich_table_renderer.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/rich_table_renderer.py
@@ -246,9 +246,9 @@ class RichTableRenderer(RichRendererBase):
         # Field value extractors mapping
         field_extractors: dict[str, Callable[[TaskRowViewModel], str]] = {
             "id": lambda t: str(t.id),
-            "name": lambda t: f"[strike dim]{t.name}[/strike dim]"
-            if t.is_finished
-            else t.name,
+            "name": lambda t: (
+                f"[strike dim]{t.name}[/strike dim]" if t.is_finished else t.name
+            ),
             "note": lambda t: "📝" if t.has_notes else "",
             "priority": lambda t: str(t.priority),
             "status": lambda t: self._format_status(t),
@@ -399,5 +399,4 @@ class RichTableRenderer(RichRendererBase):
         # Format based on duration
         if days > 0:
             return f"{days}d {hours}:{minutes:02d}:{seconds:02d}"
-        else:
-            return f"{hours}:{minutes:02d}:{seconds:02d}"
+        return f"{hours}:{minutes:02d}:{seconds:02d}"

--- a/packages/taskdog-ui/src/taskdog/tui/commands/optimize.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/optimize.py
@@ -54,9 +54,8 @@ class OptimizeCommand(TUICommandBase):
             ]
             failures_text = "\n".join(failure_lines)
             return f"{prefix}{failed_count} task(s) failed:\n{failures_text}"
-        else:
-            # Show summary only for many failures
-            return f"{prefix}{failed_count} tasks failed to schedule. Check gantt chart for details."
+        # Show summary only for many failures
+        return f"{prefix}{failed_count} tasks failed to schedule. Check gantt chart for details."
 
     def execute(self) -> None:
         """Execute the optimize command."""

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/stats_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/stats_dialog.py
@@ -445,19 +445,17 @@ class StatsDialog(BaseModalDialog[None], ViNavigationMixin):
         """Get CSS class for a rate value."""
         if rate >= 0.8:
             return "stats-value-success"
-        elif rate >= 0.5:
+        if rate >= 0.5:
             return "stats-value-warning"
-        else:
-            return "stats-value-error"
+        return "stats-value-error"
 
     def _get_estimation_accuracy_class(self, accuracy: float) -> str:
         """Get CSS class for estimation accuracy."""
         if 0.9 <= accuracy <= 1.1:
             return "stats-value-success"
-        elif 0.7 <= accuracy <= 1.3:
+        if 0.7 <= accuracy <= 1.3:
             return "stats-value-warning"
-        else:
-            return "stats-value-error"
+        return "stats-value-error"
 
     # ── Vi navigation (delegates to active tab's scroll widget) ──────────
 

--- a/packages/taskdog-ui/src/taskdog/tui/forms/validators/optimization_validators.py
+++ b/packages/taskdog-ui/src/taskdog/tui/forms/validators/optimization_validators.py
@@ -24,9 +24,9 @@ class StartDateTextualValidator(Validator):
 
         if lower == "today":
             return today.strftime("%Y-%m-%d")
-        elif lower == "tomorrow":
+        if lower == "tomorrow":
             return (today + timedelta(days=1)).strftime("%Y-%m-%d")
-        elif lower == "yesterday":
+        if lower == "yesterday":
             return (today - timedelta(days=1)).strftime("%Y-%m-%d")
         return value
 

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/task_search_filter.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/task_search_filter.py
@@ -144,19 +144,19 @@ class TaskSearchFilter:
                 token.value, searchable_fields, case_sensitive
             )
 
-        elif token.type == TokenType.EXCLUDE:
+        if token.type == TokenType.EXCLUDE:
             return not self._contains_in_fields(
                 token.value, searchable_fields, case_sensitive
             )
 
-        elif token.type == TokenType.EXCLUDE_STATUS:
+        if token.type == TokenType.EXCLUDE_STATUS:
             if token.value == "is_finished":
                 # !completed shorthand - exclude COMPLETED and CANCELED
                 return not task_vm.is_finished
             # Exclude specific status value
             return task_vm.status.value != token.value
 
-        elif token.type == TokenType.EXCLUDE_TAG:
+        if token.type == TokenType.EXCLUDE_TAG:
             # Case-insensitive tag comparison
             lower_tag = token.value.lower()
             return not any(t.lower() == lower_tag for t in task_vm.tags)

--- a/packages/taskdog-ui/tests/presentation/tui/commands/test_base.py
+++ b/packages/taskdog-ui/tests/presentation/tui/commands/test_base.py
@@ -205,13 +205,13 @@ class TestTUICommandBase:
         def add_side_effect(task_id, dep_id):
             if dep_id == 3:
                 raise TaskValidationError("Circular dependency detected")
-            return None
+            return
 
         # Mock remove_dependency to fail for dep 2
         def remove_side_effect(task_id, dep_id):
             if dep_id == 2:
                 raise TaskValidationError("Dependency not found")
-            return None
+            return
 
         self.context.api_client.add_dependency.side_effect = add_side_effect
         self.context.api_client.remove_dependency.side_effect = remove_side_effect

--- a/packages/taskdog-ui/tests/tui/dialogs/test_algorithm_selection_dialog.py
+++ b/packages/taskdog-ui/tests/tui/dialogs/test_algorithm_selection_dialog.py
@@ -154,11 +154,11 @@ class TestAlgorithmSelectionDialogSubmit:
         def mock_query_one(selector: str, widget_type: type) -> MagicMock:
             if "algorithm" in selector:
                 return mock_select
-            elif "max-hours" in selector:
+            if "max-hours" in selector:
                 return mock_max_hours
-            elif "start-date" in selector:
+            if "start-date" in selector:
                 return mock_start_date
-            elif "force" in selector:
+            if "force" in selector:
                 return mock_checkbox
             return MagicMock()
 
@@ -214,11 +214,11 @@ class TestAlgorithmSelectionDialogSubmit:
         def mock_query_one(selector: str, widget_type: type) -> MagicMock:
             if "algorithm" in selector:
                 return mock_select
-            elif "max-hours" in selector:
+            if "max-hours" in selector:
                 return mock_max_hours
-            elif "start-date" in selector:
+            if "start-date" in selector:
                 return mock_start_date
-            elif "force" in selector:
+            if "force" in selector:
                 return mock_checkbox
             return MagicMock()
 
@@ -250,11 +250,11 @@ class TestAlgorithmSelectionDialogSubmit:
         def mock_query_one(selector: str, widget_type: type) -> MagicMock:
             if "algorithm" in selector:
                 return mock_select
-            elif "max-hours" in selector:
+            if "max-hours" in selector:
                 return mock_max_hours
-            elif "start-date" in selector:
+            if "start-date" in selector:
                 return mock_start_date
-            elif "force" in selector:
+            if "force" in selector:
                 return mock_checkbox
             return MagicMock()
 
@@ -286,11 +286,11 @@ class TestAlgorithmSelectionDialogSubmit:
         def mock_query_one(selector: str, widget_type: type) -> MagicMock:
             if "algorithm" in selector:
                 return mock_select
-            elif "max-hours" in selector:
+            if "max-hours" in selector:
                 return mock_max_hours
-            elif "start-date" in selector:
+            if "start-date" in selector:
                 return mock_start_date
-            elif "force" in selector:
+            if "force" in selector:
                 return mock_checkbox
             return MagicMock()
 
@@ -322,11 +322,11 @@ class TestAlgorithmSelectionDialogSubmit:
         def mock_query_one(selector: str, widget_type: type) -> MagicMock:
             if "algorithm" in selector:
                 return mock_select
-            elif "max-hours" in selector:
+            if "max-hours" in selector:
                 return mock_max_hours
-            elif "start-date" in selector:
+            if "start-date" in selector:
                 return mock_start_date
-            elif "force" in selector:
+            if "force" in selector:
                 return mock_checkbox
             return MagicMock()
 
@@ -358,11 +358,11 @@ class TestAlgorithmSelectionDialogSubmit:
         def mock_query_one(selector: str, widget_type: type) -> MagicMock:
             if "algorithm" in selector:
                 return mock_select
-            elif "max-hours" in selector:
+            if "max-hours" in selector:
                 return mock_max_hours
-            elif "start-date" in selector:
+            if "start-date" in selector:
                 return mock_start_date
-            elif "force" in selector:
+            if "force" in selector:
                 return mock_checkbox
             return MagicMock()
 

--- a/packages/taskdog-ui/tests/utils/test_editor.py
+++ b/packages/taskdog-ui/tests/utils/test_editor.py
@@ -48,7 +48,7 @@ class TestGetEditor:
         def side_effect(args, **kwargs):
             if args == ["which", "vim"]:
                 raise subprocess.CalledProcessError(1, "which")
-            return None  # nano found
+            return  # nano found
 
         mock_run.side_effect = side_effect
 
@@ -63,7 +63,7 @@ class TestGetEditor:
         def side_effect(args, **kwargs):
             if args == ["which", "vim"] or args == ["which", "nano"]:
                 raise subprocess.CalledProcessError(1, "which")
-            return None  # vi found
+            return  # vi found
 
         mock_run.side_effect = side_effect
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,10 +108,12 @@ select = [
   "N",  # pep8-naming
   "SIM",  # simplify
   "PIE",  # misc lints (unnecessary pass, etc.)
+  "RET",  # return statement simplification
   "RUF",  # ruff-specific rules
 ]
 ignore = [
   "E501",  # line too long (handled by formatter)
+  "RET504",  # unnecessary assignment before return (intentional for readability)
 ]
 
 # Per-file ignores


### PR DESCRIPTION
## Summary

- Add `RET` (flake8-return) to the ruff lint rule selection
- Auto-fix 65 violations across src and test files:
  - `RET505`: superfluous `else`/`elif` after `return`
  - `RET501`: unnecessary explicit `return None`
  - `RET506`: superfluous `else` after `raise`
- Ignore `RET504` (unnecessary assignment before return) — intermediate variables kept intentionally for readability

## Test plan

- [x] `make lint` passes across all packages
- [x] `make test` passes (2611 tests, 0 failures)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)