### PR TITLE
refactor: enable ruff ISC rule for implicit string concatenation detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ select = [
   "W",  # pycodestyle warnings
   "F",  # pyflakes
   "I",  # isort
+  "ISC",  # flake8-implicit-str-concat
   "UP",  # pyupgrade
   "B",  # flake8-bugbear
   "C90",  # mccabe


### PR DESCRIPTION
## Summary

- Enable ruff's `ISC` (flake8-implicit-str-concat) rule to prevent subtle bugs from unintentional adjacent string literal concatenation
- No existing violations — this is a preventive measure only (1-line config change)

Closes #700

## Test plan

- [x] `make lint` — all 5 packages pass with the new `ISC` rule enabled
- [x] Zero violations in existing codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)