### PR TITLE
ci: add codespell for typo detection

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = .git,*.egg-info,*.pyc,__pycache__,.mypy_cache,.ruff_cache,.venv,uv.lock
+ignore-words-list = selectin,re-use

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Run linter
         run: make lint
 
+      - name: Run spell checker
+        run: uv tool run codespell
+
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,13 @@ repos:
     hooks:
       - id: actionlint
 
+  # Spell checker
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        additional_dependencies: [tomli]
+
   # Standard pre-commit hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
         install install-dev install-hooks install-core install-server install-ui install-client install-mcp \
         install-ui-only install-server-only reinstall \
         tool-install-ui tool-install-server check-deps \
-        clean lint format typecheck check \
+        clean lint format typecheck spell check \
         lint-core lint-client lint-server lint-ui lint-mcp \
         typecheck-core typecheck-client typecheck-server typecheck-ui typecheck-mcp \
         bump-version show-version
@@ -255,7 +255,10 @@ typecheck-server: typecheck-taskdog-server ## Type check taskdog-server
 typecheck-ui: typecheck-taskdog-ui ## Type check taskdog-ui
 typecheck-mcp: typecheck-taskdog-mcp ## Type check taskdog-mcp
 
-check: lint typecheck ## Run all code quality checks (lint + typecheck)
+spell: ## Run spell checker
+	uv tool run codespell
+
+check: lint typecheck spell ## Run all code quality checks (lint + typecheck + spell)
 	@echo ""
 	@echo "✓ All code quality checks passed!"
 	@echo ""


### PR DESCRIPTION
## Summary

Closes #706

- Add [codespell](https://github.com/codespell-project/codespell) to detect typos in code and comments
- Integrate into pre-commit hooks (`.pre-commit-config.yaml`), CI lint job (`.github/workflows/ci.yml`), and Makefile (`make spell` / `make check`)
- Add `.codespellrc` with skip patterns for generated files and ignore list for false positives (`selectin`, `re-use`)

## Changes

| File | Change |
|------|--------|
| `.codespellrc` | New config: skip patterns + ignore words |
| `.pre-commit-config.yaml` | Add codespell hook (v2.4.1) |
| `.github/workflows/ci.yml` | Add "Run spell checker" step to lint job |
| `Makefile` | Add `spell` target, include in `check` |

## Test plan

- [x] `uv tool run codespell` passes with no errors
- [x] `make spell` runs successfully
- [x] Pre-commit hook passes (`codespell` hook in pre-commit output)
- [ ] CI lint job passes with new spell checker step

🤖 Generated with [Claude Code](https://claude.com/claude-code)