### PR TITLE
refactor(ui): remove unused raw fields from Gantt/Timeline ViewModels

### DIFF
--- a/packages/taskdog-ui/src/taskdog/presenters/gantt_presenter.py
+++ b/packages/taskdog-ui/src/taskdog/presenters/gantt_presenter.py
@@ -68,9 +68,7 @@ class GanttPresenter:
 
         return TaskGanttRowViewModel(
             id=task.id,
-            name=task.name,
             formatted_name=formatted_name,
-            estimated_duration=task.estimated_duration,
             formatted_estimated_duration=formatted_estimated_duration,
             status=task.status,
             planned_start=task.planned_start.date() if task.planned_start else None,

--- a/packages/taskdog-ui/src/taskdog/presenters/timeline_presenter.py
+++ b/packages/taskdog-ui/src/taskdog/presenters/timeline_presenter.py
@@ -139,7 +139,6 @@ class TimelinePresenter:
 
         return TimelineTaskRowViewModel(
             task_id=task_row.id,
-            name=task_row.name,
             formatted_name=formatted_name,
             actual_start=start_time,
             actual_end=end_time,

--- a/packages/taskdog-ui/src/taskdog/view_models/gantt_view_model.py
+++ b/packages/taskdog-ui/src/taskdog/view_models/gantt_view_model.py
@@ -21,9 +21,7 @@ class TaskGanttRowViewModel(BaseViewModel):
 
     Attributes:
         id: Task ID
-        name: Task name (raw, without formatting)
         formatted_name: Task name with presentation formatting (strikethrough, etc.)
-        estimated_duration: Estimated duration in hours (None if not set)
         formatted_estimated_duration: Formatted duration string (e.g., "8.0", "-")
         status: Task status (needed for timeline cell formatting)
         planned_start: Planned start date (None if not set)
@@ -35,9 +33,7 @@ class TaskGanttRowViewModel(BaseViewModel):
     """
 
     id: int
-    name: str
     formatted_name: str
-    estimated_duration: float | None
     formatted_estimated_duration: str
     status: TaskStatus
     planned_start: date | None

--- a/packages/taskdog-ui/src/taskdog/view_models/timeline_view_model.py
+++ b/packages/taskdog-ui/src/taskdog/view_models/timeline_view_model.py
@@ -20,7 +20,6 @@ class TimelineTaskRowViewModel(BaseViewModel):
 
     Attributes:
         task_id: Task ID
-        name: Task name (raw, without formatting)
         formatted_name: Task name with presentation formatting (strikethrough, etc.)
         actual_start: Actual start time on the target date
         actual_end: Actual end time on the target date
@@ -30,7 +29,6 @@ class TimelineTaskRowViewModel(BaseViewModel):
     """
 
     task_id: int
-    name: str
     formatted_name: str
     actual_start: time
     actual_end: time

--- a/packages/taskdog-ui/tests/presentation/renderers/test_rich_gantt_renderer.py
+++ b/packages/taskdog-ui/tests/presentation/renderers/test_rich_gantt_renderer.py
@@ -22,9 +22,7 @@ class TestRichGanttRendererBuildTable:
         # Sample task view models
         self.task1 = TaskGanttRowViewModel(
             id=1,
-            name="Task 1",
             formatted_name="Task 1",
-            estimated_duration=8.0,
             formatted_estimated_duration="8.0",
             status=TaskStatus.PENDING,
             planned_start=date(2025, 1, 1),
@@ -37,9 +35,7 @@ class TestRichGanttRendererBuildTable:
 
         self.task2 = TaskGanttRowViewModel(
             id=2,
-            name="Task 2",
             formatted_name="[strike dim]Task 2[/strike dim]",
-            estimated_duration=4.0,
             formatted_estimated_duration="4.0",
             status=TaskStatus.COMPLETED,
             planned_start=date(2025, 1, 2),
@@ -162,9 +158,7 @@ class TestRichGanttRendererBuildTable:
             tasks=[
                 TaskGanttRowViewModel(
                     id=1,
-                    name="Task without estimate",
                     formatted_name="Task without estimate",
-                    estimated_duration=None,
                     formatted_estimated_duration="-",
                     status=TaskStatus.PENDING,
                     planned_start=date(2025, 1, 1),
@@ -222,9 +216,7 @@ class TestRichGanttRendererRender:
             tasks=[
                 TaskGanttRowViewModel(
                     id=1,
-                    name="Task 1",
                     formatted_name="Task 1",
-                    estimated_duration=4.0,
                     formatted_estimated_duration="4.0",
                     status=TaskStatus.PENDING,
                     planned_start=date(2025, 1, 1),

--- a/packages/taskdog-ui/tests/presenters/test_timeline_presenter.py
+++ b/packages/taskdog-ui/tests/presenters/test_timeline_presenter.py
@@ -99,7 +99,7 @@ class TestTimelinePresenter:
 
         row = result.rows[0]
         assert row.task_id == 1
-        assert row.name == "Task A"
+        assert row.formatted_name == "[strike dim]Task A[/strike dim]"
         assert row.actual_start == time(9, 0)
         assert row.actual_end == time(12, 0)
         assert row.duration_hours == 3.0

--- a/packages/taskdog-ui/tests/renderers/test_rich_timeline_renderer.py
+++ b/packages/taskdog-ui/tests/renderers/test_rich_timeline_renderer.py
@@ -39,7 +39,6 @@ class TestRichTimelineRenderer:
             formatted_name = f"[strike dim]{name}[/strike dim]"
         return TimelineTaskRowViewModel(
             task_id=task_id,
-            name=name,
             formatted_name=formatted_name,
             actual_start=actual_start,
             actual_end=actual_end,

--- a/packages/taskdog-ui/tests/services/test_task_data_loader.py
+++ b/packages/taskdog-ui/tests/services/test_task_data_loader.py
@@ -83,9 +83,7 @@ class TestTaskDataLoader:
 
         gantt_task_vm = TaskGanttRowViewModel(
             id=1,
-            name="Task 1",
             formatted_name="Task 1",
-            estimated_duration=None,
             formatted_estimated_duration="-",
             status=TaskStatus.PENDING,
             planned_start=None,
@@ -135,9 +133,7 @@ class TestTaskDataLoader:
 
         gantt_task1 = TaskGanttRowViewModel(
             id=1,
-            name="Task 1",
             formatted_name="Task 1",
-            estimated_duration=None,
             formatted_estimated_duration="-",
             status=TaskStatus.PENDING,
             planned_start=None,
@@ -149,9 +145,7 @@ class TestTaskDataLoader:
         )
         gantt_task2 = TaskGanttRowViewModel(
             id=2,
-            name="Task 2",
             formatted_name="Task 2",
-            estimated_duration=None,
             formatted_estimated_duration="-",
             status=TaskStatus.PENDING,
             planned_start=None,
@@ -163,9 +157,7 @@ class TestTaskDataLoader:
         )
         gantt_task3 = TaskGanttRowViewModel(
             id=3,
-            name="Task 3",
             formatted_name="Task 3",
-            estimated_duration=None,
             formatted_estimated_duration="-",
             status=TaskStatus.PENDING,
             planned_start=None,


### PR DESCRIPTION
## Summary
- Remove unused `name` and `estimated_duration` raw fields from `TaskGanttRowViewModel` and `TimelineTaskRowViewModel`
- Only formatted versions (`formatted_name`, `formatted_estimated_duration`) are used by renderers and TUI, making the raw fields dead code
- Update presenters and all test constructors accordingly

Closes #714

## Test plan
- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] `make test-ui` passes (932 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)