### PR TITLE
refactor(core): replace GetTaskDetailInput with SingleTaskInput

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/get_task_detail.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/get_task_detail.py
@@ -1,5 +1,6 @@
 """Use case for getting task detail with notes."""
 
+from taskdog_core.application.dto.base import SingleTaskInput
 from taskdog_core.application.dto.task_detail_output import TaskDetailOutput
 from taskdog_core.application.dto.task_dto import TaskDetailDto
 from taskdog_core.application.use_cases.base import UseCase
@@ -7,23 +8,7 @@ from taskdog_core.domain.repositories.notes_repository import NotesRepository
 from taskdog_core.domain.repositories.task_repository import TaskRepository
 
 
-class GetTaskDetailInput:
-    """Input for getting task detail.
-
-    Attributes:
-        task_id: ID of the task to retrieve
-    """
-
-    def __init__(self, task_id: int):
-        """Initialize input.
-
-        Args:
-            task_id: ID of the task to retrieve
-        """
-        self.task_id = task_id
-
-
-class GetTaskDetailUseCase(UseCase[GetTaskDetailInput, TaskDetailOutput]):
+class GetTaskDetailUseCase(UseCase[SingleTaskInput, TaskDetailOutput]):
     """Use case for retrieving task details with notes.
 
     This use case fetches a task by ID and its associated notes file
@@ -40,7 +25,7 @@ class GetTaskDetailUseCase(UseCase[GetTaskDetailInput, TaskDetailOutput]):
         self.repository = repository
         self.notes_repository = notes_repository
 
-    def execute(self, input_dto: GetTaskDetailInput) -> TaskDetailOutput:
+    def execute(self, input_dto: SingleTaskInput) -> TaskDetailOutput:
         """Execute task detail retrieval.
 
         Args:

--- a/packages/taskdog-core/src/taskdog_core/controllers/query_controller.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/query_controller.py
@@ -8,6 +8,7 @@ and filter construction.
 from datetime import date
 from typing import TYPE_CHECKING
 
+from taskdog_core.application.dto.base import SingleTaskInput
 from taskdog_core.application.dto.gantt_output import GanttOutput
 from taskdog_core.application.dto.get_task_by_id_output import TaskByIdOutput
 from taskdog_core.application.dto.query_inputs import GetGanttDataInput, ListTasksInput
@@ -20,10 +21,7 @@ from taskdog_core.application.services.optimization.strategy_factory import (
     StrategyFactory,
 )
 from taskdog_core.application.use_cases.get_gantt_data import GetGanttDataUseCase
-from taskdog_core.application.use_cases.get_task_detail import (
-    GetTaskDetailInput,
-    GetTaskDetailUseCase,
-)
+from taskdog_core.application.use_cases.get_task_detail import GetTaskDetailUseCase
 from taskdog_core.application.use_cases.list_tasks import ListTasksUseCase
 from taskdog_core.domain.repositories.notes_repository import NotesRepository
 from taskdog_core.domain.repositories.task_repository import TaskRepository
@@ -204,7 +202,7 @@ class QueryController:
             )
 
         use_case = GetTaskDetailUseCase(self.repository, self.notes_repository)
-        return use_case.execute(GetTaskDetailInput(task_id))
+        return use_case.execute(SingleTaskInput(task_id=task_id))
 
     def get_algorithm_metadata(self) -> list[tuple[str, str, str]]:
         """Get metadata for all available optimization algorithms.

--- a/packages/taskdog-core/tests/application/use_cases/test_get_task_detail_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_get_task_detail_use_case.py
@@ -5,10 +5,8 @@ from datetime import datetime
 import pytest
 from fixtures.repositories import InMemoryNotesRepository
 
-from taskdog_core.application.use_cases.get_task_detail import (
-    GetTaskDetailInput,
-    GetTaskDetailUseCase,
-)
+from taskdog_core.application.dto.base import SingleTaskInput
+from taskdog_core.application.use_cases.get_task_detail import GetTaskDetailUseCase
 from taskdog_core.domain.exceptions.task_exceptions import TaskNotFoundException
 
 
@@ -26,7 +24,7 @@ class TestGetTaskDetailUseCase:
         """Test execute returns TaskDetailDTO with task data."""
         task = self.repository.create(name="Test Task", priority=1)
 
-        input_dto = GetTaskDetailInput(task.id)
+        input_dto = SingleTaskInput(task.id)
         result = self.use_case.execute(input_dto)
 
         assert result.task.id == task.id
@@ -42,7 +40,7 @@ class TestGetTaskDetailUseCase:
         notes_content = "# Test Notes\n\nThis is a test note."
         self.notes_repository.write_notes(task.id, notes_content)
 
-        input_dto = GetTaskDetailInput(task.id)
+        input_dto = SingleTaskInput(task.id)
         result = self.use_case.execute(input_dto)
 
         assert result.has_notes is True
@@ -52,7 +50,7 @@ class TestGetTaskDetailUseCase:
         """Test execute handles missing notes gracefully."""
         task = self.repository.create(name="Test Task", priority=1)
 
-        input_dto = GetTaskDetailInput(task.id)
+        input_dto = SingleTaskInput(task.id)
         result = self.use_case.execute(input_dto)
 
         assert result.has_notes is False
@@ -60,7 +58,7 @@ class TestGetTaskDetailUseCase:
 
     def test_execute_with_invalid_task_raises_error(self):
         """Test execute with non-existent task raises TaskNotFoundException."""
-        input_dto = GetTaskDetailInput(task_id=999)
+        input_dto = SingleTaskInput(task_id=999)
 
         with pytest.raises(TaskNotFoundException) as exc_info:
             self.use_case.execute(input_dto)
@@ -78,7 +76,7 @@ class TestGetTaskDetailUseCase:
             estimated_duration=2.5,
         )
 
-        input_dto = GetTaskDetailInput(task.id)
+        input_dto = SingleTaskInput(task.id)
         result = self.use_case.execute(input_dto)
 
         assert result.task.name == "Complex Task"


### PR DESCRIPTION
## Summary

- Remove duplicate `GetTaskDetailInput` class from `get_task_detail.py` and replace it with the existing `SingleTaskInput` dataclass, which has the identical role of wrapping a single `task_id`
- Update `QueryController` and tests to use `SingleTaskInput`

## Test plan

- [x] `make test-core` — 1097 tests passed
- [x] `make lint` — clean
- [x] `make typecheck` — clean