### PR TITLE
fix: disable smooth scrolling and set Gantt horizontal scroll to CHARS_PER_DAY

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/widgets/audit_log_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/audit_log_table.py
@@ -45,6 +45,14 @@ class AuditLogTable(DataTable, TUIWidget, ViNavigationMixin):  # type: ignore[ty
         self.cursor_type = "none"
         self.zebra_stripes = True
 
+    def action_scroll_down(self) -> None:
+        """Scroll down one line."""
+        self.scroll_down(animate=False)
+
+    def action_scroll_up(self) -> None:
+        """Scroll up one line."""
+        self.scroll_up(animate=False)
+
     def action_goto_top(self) -> None:
         """Scroll to the top of the table."""
         self.scroll_home(animate=False)

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
@@ -96,6 +96,7 @@ class GanttWidget(Vertical, ViNavigationMixin, TUIWidget):
             **kwargs: Keyword arguments to pass to the method
         """
         if self._gantt_table:
+            kwargs.setdefault("animate", False)
             getattr(self._gantt_table, method_name)(*args, **kwargs)
 
     def action_scroll_down(self) -> None:
@@ -123,12 +124,16 @@ class GanttWidget(Vertical, ViNavigationMixin, TUIWidget):
         self._delegate_scroll("scroll_page_up")
 
     def action_scroll_left(self) -> None:
-        """Scroll left."""
-        self._delegate_scroll("scroll_left")
+        """Scroll left by one day."""
+        if self._gantt_table:
+            self._gantt_table.scroll_x = max(
+                0, self._gantt_table.scroll_x - CHARS_PER_DAY
+            )
 
     def action_scroll_right(self) -> None:
-        """Scroll right."""
-        self._delegate_scroll("scroll_right")
+        """Scroll right by one day."""
+        if self._gantt_table:
+            self._gantt_table.scroll_x = self._gantt_table.scroll_x + CHARS_PER_DAY
 
     def action_scroll_home_horizontal(self) -> None:
         """Scroll to leftmost position (0 key)."""


### PR DESCRIPTION
## Summary
- Disable smooth scroll animation across TUI widgets for consistent, instant scrolling behavior
- Set Gantt horizontal scroll to move exactly `CHARS_PER_DAY` (3 chars = 1 day) per key press via direct `scroll_x` assignment
- Add `action_scroll_down`/`action_scroll_up` overrides to `AuditLogTable` with `animate=False`

## Details
- `GanttWidget._delegate_scroll`: added `kwargs.setdefault("animate", False)` so all delegated scroll calls skip animation
- `GanttWidget.action_scroll_left/right`: replaced delegation with direct `scroll_x` assignment using `CHARS_PER_DAY` constant
- `AuditLogTable`: added scroll overrides matching the pattern already used by `action_goto_top`/`action_goto_bottom`

## Test Plan
- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] `make test-ui` passes (934 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)