### PR TITLE
refactor: unify presenter API to instance methods with consistent naming

### DIFF
--- a/packages/taskdog-ui/src/taskdog/cli/commands/stats.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/stats.py
@@ -52,7 +52,7 @@ def stats_command(ctx: click.Context, period: str, focus: str) -> None:
         return
 
     # Convert DTO to ViewModel (Mapper applies presentation logic)
-    view_model = StatisticsPresenter.from_statistics_result(result)
+    view_model = StatisticsPresenter().present(result)
 
     # Render statistics
     renderer = RichStatisticsRenderer(console_writer)

--- a/packages/taskdog-ui/src/taskdog/presenters/__init__.py
+++ b/packages/taskdog-ui/src/taskdog/presenters/__init__.py
@@ -8,5 +8,11 @@ ensure the presentation layer remains independent from domain entities.
 from taskdog.presenters.gantt_presenter import GanttPresenter
 from taskdog.presenters.statistics_presenter import StatisticsPresenter
 from taskdog.presenters.table_presenter import TablePresenter
+from taskdog.presenters.timeline_presenter import TimelinePresenter
 
-__all__ = ["GanttPresenter", "StatisticsPresenter", "TablePresenter"]
+__all__ = [
+    "GanttPresenter",
+    "StatisticsPresenter",
+    "TablePresenter",
+    "TimelinePresenter",
+]

--- a/packages/taskdog-ui/src/taskdog/presenters/statistics_presenter.py
+++ b/packages/taskdog-ui/src/taskdog/presenters/statistics_presenter.py
@@ -26,8 +26,8 @@ class StatisticsPresenter:
     2. Converting DTO data to presentation-ready ViewModels
     """
 
-    @staticmethod
-    def from_statistics_result(
+    def present(
+        self,
         statistics_result: StatisticsOutput,
     ) -> StatisticsViewModel:
         """Convert StatisticsOutput DTO to StatisticsViewModel.
@@ -41,14 +41,12 @@ class StatisticsPresenter:
         # Convert TimeStatistics if present
         time_stats_vm = None
         if statistics_result.time_stats:
-            time_stats_vm = StatisticsPresenter._map_time_statistics(
-                statistics_result.time_stats
-            )
+            time_stats_vm = self._map_time_statistics(statistics_result.time_stats)
 
         # Convert EstimationAccuracyStatistics if present
         estimation_stats_vm = None
         if statistics_result.estimation_stats:
-            estimation_stats_vm = StatisticsPresenter._map_estimation_statistics(
+            estimation_stats_vm = self._map_estimation_statistics(
                 statistics_result.estimation_stats
             )
 
@@ -62,8 +60,9 @@ class StatisticsPresenter:
             trend_stats=statistics_result.trend_stats,
         )
 
-    @staticmethod
-    def _map_time_statistics(time_stats: TimeStatistics) -> TimeStatisticsViewModel:
+    def _map_time_statistics(
+        self, time_stats: TimeStatistics
+    ) -> TimeStatisticsViewModel:
         """Convert TimeStatistics to TimeStatisticsViewModel.
 
         Args:
@@ -74,15 +73,11 @@ class StatisticsPresenter:
         """
         longest_task_vm = None
         if time_stats.longest_task:
-            longest_task_vm = StatisticsPresenter._map_task_to_summary(
-                time_stats.longest_task
-            )
+            longest_task_vm = self._map_task_to_summary(time_stats.longest_task)
 
         shortest_task_vm = None
         if time_stats.shortest_task:
-            shortest_task_vm = StatisticsPresenter._map_task_to_summary(
-                time_stats.shortest_task
-            )
+            shortest_task_vm = self._map_task_to_summary(time_stats.shortest_task)
 
         return TimeStatisticsViewModel(
             total_work_hours=time_stats.total_work_hours,
@@ -93,8 +88,8 @@ class StatisticsPresenter:
             tasks_with_time_tracking=time_stats.tasks_with_time_tracking,
         )
 
