### PR TITLE
refactor(core): remove pass-through __init__ from controllers

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/controllers/task_lifecycle_controller.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/task_lifecycle_controller.py
@@ -26,8 +26,6 @@ from taskdog_core.application.use_cases.status_change_use_case import (
 )
 from taskdog_core.controllers.base_controller import BaseTaskController
 from taskdog_core.domain.repositories.task_repository import TaskRepository
-from taskdog_core.domain.services.logger import Logger
-from taskdog_core.shared.config_manager import Config
 
 # Type alias for use case factory function
 StatusChangeUseCaseFactory = Callable[
@@ -52,21 +50,6 @@ class TaskLifecycleController(BaseTaskController):
         config: Application configuration (inherited from BaseTaskController)
         logger: Optional logger (inherited from BaseTaskController)
     """
-
-    def __init__(
-        self,
-        repository: TaskRepository,
-        config: Config,
-        logger: Logger,
-    ):
-        """Initialize the lifecycle controller.
-
-        Args:
-            repository: Task repository
-            config: Application configuration
-            logger: Logger for operation tracking
-        """
-        super().__init__(repository, config, logger)
 
     def _execute_status_change(
         self,

--- a/packages/taskdog-core/src/taskdog_core/controllers/task_relationship_controller.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/task_relationship_controller.py
@@ -20,9 +20,6 @@ from taskdog_core.application.use_cases.delete_tag import DeleteTagUseCase
 from taskdog_core.application.use_cases.remove_dependency import RemoveDependencyUseCase
 from taskdog_core.application.use_cases.set_task_tags import SetTaskTagsUseCase
 from taskdog_core.controllers.base_controller import BaseTaskController
-from taskdog_core.domain.repositories.task_repository import TaskRepository
-from taskdog_core.domain.services.logger import Logger
-from taskdog_core.shared.config_manager import Config
 
 
 class TaskRelationshipController(BaseTaskController):
@@ -39,16 +36,6 @@ class TaskRelationshipController(BaseTaskController):
         config: Application configuration (inherited from BaseTaskController)
         logger: Optional logger (inherited from BaseTaskController)
     """
-
-    def __init__(self, repository: TaskRepository, config: Config, logger: Logger):
-        """Initialize the relationship controller.
-
-        Args:
-            repository: Task repository
-            config: Application configuration
-            logger: Logger for operation tracking
-        """
-        super().__init__(repository, config, logger)
 
     def add_dependency(self, task_id: int, depends_on_id: int) -> TaskOperationOutput:
         """Add a dependency to a task.


### PR DESCRIPTION
## Summary

- Remove redundant `__init__` methods from `TaskLifecycleController` and `TaskRelationshipController` that only called `super().__init__()` with identical parameters
- Clean up unused imports (`Config`, `Logger`) that were only needed by the removed constructors

## Test plan

- [x] `make test-core` — 1097 passed
- [x] `make test-server` — 291 passed
- [x] `make lint` — passed
- [x] `make typecheck` — passed