### PR TITLE
refactor: reduce verbose patterns in TUI code

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/commands/add.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/add.py
@@ -4,7 +4,6 @@ from taskdog.tui.commands.base import TUICommandBase
 from taskdog.tui.dialogs.task_form_dialog import TaskFormDialog
 from taskdog.tui.events import TaskCreated
 from taskdog.tui.forms.task_form_fields import TaskFormData
-from taskdog_core.domain.exceptions.task_exceptions import TaskError
 
 
 class AddCommand(TUICommandBase):
@@ -58,12 +57,7 @@ class AddCommand(TUICommandBase):
         )
 
         # Fetch existing tags for auto-completion (graceful degradation on failure)
-        existing_tags: list[str] | None = None
-        try:
-            tag_stats = self.context.api_client.get_tag_statistics()
-            existing_tags = list(tag_stats.tag_counts.keys())
-        except TaskError:
-            pass
+        existing_tags = self.fetch_existing_tags()
 
         dialog = TaskFormDialog(
             input_defaults=input_defaults, existing_tags=existing_tags

--- a/packages/taskdog-ui/src/taskdog/tui/commands/base.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/base.py
@@ -203,6 +203,20 @@ class TUICommandBase(ABC):  # noqa: B024
         """
         self.app.notify(message, severity="warning")
 
+    def fetch_existing_tags(self) -> list[str] | None:
+        """Fetch existing tags for auto-completion.
+
+        Gracefully degrades on failure by returning None.
+
+        Returns:
+            List of existing tag names, or None if fetch failed
+        """
+        try:
+            tag_stats = self.context.api_client.get_tag_statistics()
+            return list(tag_stats.tag_counts.keys())
+        except TaskError:
+            return None
+
     def manage_dependencies(
         self,
         task_id: int,

--- a/packages/taskdog-ui/src/taskdog/tui/commands/batch_confirmation_base.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/batch_confirmation_base.py
@@ -81,6 +81,45 @@ class BatchConfirmationCommandBase(TUICommandBase):
             Various exceptions depending on the operation
         """
 
+    def _process_confirmed_tasks(self, task_ids: list[int]) -> tuple[int, int]:
+        """Process each task in the batch after confirmation.
+
+        Args:
+            task_ids: List of task IDs to process
+
+        Returns:
+            Tuple of (success_count, failure_count)
+        """
+        success_count = 0
+        failure_count = 0
+
+        for task_id in task_ids:
+            try:
+                self.execute_confirmed_action(task_id)
+                success_count += 1
+            except Exception as e:
+                self.notify_error(f"Task {task_id}", e)
+                failure_count += 1
+
+        return success_count, failure_count
+
+    def _finalize_batch(self, success_count: int, failure_count: int) -> None:
+        """Clear selection, reload tasks, and show summary if needed.
+
+        Args:
+            success_count: Number of successfully processed tasks
+            failure_count: Number of failed tasks
+        """
+        self.clear_task_selection()
+        self.reload_tasks()
+
+        # Show result summary (only for failures - success notifications via WebSocket)
+        if failure_count > 0:
+            total = success_count + failure_count
+            self.notify_warning(
+                f"Completed {total} tasks: {success_count} succeeded, {failure_count} failed"
+            )
+
     def execute(self) -> None:
         """Execute batch operation with confirmation.
 
@@ -96,35 +135,10 @@ class BatchConfirmationCommandBase(TUICommandBase):
         task_count = len(task_ids)
 
         def handle_confirmation(confirmed: bool | None) -> None:
-            """Handle the confirmation response.
-
-            Args:
-                confirmed: True if user confirmed, False/None otherwise
-            """
             if not confirmed:
-                return  # User cancelled
-
-            success_count = 0
-            failure_count = 0
-
-            for task_id in task_ids:
-                try:
-                    self.execute_confirmed_action(task_id)
-                    success_count += 1
-                except Exception as e:
-                    self.notify_error(f"Task {task_id}", e)
-                    failure_count += 1
-
-            # Clear selection and reload tasks
-            self.clear_task_selection()
-            self.reload_tasks()
-
-            # Show result summary (only for failures - success notifications via WebSocket)
-            if failure_count > 0:
-                total = success_count + failure_count
-                self.notify_warning(
-                    f"Completed {total} tasks: {success_count} succeeded, {failure_count} failed"
-                )
+                return
+            success_count, failure_count = self._process_confirmed_tasks(task_ids)
+            self._finalize_batch(success_count, failure_count)
 
         # Show confirmation dialog
         dialog = ConfirmationDialog(

--- a/packages/taskdog-ui/src/taskdog/tui/commands/edit.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/edit.py
@@ -7,7 +7,6 @@ from taskdog.tui.events import TaskUpdated
 from taskdog.tui.forms.task_form_fields import TaskFormData
 from taskdog_core.application.dto.task_dto import TaskDetailDto
 from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
-from taskdog_core.domain.exceptions.task_exceptions import TaskError
 
 
 class EditCommand(TUICommandBase):
@@ -45,12 +44,7 @@ class EditCommand(TUICommandBase):
         )
 
         # Fetch existing tags for auto-completion (graceful degradation on failure)
-        existing_tags: list[str] | None = None
-        try:
-            tag_stats = self.context.api_client.get_tag_statistics()
-            existing_tags = list(tag_stats.tag_counts.keys())
-        except TaskError:
-            pass
+        existing_tags = self.fetch_existing_tags()
 
         dialog = TaskFormDialog(
             task=original_task,

--- a/packages/taskdog-ui/src/taskdog/tui/screens/main_screen.py
+++ b/packages/taskdog-ui/src/taskdog/tui/screens/main_screen.py
@@ -187,14 +187,6 @@ class MainScreen(Screen[None]):
             total = self.state.total_count
             self.custom_footer.update_result(matched, total)
 
-    # Delegate methods to task_table for compatibility
-
-    def load_tasks(self, view_models: list[TaskRowViewModel]) -> None:
-        """Load task ViewModels into the table."""
-        if self.task_table:
-            self.task_table.load_tasks(view_models)
-            self._update_search_result()
-
     def refresh_tasks(
         self, view_models: list[TaskRowViewModel], keep_scroll_position: bool = False
     ) -> None:
@@ -204,47 +196,6 @@ class MainScreen(Screen[None]):
                 view_models, keep_scroll_position=keep_scroll_position
             )
             self._update_search_result()
-
-    def get_selected_task_id(self) -> int | None:
-        """Get the ID of the currently selected task."""
-        if self.task_table:
-            return self.task_table.get_selected_task_id()
-        return None
-
-    def get_selected_task_vm(self) -> TaskRowViewModel | None:
-        """Get the currently selected task as a ViewModel."""
-        if self.task_table:
-            return self.task_table.get_selected_task_vm()
-        return None
-
-    def get_selected_task_ids(self) -> list[int]:
-        """Get all selected task IDs for batch operations."""
-        if self.task_table:
-            return self.task_table.get_selected_task_ids()
-        return []
-
-    def get_explicitly_selected_task_ids(self) -> list[int]:
-        """Get only explicitly selected task IDs (no cursor fallback)."""
-        if self.task_table:
-            return self.task_table.get_explicitly_selected_task_ids()
-        return []
-
-    def clear_task_selection(self) -> None:
-        """Clear all task selections."""
-        if self.task_table:
-            self.task_table.clear_selection()
-
-    def focus_table(self) -> None:
-        """Focus the task table."""
-        if self.task_table:
-            self.task_table.focus()
-
-    @property
-    def all_viewmodels(self) -> list[TaskRowViewModel]:
-        """Get all loaded ViewModels from the table."""
-        if self.task_table:
-            return self.task_table.all_viewmodels
-        return []
 
     def action_focus_next(self) -> None:
         """Move focus to the next widget (Ctrl+J)."""

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
@@ -82,50 +82,55 @@ class GanttWidget(Vertical, ViNavigationMixin, TUIWidget):
         yield self._legend_widget
 
     # Vi-style scroll actions - delegate to gantt table
+
+    def _delegate_scroll(
+        self, method_name: str, *args: int | float | None, **kwargs: Any
+    ) -> None:
+        """Delegate a scroll action to the gantt table if available.
+
+        Args:
+            method_name: Name of the scroll method to call on _gantt_table
+            *args: Positional arguments to pass to the method
+            **kwargs: Keyword arguments to pass to the method
+        """
+        if self._gantt_table:
+            getattr(self._gantt_table, method_name)(*args, **kwargs)
+
     def action_scroll_down(self) -> None:
         """Scroll down one line."""
-        if self._gantt_table:
-            self._gantt_table.scroll_down()
+        self._delegate_scroll("scroll_down")
 
     def action_scroll_up(self) -> None:
         """Scroll up one line."""
-        if self._gantt_table:
-            self._gantt_table.scroll_up()
+        self._delegate_scroll("scroll_up")
 
     def action_scroll_home(self) -> None:
         """Scroll to top."""
-        if self._gantt_table:
-            self._gantt_table.scroll_home()
+        self._delegate_scroll("scroll_home")
 
     def action_scroll_end(self) -> None:
         """Scroll to bottom."""
-        if self._gantt_table:
-            self._gantt_table.scroll_end()
+        self._delegate_scroll("scroll_end")
 
     def action_page_down(self) -> None:
         """Scroll down half a page."""
-        if self._gantt_table:
-            self._gantt_table.scroll_page_down()
+        self._delegate_scroll("scroll_page_down")
 
     def action_page_up(self) -> None:
         """Scroll up half a page."""
-        if self._gantt_table:
-            self._gantt_table.scroll_page_up()
+        self._delegate_scroll("scroll_page_up")
 
     def action_scroll_left(self) -> None:
         """Scroll left."""
-        if self._gantt_table:
-            self._gantt_table.scroll_left()
+        self._delegate_scroll("scroll_left")
 
     def action_scroll_right(self) -> None:
         """Scroll right."""
-        if self._gantt_table:
-            self._gantt_table.scroll_right()
+        self._delegate_scroll("scroll_right")
 
     def action_scroll_home_horizontal(self) -> None:
         """Scroll to leftmost position (0 key)."""
-        if self._gantt_table:
-            self._gantt_table.scroll_to(0, None, animate=False)
+        self._delegate_scroll("scroll_to", 0, None, animate=False)
 
     def action_scroll_end_horizontal(self) -> None:
         """Scroll to rightmost position ($ key)."""


### PR DESCRIPTION
## Summary

- Add `_delegate_scroll()` helper to `GanttWidget`, simplifying 8 scroll delegation methods from repeated null-check blocks to one-liners
- Extract `fetch_existing_tags()` to `TUICommandBase`, removing duplicate 6-line try-except blocks from `AddCommand` and `EditCommand`
- Remove 8 unused delegation methods from `MainScreen` — commands already access `task_table` directly via `TUICommandBase`
- Extract `_process_confirmed_tasks()` and `_finalize_batch()` from `BatchConfirmationBase`'s inline callback closure

Net result: **-28 lines** (81 added, 109 removed), no behavioral changes.

## Test plan

- [x] `make lint` — all checks passed
- [x] `make typecheck` — no issues across all packages
- [x] `make test` — all tests passed (core + server + ui + mcp)


🤖 Generated with [Claude Code](https://claude.com/claude-code)