### PR TITLE
refactor: enable ruff A rule for flake8-builtins detection

### DIFF
--- a/packages/taskdog-client/src/taskdog_client/query_client.py
+++ b/packages/taskdog-client/src/taskdog_client/query_client.py
@@ -38,7 +38,7 @@ class QueryClient:
 
     def _build_list_params(
         self,
-        all: bool,
+        include_archived: bool,
         sort_by: str,
         reverse: bool,
         status: str | None = None,
@@ -48,7 +48,7 @@ class QueryClient:
         """Build common parameters for list operations.
 
         Args:
-            all: Include archived tasks
+            include_archived: Include archived tasks
             sort_by: Sort field
             reverse: Reverse sort order
             status: Filter by status
@@ -59,7 +59,7 @@ class QueryClient:
             Dictionary of query parameters
         """
         params: dict[str, Any] = {
-            "all": str(all).lower(),
+            "all": str(include_archived).lower(),
             "sort": sort_by,
             "reverse": str(reverse).lower(),
         }
@@ -76,7 +76,7 @@ class QueryClient:
 
     def list_tasks(
         self,
-        all: bool = False,
+        include_archived: bool = False,
         status: str | None = None,
         tags: list[str] | None = None,
         start_date: date | None = None,
@@ -90,7 +90,7 @@ class QueryClient:
         """List tasks with optional filtering and sorting.
 
         Args:
-            all: Include archived tasks (default: False)
+            include_archived: Include archived tasks (default: False)
             status: Filter by status (e.g., "pending", "in_progress", "completed", "canceled")
             tags: Filter by tags (OR logic)
             start_date: Filter by start date
@@ -116,7 +116,9 @@ class QueryClient:
             if gantt_end_date:
                 extra["gantt_end_date"] = gantt_end_date.isoformat()
 
-        params = self._build_list_params(all, sort_by, reverse, status, tags, **extra)
+        params = self._build_list_params(
+            include_archived, sort_by, reverse, status, tags, **extra
+        )
         data = self._base._request_json("get", "/api/v1/tasks", params=params)
         return convert_to_task_list_output(data)
 
@@ -152,7 +154,7 @@ class QueryClient:
 
     def get_gantt_data(
         self,
-        all: bool = False,
+        include_archived: bool = False,
         status: str | None = None,
         tags: list[str] | None = None,
         filter_start_date: date | None = None,
@@ -165,7 +167,7 @@ class QueryClient:
         """Get Gantt chart data.
 
         Args:
-            all: Include archived tasks (default: False)
+            include_archived: Include archived tasks (default: False)
             status: Filter by status
             tags: Filter by tags (OR logic)
             filter_start_date: Filter tasks by start date
@@ -193,7 +195,9 @@ class QueryClient:
         if end_date:
             extra["end_date"] = end_date.isoformat()
 
-        params = self._build_list_params(all, sort_by, reverse, status, tags, **extra)
+        params = self._build_list_params(
+            include_archived, sort_by, reverse, status, tags, **extra
+        )
         data = self._base._request_json("get", "/api/v1/gantt", params=params)
         return convert_to_gantt_output(data)
 

--- a/packages/taskdog-client/src/taskdog_client/taskdog_api_client.py
+++ b/packages/taskdog-client/src/taskdog_client/taskdog_api_client.py
@@ -298,7 +298,7 @@ class TaskdogApiClient:
 
     def list_tasks(
         self,
-        all: bool = False,
+        include_archived: bool = False,
         status: str | None = None,
         tags: list[str] | None = None,
         start_date: date | None = None,
@@ -311,7 +311,7 @@ class TaskdogApiClient:
     ) -> TaskListOutput:
         """List tasks with optional filtering and sorting."""
         return self._queries.list_tasks(
-            all,
+            include_archived,
             status,
             tags,
             start_date,
@@ -333,7 +333,7 @@ class TaskdogApiClient:
 
     def get_gantt_data(
         self,
-        all: bool = False,
+        include_archived: bool = False,
         status: str | None = None,
         tags: list[str] | None = None,
         filter_start_date: date | None = None,
@@ -345,7 +345,7 @@ class TaskdogApiClient:
     ) -> GanttOutput:
         """Get Gantt chart data."""
         return self._queries.get_gantt_data(
-            all,
+            include_archived,
             status,
             tags,
             filter_start_date,

--- a/packages/taskdog-client/tests/test_query_client.py
+++ b/packages/taskdog-client/tests/test_query_client.py
@@ -30,7 +30,7 @@ class TestQueryClient:
         mock_convert.return_value = mock_output
 
         result = self.client.list_tasks(
-            all=False,
+            include_archived=False,
             status="pending",
             tags=["urgent"],
             start_date=date(2025, 1, 1),
@@ -93,7 +93,7 @@ class TestQueryClient:
         mock_convert.return_value = mock_output
 
         result = self.client.get_gantt_data(
-            all=False,
+            include_archived=False,
             status="in_progress",
             sort_by="deadline",
             reverse=False,

--- a/packages/taskdog-client/tests/test_taskdog_api_client.py
+++ b/packages/taskdog-client/tests/test_taskdog_api_client.py
@@ -273,7 +273,7 @@ class TestTaskdogApiClientDelegation:
     # Query methods
     def test_list_tasks(self, client):
         """Test list_tasks delegates to QueryClient."""
-        client.list_tasks(all=True, sort_by="priority")
+        client.list_tasks(include_archived=True, sort_by="priority")
         client._queries.list_tasks.assert_called_once()
 
     def test_get_task_by_id(self, client):

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_crud.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_crud.py
@@ -43,7 +43,7 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
             Dictionary with tasks list and metadata
         """
         result = client.list_tasks(
-            all=include_archived,
+            include_archived=include_archived,
             status=status,
             tags=tags,
             sort_by=sort_by,

--- a/packages/taskdog-mcp/tests/test_tools.py
+++ b/packages/taskdog-mcp/tests/test_tools.py
@@ -377,7 +377,7 @@ class TestTaskCrudTools:
         )
 
         client.list_tasks.assert_called_once_with(
-            all=True,
+            include_archived=True,
             status="PENDING",
             tags=["test"],
             sort_by="priority",

--- a/packages/taskdog-server/src/taskdog_server/api/routers/analytics.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/analytics.py
@@ -207,7 +207,9 @@ async def get_gantt_chart(
     controller: QueryControllerDep,
     holiday_checker: HolidayCheckerDep,
     _client_name: AuthenticatedClientDep,
-    all: Annotated[bool, Query(description="Include archived tasks")] = False,
+    include_archived: Annotated[
+        bool, Query(alias="all", description="Include archived tasks")
+    ] = False,
     status_filter: Annotated[
         str | None, Query(alias="status", description="Filter by status")
     ] = None,
@@ -228,7 +230,7 @@ async def get_gantt_chart(
     Args:
         controller: Query controller dependency
         holiday_checker: Holiday checker dependency
-        all: Include archived tasks
+        include_archived: Include archived tasks
         status_filter: Filter by task status
         tags: Filter by tags (OR logic)
         start_date: Chart start date
@@ -245,7 +247,7 @@ async def get_gantt_chart(
 
     # Create Input DTO (filter building is done in Use Case)
     input_dto = GetGanttDataInput(
-        include_archived=all,
+        include_archived=include_archived,
         status=status_filter,
         tags=tags or [],
         start_date=start,

--- a/packages/taskdog-server/src/taskdog_server/api/routers/tasks.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/tasks.py
@@ -114,7 +114,9 @@ async def list_tasks(
     notes_repo: NotesRepositoryDep,
     holiday_checker: HolidayCheckerDep,
     _client_name: AuthenticatedClientDep,
-    all: Annotated[bool, Query(description="Include archived tasks")] = False,
+    include_archived: Annotated[
+        bool, Query(alias="all", description="Include archived tasks")
+    ] = False,
     status_filter: Annotated[
         str | None, Query(alias="status", description="Filter by status")
     ] = None,
@@ -140,7 +142,7 @@ async def list_tasks(
     Args:
         controller: Query controller dependency
         holiday_checker: Holiday checker dependency
-        all: Include archived tasks
+        include_archived: Include archived tasks
         status_filter: Filter by task status
         tags: Filter by tags (OR logic)
         start_date: Filter by start date (ISO format)
@@ -162,7 +164,7 @@ async def list_tasks(
 
     # Create Input DTO (filter building is done in Use Case)
     input_dto = ListTasksInput(
-        include_archived=all,
+        include_archived=include_archived,
         status=status_filter,
         tags=tags or [],
         start_date=start,

--- a/packages/taskdog-ui/src/taskdog/cli/commands/common_options.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/common_options.py
@@ -13,7 +13,7 @@ def filter_options() -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     Usage:
         @click.command()
         @filter_options()
-        def my_command(ctx, all, status, ...):
+        def my_command(ctx, include_archived, status, ...):
             pass
     """
 
@@ -30,6 +30,7 @@ def filter_options() -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         @click.option(
             "--all",
             "-a",
+            "include_archived",
             is_flag=True,
             help="Show all tasks including completed, canceled, and archived",
         )

--- a/packages/taskdog-ui/src/taskdog/cli/commands/export.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/export.py
@@ -37,6 +37,7 @@ VALID_FIELDS = {
 )
 @click.option(
     "--format",
+    "export_format",
     type=click.Choice(["json", "csv", "markdown"]),
     default="json",
     help="Output format (default: json).",
@@ -67,11 +68,11 @@ VALID_FIELDS = {
 @click.pass_context
 def export_command(
     ctx: click.Context,
-    format: str,
+    export_format: str,
     output: str | None,
     fields: list[str] | None,
     tag: tuple[str, ...],
-    all: bool,
+    include_archived: bool,
     status: str | None,
     start_date: datetime | None,
     end_date: datetime | None,
@@ -109,7 +110,7 @@ def export_command(
 
         # Get filtered tasks via API client (export uses default id sorting)
         result = api_client.list_tasks(
-            all=all,
+            include_archived=include_archived,
             status=status,
             tags=tags,
             start_date=start_date,
@@ -122,14 +123,14 @@ def export_command(
         # fields is already parsed and validated by FieldList Click type
         # Create appropriate exporter based on format
         exporter: TaskExporter
-        if format == "json":
+        if export_format == "json":
             exporter = JsonTaskExporter(field_list=fields)
-        elif format == "csv":
+        elif export_format == "csv":
             exporter = CsvTaskExporter(field_list=fields)
-        elif format == "markdown":
+        elif export_format == "markdown":
             exporter = MarkdownTableExporter(field_list=fields)
         else:
-            raise ValueError(f"Unsupported format: {format}")
+            raise ValueError(f"Unsupported format: {export_format}")
 
         # Export tasks
         tasks_data = exporter.export(tasks)

--- a/packages/taskdog-ui/src/taskdog/cli/commands/gantt.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/gantt.py
@@ -78,7 +78,7 @@ def gantt_command(
     tag: tuple[str, ...],
     start_date: datetime | None,
     end_date: datetime | None,
-    all: bool,
+    include_archived: bool,
     status: str | None,
     sort: str,
     reverse: bool,
@@ -110,7 +110,7 @@ def gantt_command(
 
     # Get Gantt data via API client
     gantt_result = ctx_obj.api_client.get_gantt_data(
-        all=all,
+        include_archived=include_archived,
         status=status,
         tags=tags,
         sort_by=sort,

--- a/packages/taskdog-ui/src/taskdog/cli/commands/table.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/table.py
@@ -41,7 +41,7 @@ from taskdog.shared.click_types.field_list import FieldList
 @handle_command_errors("displaying tasks")
 def table_command(
     ctx: click.Context,
-    all: bool,
+    include_archived: bool,
     status: str | None,
     sort: str,
     reverse: bool,
@@ -77,7 +77,7 @@ def table_command(
 
     # Get filtered and sorted tasks via API client
     result = ctx_obj.api_client.list_tasks(
-        all=all,
+        include_archived=include_archived,
         status=status,
         tags=tags,
         start_date=start_date.date() if start_date else None,

--- a/packages/taskdog-ui/src/taskdog/cli/commands/timeline.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/timeline.py
@@ -71,7 +71,7 @@ def timeline_command(
     # Get all tasks (we'll filter by actual_start/end in the presenter)
     # Include all statuses since we want to show completed work too
     task_list = ctx_obj.api_client.list_tasks(
-        all=True,  # Include archived to show historical work
+        include_archived=True,  # Include archived to show historical work
         sort_by="id",
         reverse=False,
     )

--- a/packages/taskdog-ui/src/taskdog/services/task_data_loader.py
+++ b/packages/taskdog-ui/src/taskdog/services/task_data_loader.py
@@ -60,7 +60,7 @@ class TaskDataLoader:
 
     def load_tasks(
         self,
-        all: bool = False,
+        include_archived: bool = False,
         sort_by: str = "id",
         reverse: bool = False,
         date_range: tuple[date, date] | None = None,
@@ -68,7 +68,7 @@ class TaskDataLoader:
         """Load tasks from API and create ViewModels.
 
         Args:
-            all: Include archived tasks (default: False)
+            include_archived: Include archived tasks (default: False)
             sort_by: Sort field name
             reverse: Sort direction (default: False for ascending)
             date_range: Optional (start_date, end_date) for gantt data
@@ -81,7 +81,7 @@ class TaskDataLoader:
         gantt_start_date, gantt_end_date = date_range or (None, None)
 
         task_list_output = self.api_client.list_tasks(
-            all=all,
+            include_archived=include_archived,
             sort_by=sort_by,
             reverse=reverse,
             include_gantt=include_gantt,

--- a/packages/taskdog-ui/src/taskdog/tui/services/task_ui_manager.py
+++ b/packages/taskdog-ui/src/taskdog/tui/services/task_ui_manager.py
@@ -112,7 +112,7 @@ class TaskUIManager:
             date_range = self._calculate_gantt_date_range()
 
             return self.task_data_loader.load_tasks(
-                all=False,  # Non-archived by default
+                include_archived=False,  # Non-archived by default
                 sort_by=self.state.sort_by,
                 reverse=self.state.sort_reverse,
                 date_range=date_range,
@@ -176,7 +176,7 @@ class TaskUIManager:
                 gantt_view_model=task_data.filtered_gantt_view_model,
                 sort_by=self.state.sort_by,
                 reverse=self.state.sort_reverse,
-                all=False,  # Non-archived by default
+                include_archived=False,  # Non-archived by default
                 keep_scroll_position=keep_scroll_position,
             )
 
@@ -221,11 +221,11 @@ class TaskUIManager:
         sort_by = self.state.sort_by
         main_screen = self._get_main_screen()
         if main_screen and main_screen.gantt_widget:
-            all_tasks = main_screen.gantt_widget.get_filter_all()
+            all_tasks = main_screen.gantt_widget.get_filter_include_archived()
             sort_by = main_screen.gantt_widget.get_sort_by()
 
         task_list_output = self.task_data_loader.api_client.list_tasks(
-            all=all_tasks,
+            include_archived=all_tasks,
             sort_by=sort_by,
             reverse=self.state.sort_reverse,
             include_gantt=True,

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
@@ -57,7 +57,9 @@ class GanttWidget(Vertical, ViNavigationMixin, TUIWidget):
         self._task_ids: list[int] = []
         # NOTE: _gantt_view_model removed - now accessed via self.app.state.gantt_cache (Step 4)
         # NOTE: _sort_by and _reverse removed - now accessed via self.app.state (Step 2)
-        self._filter_all: bool = False  # Include archived tasks flag for recalculation
+        self._filter_include_archived: bool = (
+            False  # Include archived tasks flag for recalculation
+        )
         self._keep_scroll_position: bool = False  # Preserve scroll position on refresh
         self._gantt_table: GanttDataTable | None = None
         self._title_widget: Static | None = None
@@ -144,7 +146,7 @@ class GanttWidget(Vertical, ViNavigationMixin, TUIWidget):
         gantt_view_model: GanttViewModel,
         sort_by: str = "deadline",
         reverse: bool = False,
-        all: bool = False,
+        include_archived: bool = False,
         keep_scroll_position: bool = False,
     ) -> None:
         """Update the gantt chart with new gantt data.
@@ -154,7 +156,7 @@ class GanttWidget(Vertical, ViNavigationMixin, TUIWidget):
             gantt_view_model: Presentation-ready gantt data
             sort_by: Sort order for tasks (kept for compatibility, value comes from app.state)
             reverse: Sort direction (kept for compatibility, value comes from app.state)
-            all: Include archived tasks (default: False)
+            include_archived: Include archived tasks (default: False)
             keep_scroll_position: Whether to preserve scroll position during refresh.
                                  Set to True for periodic updates to avoid scroll stuttering.
         """
@@ -163,7 +165,7 @@ class GanttWidget(Vertical, ViNavigationMixin, TUIWidget):
         self.tui_state.gantt_cache = gantt_view_model
         # NOTE: sort_by and reverse parameters kept for API compatibility,
         # but actual values are read from self.tui_state
-        self._filter_all = all
+        self._filter_include_archived = include_archived
         self._keep_scroll_position = keep_scroll_position
         self._render_gantt()
 
@@ -378,13 +380,13 @@ class GanttWidget(Vertical, ViNavigationMixin, TUIWidget):
 
     # Public API methods for external access
 
-    def get_filter_all(self) -> bool:
+    def get_filter_include_archived(self) -> bool:
         """Get current archive filter setting.
 
         Returns:
             Whether to include archived tasks
         """
-        return self._filter_all
+        return self._filter_include_archived
 
     def get_sort_by(self) -> str:
         """Get current sort order.

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_export_command.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_export_command.py
@@ -123,7 +123,7 @@ class TestExportCommand:
         # Verify
         assert result.exit_code == 0
         call_kwargs = self.api_client.list_tasks.call_args[1]
-        assert call_kwargs["all"] is True
+        assert call_kwargs["include_archived"] is True
 
     @patch("taskdog.cli.commands.export.JsonTaskExporter")
     def test_export_with_status_filter(self, mock_exporter_class):

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_gantt_command.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_gantt_command.py
@@ -61,7 +61,7 @@ class TestGanttCommand:
         # Verify
         assert result.exit_code == 0
         call_kwargs = self.api_client.get_gantt_data.call_args[1]
-        assert call_kwargs["all"] is True
+        assert call_kwargs["include_archived"] is True
 
     @patch("taskdog.cli.commands.gantt.RichGanttRenderer")
     @patch("taskdog.cli.commands.gantt.GanttPresenter")

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_table_command.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_table_command.py
@@ -34,7 +34,7 @@ class TestTableCommand:
         # Verify
         assert result.exit_code == 0
         self.api_client.list_tasks.assert_called_once_with(
-            all=False,
+            include_archived=False,
             status=None,
             tags=None,
             start_date=None,
@@ -57,7 +57,7 @@ class TestTableCommand:
         # Verify
         assert result.exit_code == 0
         call_kwargs = self.api_client.list_tasks.call_args[1]
-        assert call_kwargs["all"] is True
+        assert call_kwargs["include_archived"] is True
 
     @patch("taskdog.cli.commands.table.render_table")
     def test_with_status_filter(self, mock_render_table):

--- a/packages/taskdog-ui/tests/presentation/exporters/test_markdown_table_exporter.py
+++ b/packages/taskdog-ui/tests/presentation/exporters/test_markdown_table_exporter.py
@@ -14,7 +14,7 @@ class TestMarkdownTableExporter:
 
     def _create_task_dto(
         self,
-        id: int,
+        task_id: int,
         name: str,
         priority: int,
         status: TaskStatus,
@@ -33,7 +33,7 @@ class TestMarkdownTableExporter:
     ) -> TaskRowDto:
         """Helper to create TaskRowDto with default values."""
         return TaskRowDto(
-            id=id,
+            id=task_id,
             name=name,
             priority=priority,
             status=status,
@@ -57,7 +57,7 @@ class TestMarkdownTableExporter:
         """Test basic markdown table export."""
         tasks = [
             self._create_task_dto(
-                id=1,
+                task_id=1,
                 name="Task 1",
                 priority=5,
                 status=TaskStatus.PENDING,
@@ -65,7 +65,7 @@ class TestMarkdownTableExporter:
                 estimated_duration=8.0,
             ),
             self._create_task_dto(
-                id=2,
+                task_id=2,
                 name="Task 2",
                 priority=3,
                 status=TaskStatus.COMPLETED,
@@ -92,7 +92,7 @@ class TestMarkdownTableExporter:
         """Test markdown export with specific fields."""
         tasks = [
             self._create_task_dto(
-                id=1,
+                task_id=1,
                 name="Task 1",
                 priority=5,
                 status=TaskStatus.PENDING,
@@ -113,7 +113,7 @@ class TestMarkdownTableExporter:
         """Test that None values are displayed as '-'."""
         tasks = [
             self._create_task_dto(
-                id=1,
+                task_id=1,
                 name="Task 1",
                 priority=5,
                 status=TaskStatus.PENDING,
@@ -134,7 +134,7 @@ class TestMarkdownTableExporter:
         """Test datetime formatting in export."""
         tasks = [
             self._create_task_dto(
-                id=1,
+                task_id=1,
                 name="Task 1",
                 priority=5,
                 status=TaskStatus.PENDING,

--- a/packages/taskdog-ui/tests/services/test_task_data_loader.py
+++ b/packages/taskdog-ui/tests/services/test_task_data_loader.py
@@ -46,7 +46,7 @@ class TestTaskDataLoader:
 
         # Execute
         result = self.loader.load_tasks(
-            all=False,
+            include_archived=False,
             sort_by="deadline",
             date_range=None,
         )
@@ -110,7 +110,7 @@ class TestTaskDataLoader:
 
         # Execute with date range
         result = self.loader.load_tasks(
-            all=False,
+            include_archived=False,
             sort_by="deadline",
             date_range=(date(2025, 1, 1), date(2025, 1, 7)),
         )

--- a/packages/taskdog-ui/tests/tui/services/test_task_ui_manager.py
+++ b/packages/taskdog-ui/tests/tui/services/test_task_ui_manager.py
@@ -330,7 +330,7 @@ class TestRecalculateGantt:
         self.main_screen = MagicMock()
         self.main_screen.gantt_widget = MagicMock()
         # Setup default return values for gantt_widget methods
-        self.main_screen.gantt_widget.get_filter_all.return_value = False
+        self.main_screen.gantt_widget.get_filter_include_archived.return_value = False
         self.main_screen.gantt_widget.get_sort_by.return_value = "deadline"
         self.on_connection_error = MagicMock()
 
@@ -366,7 +366,7 @@ class TestRecalculateGantt:
 
         # Verify API was called with parameters from gantt_widget
         self.task_data_loader.api_client.list_tasks.assert_called_once_with(
-            all=False,  # from gantt_widget.get_filter_all()
+            include_archived=False,  # from gantt_widget.get_filter_include_archived()
             sort_by="deadline",  # from gantt_widget.get_sort_by()
             reverse=self.state.sort_reverse,
             include_gantt=True,
@@ -385,7 +385,7 @@ class TestRecalculateGantt:
     def test_recalculate_gantt_respects_gantt_widget_filter_state(self):
         """Test recalculate_gantt uses filter/sort state from gantt_widget."""
         # Setup - gantt_widget has "all tasks" filter enabled
-        self.main_screen.gantt_widget.get_filter_all.return_value = True
+        self.main_screen.gantt_widget.get_filter_include_archived.return_value = True
         self.main_screen.gantt_widget.get_sort_by.return_value = "priority"
 
         gantt = create_gantt_viewmodel()
@@ -403,7 +403,9 @@ class TestRecalculateGantt:
 
         # Verify API was called with filter state from gantt_widget
         call_kwargs = self.task_data_loader.api_client.list_tasks.call_args[1]
-        assert call_kwargs["all"] is True  # Respects gantt_widget.get_filter_all()
+        assert (
+            call_kwargs["include_archived"] is True
+        )  # Respects gantt_widget.get_filter_include_archived()
         assert (
             call_kwargs["sort_by"] == "priority"
         )  # Respects gantt_widget.get_sort_by()
@@ -487,7 +489,7 @@ class TestErrorHandling:
             date.today(),
             date.today() + timedelta(days=7),
         )
-        self.main_screen.gantt_widget.get_filter_all.return_value = False
+        self.main_screen.gantt_widget.get_filter_include_archived.return_value = False
         self.main_screen.gantt_widget.get_sort_by.return_value = "deadline"
         self.on_connection_error = MagicMock()
         self.on_auth_error = MagicMock()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ src = ["src", "tests"]
 
 [tool.ruff.lint]
 select = [
+  "A",  # flake8-builtins
   "E",  # pycodestyle errors
   "W",  # pycodestyle warnings
   "F",  # pyflakes


### PR DESCRIPTION
## Summary

- Enable ruff's `A` (flake8-builtins) rule to detect variables/arguments that shadow Python builtins
- Rename Python parameter names while preserving backward-compatible CLI flags (`--all`, `--format`) and HTTP API query parameters (`?all=`)
- Fix all 14 violations across 5 packages: `all` → `include_archived`, `format` → `export_format`, `id` → `task_id` (test only)

Closes #702

## Test plan

- [x] `make lint` — all 5 packages pass with the new `A` rule enabled
- [x] `make test` — all tests pass (core: 1097, server: 285, UI: 934)
- [x] `make typecheck` — no issues found
- [x] CLI flags (`--all`, `--format`) unchanged — no user-facing changes
- [x] HTTP API query params (`?all=true`) unchanged via `Query(alias="all")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)