### PR TITLE
refactor: enable ruff FURB rule for modern Python patterns

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/commands/base.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/base.py
@@ -109,8 +109,7 @@ class TUICommandBase(ABC):  # noqa: B024
         """
         # Convert "AddTaskCommand" to "adding task"
         class_name = self.__class__.__name__
-        if class_name.endswith("Command"):
-            class_name = class_name[:-7]  # Remove "Command" suffix
+        class_name = class_name.removesuffix("Command")  # Remove "Command" suffix
 
         # Convert camel case to words: "AddTask" -> "Add Task"
         import re
@@ -119,8 +118,7 @@ class TUICommandBase(ABC):  # noqa: B024
         # Add "...ing" suffix if it doesn't already end with "ing"
         if not words.endswith("ing"):
             # Simple heuristic: if ends with 'e', drop it before adding 'ing'
-            if words.endswith("e"):
-                words = words[:-1]
+            words = words.removesuffix("e")
             words += "ing"
 
         return words

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ select = [
   "PIE",  # misc lints (unnecessary pass, etc.)
   "RET",  # return statement simplification
   "PERF",  # performance anti-patterns
+  "FURB",  # refurb modernization
   "RUF",  # ruff-specific rules
 ]
 ignore = [


### PR DESCRIPTION
## Summary

- Add `FURB` (refurb) to the ruff lint rule selection
- Auto-fix 2 `FURB188` violations: replace `endswith()`+slice with `str.removesuffix()` in TUI command base

## Test plan

- [x] `make lint` passes across all packages
- [x] `make test` passes (2611 tests, 0 failures)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)