### PR TITLE
refactor: enable ruff C4 rule for flake8-comprehensions

### DIFF
--- a/packages/taskdog-core/tests/shared/test_config_manager.py
+++ b/packages/taskdog-core/tests/shared/test_config_manager.py
@@ -224,7 +224,7 @@ class TestConfigManagerEnvVars:
         # Ensure no TASKDOG_ env vars are set
         taskdog_vars = [k for k in os.environ if k.startswith("TASKDOG_")]
 
-        with patch.dict(os.environ, {k: "" for k in taskdog_vars}, clear=False):
+        with patch.dict(os.environ, dict.fromkeys(taskdog_vars, ""), clear=False):
             # Remove the vars we just blanked
             for k in taskdog_vars:
                 os.environ.pop(k, None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ select = [
   "SIM",  # simplify
   "PIE",  # misc lints (unnecessary pass, etc.)
   "RET",  # return statement simplification
+  "C4",  # flake8-comprehensions
   "PERF",  # performance anti-patterns
   "FURB",  # refurb modernization
   "RUF",  # ruff-specific rules


### PR DESCRIPTION
## Summary
- Enable the `C4` (flake8-comprehensions) ruff rule to catch unnecessary dict/list/set constructor calls
- Fix 1 violation: replace `{k: "" for k in taskdog_vars}` with `dict.fromkeys(taskdog_vars, "")` (C420) in test code

## Test plan
- [x] `make lint` passes with zero C4 violations across all packages
- [x] `make test-core` passes (1097 tests, 93.40% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)