-    @staticmethod
     def _map_estimation_statistics(
+        self,
         estimation_stats: EstimationAccuracyStatistics,
     ) -> EstimationAccuracyStatisticsViewModel:
         """Convert EstimationAccuracyStatistics to EstimationAccuracyStatisticsViewModel.
@@ -106,12 +101,12 @@ class StatisticsPresenter:
             EstimationAccuracyStatisticsViewModel with TaskSummaryViewModel
         """
         best_estimated_tasks_vm = [
-            StatisticsPresenter._map_task_to_summary(task)
+            self._map_task_to_summary(task)
             for task in estimation_stats.best_estimated_tasks
         ]
 
         worst_estimated_tasks_vm = [
-            StatisticsPresenter._map_task_to_summary(task)
+            self._map_task_to_summary(task)
             for task in estimation_stats.worst_estimated_tasks
         ]
 
@@ -125,8 +120,7 @@ class StatisticsPresenter:
             worst_estimated_tasks=worst_estimated_tasks_vm,
         )
 
-    @staticmethod
-    def _map_task_to_summary(task: TaskSummaryDto) -> TaskSummaryViewModel:
+    def _map_task_to_summary(self, task: TaskSummaryDto) -> TaskSummaryViewModel:
         """Convert a TaskSummaryDto to TaskSummaryViewModel.
 
         Args:

--- a/packages/taskdog-ui/src/taskdog/presenters/table_presenter.py
+++ b/packages/taskdog-ui/src/taskdog/presenters/table_presenter.py
@@ -26,9 +26,9 @@ class TablePresenter:
         Returns:
             List of TaskRowViewModels ready for rendering
         """
-        return [self._task_to_view_model(task) for task in output.tasks]
+        return [self._map_task_to_view_model(task) for task in output.tasks]
 
