### PR TITLE
chore: add uv lock --check to CI (#708)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,11 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Install dependencies
-        run: uv sync --all-extras --dev
-
       - name: Check lock file is up to date
         run: uv lock --check
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
 
       - name: Run linter
         run: make lint


### PR DESCRIPTION
## Summary

Closes #708

Add `uv lock --check` step to the CI lint job to detect stale lock files when `pyproject.toml` is modified without running `uv lock`.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Add "Check lock file is up to date" step before linter |

## Test plan

- [x] `uv lock --check` passes locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)