### PR TITLE
fix: create data directory before systemd service setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ install: check-deps ## Install all commands globally with uv tool (recommended)
 	@echo ""
 ifeq ($(PLATFORM),linux)
 	@echo "Setting up systemd user service..."
+	@mkdir -p ~/.local/share/taskdog
 	@mkdir -p ~/.config/systemd/user
 	@cp contrib/systemd/taskdog-server.service ~/.config/systemd/user/
 	@systemctl --user daemon-reload


### PR DESCRIPTION
## Summary
- On fresh installs, `make install` sets up a systemd service with `ReadWritePaths=%h/.local/share/taskdog`, but the directory doesn't exist yet — systemd validates this path **before** launching the process, causing error 226 (NAMESPACE)
- Add `mkdir -p ~/.local/share/taskdog` in the Makefile's install target, before the systemd service setup

Closes #690

## Test plan
- [ ] On a clean system (or after `rm -rf ~/.local/share/taskdog`), run `make install` and verify `~/.local/share/taskdog` exists
- [ ] `systemctl --user start taskdog-server` should start without error 226

🤖 Generated with [Claude Code](https://claude.com/claude-code)