### PR TITLE
refactor: enable ruff PERF rule for performance anti-patterns

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/queries/filters/date_range_filter.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/filters/date_range_filter.py
@@ -46,16 +46,17 @@ class DateRangeFilter(TaskFilter):
         filtered = []
         for task in tasks:
             # Collect all date fields from the task
-            task_dates = []
-            for dt in [
-                task.planned_start,
-                task.planned_end,
-                task.actual_start,
-                task.actual_end,
-                task.deadline,
-            ]:
-                if dt:
-                    task_dates.append(dt.date())
+            task_dates = [
+                dt.date()
+                for dt in [
+                    task.planned_start,
+                    task.planned_end,
+                    task.actual_start,
+                    task.actual_end,
+                    task.deadline,
+                ]
+                if dt
+            ]
 
             # Include tasks with no dates (unscheduled tasks)
             if not task_dates:

--- a/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
@@ -467,18 +467,18 @@ class TaskQueryService(QueryService):
             return start_date, end_date
 
         # Collect dates from tasks
-        dates = []
-        for task in tasks:
-            # Collect all date fields
+        dates = [
+            dt.date()
+            for task in tasks
             for dt in [
                 task.planned_start,
                 task.planned_end,
                 task.actual_start,
                 task.actual_end,
                 task.deadline,
-            ]:
-                if dt:
-                    dates.append(dt.date())
+            ]
+            if dt
+        ]
 
         if not dates:
             return None

--- a/packages/taskdog-core/tests/application/services/optimization/test_backward_optimization_strategy.py
+++ b/packages/taskdog-core/tests/application/services/optimization/test_backward_optimization_strategy.py
@@ -103,7 +103,7 @@ class TestBackwardOptimizationStrategy(BaseOptimizationStrategyTest):
         # Should respect max_hours_per_day
         updated_task = self.repository.get_by_id(task.id)
         assert updated_task is not None
-        for _date_str, hours in updated_task.daily_allocations.items():
+        for hours in updated_task.daily_allocations.values():
             assert hours <= 6.0
 
         # Total should be 18h

--- a/packages/taskdog-core/tests/application/services/optimization/test_balanced_optimization_strategy.py
+++ b/packages/taskdog-core/tests/application/services/optimization/test_balanced_optimization_strategy.py
@@ -44,7 +44,7 @@ class TestBalancedOptimizationStrategy(BaseOptimizationStrategyTest):
         updated_task = self.repository.get_by_id(task.id)
         assert updated_task is not None
         assert len(updated_task.daily_allocations) == 5  # Mon-Fri
-        for _date_str, hours in updated_task.daily_allocations.items():
+        for hours in updated_task.daily_allocations.values():
             assert abs(hours - 2.0) < 1e-5
 
     def test_balanced_without_deadline_uses_default_period(self):
@@ -82,7 +82,7 @@ class TestBalancedOptimizationStrategy(BaseOptimizationStrategyTest):
         # Should respect max_hours_per_day
         updated_task = self.repository.get_by_id(task.id)
         assert updated_task is not None
-        for _date_str, hours in updated_task.daily_allocations.items():
+        for hours in updated_task.daily_allocations.values():
             assert hours <= 6.0
 
         # Total should still be 12h

--- a/packages/taskdog-core/tests/application/use_cases/test_create_task_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_create_task_use_case.py
@@ -117,7 +117,7 @@ class TestCreateTaskUseCase:
         assert persisted_task.daily_allocations
         # 5 weekdays, 10 hours = 2 hours per day
         assert len(persisted_task.daily_allocations) == 5
-        for _d, hours in persisted_task.daily_allocations.items():
+        for hours in persisted_task.daily_allocations.values():
             assert hours == pytest.approx(2.0, rel=0.01)
 
     def test_execute_no_allocations_without_estimated_duration(self):

--- a/packages/taskdog-core/tests/application/use_cases/test_update_task_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_update_task_use_case.py
@@ -445,7 +445,7 @@ class TestUpdateTaskUseCase:
         persisted_task = self.repository.get_by_id(task.id)
         assert persisted_task is not None
         # 20 hours / 5 weekdays = 4 hours per day
-        for _d, hours in persisted_task.daily_allocations.items():
+        for hours in persisted_task.daily_allocations.values():
             assert hours == 4.0
 
     def test_execute_clears_allocations_when_adding_third_field(self):

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/task_search_filter.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/task_search_filter.py
@@ -58,12 +58,11 @@ class TaskSearchFilter:
         # Smart case: case-sensitive if query has uppercase
         case_sensitive = self._is_case_sensitive(query)
 
-        filtered = []
-        for vm in view_models:
-            if self._matches_all_tokens(vm, tokens, case_sensitive):
-                filtered.append(vm)
-
-        return filtered
+        return [
+            vm
+            for vm in view_models
+            if self._matches_all_tokens(vm, tokens, case_sensitive)
+        ]
 
     def matches(
         self, task_vm: TaskRowViewModel, query: str, case_sensitive: bool | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ select = [
   "SIM",  # simplify
   "PIE",  # misc lints (unnecessary pass, etc.)
   "RET",  # return statement simplification
+  "PERF",  # performance anti-patterns
   "RUF",  # ruff-specific rules
 ]
 ignore = [


### PR DESCRIPTION
## Summary

- Add `PERF` (perflint) to the ruff lint rule selection
- Fix all 8 violations:
  - `PERF401`: replace `append` loops with list comprehensions (3 in src)
  - `PERF102`: use `.values()` instead of `.items()` when keys are unused (5 in tests)

## Test plan

- [x] `make lint` passes across all packages
- [x] `make test` passes (2611 tests, 0 failures)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)