-    def _task_to_view_model(self, task: TaskRowDto) -> TaskRowViewModel:
+    def _map_task_to_view_model(self, task: TaskRowDto) -> TaskRowViewModel:
         """Convert a TaskRowDto to TaskRowViewModel.
 
         Args:

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/stats_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/stats_dialog.py
@@ -148,7 +148,7 @@ class StatsDialog(BaseModalDialog[None], ViNavigationMixin):
                 self._api_client.calculate_statistics,
                 period=period,
             )
-            view_model = StatisticsPresenter.from_statistics_result(result)
+            view_model = StatisticsPresenter().present(result)
         except Exception as e:
             self._loaded_periods[tab_id] = False
             self.notify(f"Failed to load statistics: {e}", severity="error")

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_stats_command.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_stats_command.py
@@ -31,7 +31,7 @@ class TestStatsCommand:
         self.api_client.calculate_statistics.return_value = mock_result
 
         mock_view_model = MagicMock()
-        mock_mapper_class.from_statistics_result.return_value = mock_view_model
+        mock_mapper_class.return_value.present.return_value = mock_view_model
 
         mock_renderer = MagicMock()
         mock_renderer_class.return_value = mock_renderer
@@ -42,7 +42,7 @@ class TestStatsCommand:
         # Verify
         assert result.exit_code == 0
         self.api_client.calculate_statistics.assert_called_once_with(period="all")
-        mock_mapper_class.from_statistics_result.assert_called_once_with(mock_result)
+        mock_mapper_class.return_value.present.assert_called_once_with(mock_result)
         mock_renderer.render.assert_called_once_with(mock_view_model, focus="all")
 
     @patch("taskdog.cli.commands.stats.RichStatisticsRenderer")
@@ -53,7 +53,7 @@ class TestStatsCommand:
         mock_result = MagicMock()
         mock_result.task_stats.total_tasks = 10
         self.api_client.calculate_statistics.return_value = mock_result
-        mock_mapper_class.from_statistics_result.return_value = MagicMock()
+        mock_mapper_class.return_value.present.return_value = MagicMock()
 
         # Execute
         result = self.runner.invoke(
@@ -72,7 +72,7 @@ class TestStatsCommand:
         mock_result = MagicMock()
         mock_result.task_stats.total_tasks = 10
         self.api_client.calculate_statistics.return_value = mock_result
-        mock_mapper_class.from_statistics_result.return_value = MagicMock()
+        mock_mapper_class.return_value.present.return_value = MagicMock()
 
         mock_renderer = MagicMock()
         mock_renderer_class.return_value = mock_renderer
@@ -127,7 +127,7 @@ class TestStatsCommand:
         mock_result = MagicMock()
         mock_result.task_stats.total_tasks = 10
         self.api_client.calculate_statistics.return_value = mock_result
-        mock_mapper_class.from_statistics_result.return_value = MagicMock()
+        mock_mapper_class.return_value.present.return_value = MagicMock()
 
         # Execute
         result = self.runner.invoke(
@@ -151,7 +151,7 @@ class TestStatsCommand:
         mock_result = MagicMock()
         mock_result.task_stats.total_tasks = 10
         self.api_client.calculate_statistics.return_value = mock_result
-        mock_mapper_class.from_statistics_result.return_value = MagicMock()
+        mock_mapper_class.return_value.present.return_value = MagicMock()
 
         mock_renderer = MagicMock()
         mock_renderer_class.return_value = mock_renderer

--- a/packages/taskdog-ui/tests/presenters/test_statistics_presenter.py
+++ b/packages/taskdog-ui/tests/presenters/test_statistics_presenter.py
@@ -59,7 +59,7 @@ class TestStatisticsPresenter:
         )
 
         # Execute
-        result = StatisticsPresenter.from_statistics_result(statistics_output)
+        result = StatisticsPresenter().present(statistics_output)
 
         # Verify
         assert isinstance(result, StatisticsViewModel)
@@ -98,7 +98,7 @@ class TestStatisticsPresenter:
         )
 
         # Execute
-        result = StatisticsPresenter.from_statistics_result(statistics_output)
+        result = StatisticsPresenter().present(statistics_output)
 
         # Verify
         assert result.time_stats is not None
@@ -138,7 +138,7 @@ class TestStatisticsPresenter:
         )
 
         # Execute
-        result = StatisticsPresenter.from_statistics_result(statistics_output)
+        result = StatisticsPresenter().present(statistics_output)
 
         # Verify
         assert result.time_stats is not None
@@ -174,7 +174,7 @@ class TestStatisticsPresenter:
         )
 
         # Execute
-        result = StatisticsPresenter.from_statistics_result(statistics_output)
+        result = StatisticsPresenter().present(statistics_output)
 
         # Verify
         assert result.estimation_stats is not None
@@ -215,7 +215,7 @@ class TestStatisticsPresenter:
         )
 
         # Execute
-        result = StatisticsPresenter.from_statistics_result(statistics_output)
+        result = StatisticsPresenter().present(statistics_output)
 
         # Verify - deadline_stats is passed through directly
         assert result.deadline_stats == deadline_stats
@@ -243,7 +243,7 @@ class TestStatisticsPresenter:
         )
 
         # Execute
-        result = StatisticsPresenter.from_statistics_result(statistics_output)
+        result = StatisticsPresenter().present(statistics_output)
 
         # Verify - trend_stats is passed through directly
         assert result.trend_stats == trend_stats
@@ -298,7 +298,7 @@ class TestStatisticsPresenter:
         )
 
         # Execute
-        result = StatisticsPresenter.from_statistics_result(statistics_output)
+        result = StatisticsPresenter().present(statistics_output)
 
         # Verify all stats are present
         assert result.task_stats is not None
@@ -318,7 +318,7 @@ class TestMapTaskToSummary:
         task_dto = TaskSummaryDto(id=42, name="Test Task")
 
         # Execute
-        result = StatisticsPresenter._map_task_to_summary(task_dto)
+        result = StatisticsPresenter()._map_task_to_summary(task_dto)
 
         # Verify
         assert isinstance(result, TaskSummaryViewModel)


### PR DESCRIPTION
## Summary

- Convert `StatisticsPresenter` from static methods (`from_statistics_result()`) to instance methods with `present()` entry point, matching the pattern already used by `TablePresenter` and `GanttPresenter`
- Rename `TablePresenter._task_to_view_model` → `_map_task_to_view_model` for consistent `_map_*` naming convention across all presenters
- Export `TimelinePresenter` from `presenters/__init__.py` for completeness

All four presenters now follow a unified API: `PresenterClass().present(input)` with `_map_*` private methods.

A base class was evaluated but intentionally not introduced — the presenters have incompatible `present()` signatures and no shared logic, so a base class would add boilerplate with zero code reduction.

## Test plan

- [x] All 934 UI tests pass
- [x] Lint, format, and type checks pass (pre-commit hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)