### PR TITLE
fix: auto-fit CLI Gantt chart to terminal width

### DIFF
--- a/packages/taskdog-ui/src/taskdog/cli/commands/gantt.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/gantt.py
@@ -7,6 +7,11 @@ import click
 from taskdog.cli.commands.common_options import filter_options, sort_options
 from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_command_errors
+from taskdog.constants.table_dimensions import (
+    CHARS_PER_DAY,
+    GANTT_CLI_FIXED_COLUMNS_WIDTH,
+    MIN_TIMELINE_WIDTH,
+)
 from taskdog.presenters.gantt_presenter import GanttPresenter
 from taskdog.renderers.rich_gantt_renderer import RichGanttRenderer
 
@@ -67,7 +72,7 @@ EXAMPLE:
     "--end-date",
     "-e",
     type=click.DateTime(),
-    help="End date for the chart (YYYY-MM-DD). Defaults to last task date.",
+    help="End date for the chart (YYYY-MM-DD). Defaults to fit terminal width.",
 )
 @sort_options(default_sort="deadline")
 @filter_options()
@@ -106,7 +111,16 @@ def gantt_command(
         today = date.today()
         start_date_obj = today - timedelta(days=today.weekday())
 
-    end_date_obj = end_date.date() if end_date else None
+    if end_date:
+        end_date_obj: date | None = end_date.date()
+    else:
+        # Auto-fit to terminal width when end_date not specified
+        terminal_width = ctx_obj.console_writer.get_width()
+        timeline_width = max(
+            terminal_width - GANTT_CLI_FIXED_COLUMNS_WIDTH, MIN_TIMELINE_WIDTH
+        )
+        max_days = timeline_width // CHARS_PER_DAY
+        end_date_obj = start_date_obj + timedelta(days=max_days - 1)
 
     # Get Gantt data via API client
     gantt_result = ctx_obj.api_client.get_gantt_data(

--- a/packages/taskdog-ui/src/taskdog/constants/table_dimensions.py
+++ b/packages/taskdog-ui/src/taskdog/constants/table_dimensions.py
@@ -14,6 +14,8 @@ GANTT_TABLE_EST_HOURS_WIDTH = 7
 # Gantt Chart Timeline Dimensions
 MIN_TIMELINE_WIDTH = 30
 CHARS_PER_DAY = 3
+# Fixed columns overhead for CLI Gantt: ID(4) + Name(30) + Est(7) + padding(8) + borders(5)
+GANTT_CLI_FIXED_COLUMNS_WIDTH = 54
 
 # Gantt Widget Dimensions (TUI)
 DEFAULT_GANTT_WIDGET_WIDTH = 120

--- a/packages/taskdog-ui/src/taskdog/renderers/rich_gantt_renderer.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/rich_gantt_renderer.py
@@ -16,7 +16,7 @@ from taskdog.constants.column_headers import (
 from taskdog.constants.table_dimensions import (
     GANTT_TABLE_EST_HOURS_WIDTH,
     GANTT_TABLE_ID_WIDTH,
-    GANTT_TABLE_TASK_MIN_WIDTH,
+    TASK_NAME_COLUMN_WIDTH,
 )
 from taskdog.constants.table_styles import (
     COLUMN_ID_STYLE,
@@ -119,7 +119,7 @@ class RichGanttRenderer(RichRendererBase):
             width=GANTT_TABLE_ID_WIDTH,
         )
         table.add_column(
-            HEADER_NAME, style=COLUMN_NAME_STYLE, min_width=GANTT_TABLE_TASK_MIN_WIDTH
+            HEADER_NAME, style=COLUMN_NAME_STYLE, width=TASK_NAME_COLUMN_WIDTH
         )
         table.add_column(
             HEADER_ESTIMATED.replace("[", "\\["),

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_gantt_command.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_gantt_command.py
@@ -16,6 +16,7 @@ class TestGanttCommand:
         """Set up test fixtures."""
         self.runner = CliRunner()
         self.console_writer = MagicMock()
+        self.console_writer.get_width.return_value = 200
         self.api_client = MagicMock()
         self.cli_context = MagicMock()
         self.cli_context.console_writer = self.console_writer


### PR DESCRIPTION
## Summary
- CLI Gantt chart now auto-calculates end date from terminal width when `--end-date` is not specified, preventing line wrapping
- Fix Name column to use fixed `width=30` (matching TUI) instead of `min_width=20`, which caused unpredictable column expansion with long task names
- Add `GANTT_CLI_FIXED_COLUMNS_WIDTH` constant for accurate overhead calculation

## Test plan
- [x] `taskdog gantt` fits within terminal without wrapping
- [x] `taskdog gantt --end-date 2026-06-01` still allows explicit override
- [x] `make test-ui` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)