### PR TITLE
refactor: enable ruff TC rule for TYPE_CHECKING imports

### DIFF
--- a/packages/taskdog-client/src/taskdog_client/base_client.py
+++ b/packages/taskdog-client/src/taskdog_client/base_client.py
@@ -1,8 +1,7 @@
 """Base HTTP client infrastructure for Taskdog API."""
 
 import contextlib
-from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx  # type: ignore[import-not-found]
 
@@ -13,6 +12,9 @@ from taskdog_core.domain.exceptions.task_exceptions import (
     TaskNotFoundException,
     TaskValidationError,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class BaseApiClient:

--- a/packages/taskdog-client/src/taskdog_client/converters/optimization_converters.py
+++ b/packages/taskdog-client/src/taskdog_client/converters/optimization_converters.py
@@ -1,8 +1,6 @@
 """Optimization data converters."""
 
-from datetime import date as date_type
-from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from taskdog_core.application.dto.optimization_output import (
     OptimizationOutput,
@@ -13,6 +11,10 @@ from taskdog_core.application.dto.task_dto import TaskSummaryDto
 from taskdog_core.shared.utils.datetime_parser import parse_iso_date
 
 from .exceptions import ConversionError
+
+if TYPE_CHECKING:
+    from datetime import date as date_type
+    from datetime import datetime
 
 
 def _parse_optimization_summary(

--- a/packages/taskdog-core/src/taskdog_core/application/dto/task_dto.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/task_dto.py
@@ -7,13 +7,12 @@ the Task entity directly to the presentation layer.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date, datetime
 from typing import TYPE_CHECKING
 
-from taskdog_core.domain.entities.task import TaskStatus
-
 if TYPE_CHECKING:
-    from taskdog_core.domain.entities.task import Task
+    from datetime import date, datetime
+
+    from taskdog_core.domain.entities.task import Task, TaskStatus
 
 
 @dataclass(frozen=True)

--- a/packages/taskdog-core/src/taskdog_core/application/queries/filters/task_filter.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/filters/task_filter.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
-from taskdog_core.domain.entities.task import Task
+if TYPE_CHECKING:
+    from taskdog_core.domain.entities.task import Task
 
 
 class TaskFilter(ABC):

--- a/packages/taskdog-core/src/taskdog_core/application/queries/task_filter_builder.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/task_filter_builder.py
@@ -7,15 +7,19 @@ previously duplicated across API routes.
 
 from __future__ import annotations
 
-from taskdog_core.application.dto.query_inputs import ListTasksInput
+from typing import TYPE_CHECKING
+
 from taskdog_core.application.queries.filters.date_range_filter import DateRangeFilter
 from taskdog_core.application.queries.filters.non_archived_filter import (
     NonArchivedFilter,
 )
 from taskdog_core.application.queries.filters.status_filter import StatusFilter
 from taskdog_core.application.queries.filters.tag_filter import TagFilter
-from taskdog_core.application.queries.filters.task_filter import TaskFilter
 from taskdog_core.domain.entities.task import TaskStatus
+
+if TYPE_CHECKING:
+    from taskdog_core.application.dto.query_inputs import ListTasksInput
+    from taskdog_core.application.queries.filters.task_filter import TaskFilter
 
 
 class TaskFilterBuilder:

--- a/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
@@ -2,18 +2,16 @@
 
 from __future__ import annotations
 
-from datetime import date
 from typing import TYPE_CHECKING, Any
 
 from taskdog_core.application.dto.gantt_output import GanttDateRange, GanttOutput
 from taskdog_core.application.dto.task_dto import GanttTaskDto, TaskRowDto
 from taskdog_core.application.queries.base import QueryService
-from taskdog_core.application.queries.filters.task_filter import TaskFilter
 from taskdog_core.application.sorters.task_sorter import TaskSorter
-from taskdog_core.domain.entities.task import Task
-from taskdog_core.domain.repositories.task_repository import TaskRepository
 
 if TYPE_CHECKING:
+    from datetime import date
+
     from taskdog_core.application.queries.filters.composite_filter import (
         CompositeFilter,
     )
@@ -22,6 +20,9 @@ if TYPE_CHECKING:
     )
     from taskdog_core.application.queries.filters.status_filter import StatusFilter
     from taskdog_core.application.queries.filters.tag_filter import TagFilter
+    from taskdog_core.application.queries.filters.task_filter import TaskFilter
+    from taskdog_core.domain.entities.task import Task
+    from taskdog_core.domain.repositories.task_repository import TaskRepository
     from taskdog_core.domain.services.holiday_checker import IHolidayChecker
     from taskdog_core.domain.services.time_provider import ITimeProvider
 

--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/optimize_schedule.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/optimize_schedule.py
@@ -1,6 +1,6 @@
 """Use case for optimizing task schedules."""
 
-from datetime import datetime
+from typing import TYPE_CHECKING
 
 from taskdog_core.application.dto.optimization_output import OptimizationOutput
 from taskdog_core.application.dto.optimize_params import OptimizeParams
@@ -21,6 +21,9 @@ from taskdog_core.domain.exceptions.task_exceptions import (
 )
 from taskdog_core.domain.repositories.task_repository import TaskRepository
 from taskdog_core.domain.services.holiday_checker import IHolidayChecker
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class OptimizeScheduleUseCase(UseCase[OptimizeScheduleInput, OptimizationOutput]):

--- a/packages/taskdog-core/src/taskdog_core/application/validators/validator_registry.py
+++ b/packages/taskdog-core/src/taskdog_core/application/validators/validator_registry.py
@@ -1,15 +1,17 @@
 """Registry for field validators."""
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from taskdog_core.application.validators.datetime_validator import DateTimeValidator
-from taskdog_core.application.validators.field_validator import FieldValidator
 from taskdog_core.application.validators.numeric_field_validator import (
     NumericFieldValidator,
 )
 from taskdog_core.application.validators.status_validator import StatusValidator
 from taskdog_core.domain.entities.task import Task
 from taskdog_core.domain.repositories.task_repository import TaskRepository
+
+if TYPE_CHECKING:
+    from taskdog_core.application.validators.field_validator import FieldValidator
 
 
 class TaskFieldValidatorRegistry:

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/base_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/base_repository.py
@@ -6,13 +6,16 @@ used by all SQLite repository implementations.
 
 from __future__ import annotations
 
-from sqlalchemy.engine import Engine
-from sqlalchemy.orm import Session, sessionmaker
+from typing import TYPE_CHECKING
 
 from taskdog_core.infrastructure.persistence.database.engine_factory import (
     create_session_factory,
     create_sqlite_engine,
 )
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Engine
+    from sqlalchemy.orm import Session, sessionmaker
 
 
 class SqliteBaseRepository:

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/migration_runner.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/migration_runner.py
@@ -9,12 +9,15 @@ from __future__ import annotations
 
 import threading
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from alembic import command
 from alembic.config import Config as AlembicConfig
 from alembic.script import ScriptDirectory
 from sqlalchemy import inspect, text
-from sqlalchemy.engine import Engine
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Engine
 
 # Lock for thread-safe migration execution
 _migration_lock = threading.Lock()

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/migrations/env.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/migrations/env.py
@@ -9,13 +9,15 @@ This is necessary for in-memory SQLite databases where new connections
 create separate databases.
 """
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from alembic import context
 from sqlalchemy import engine_from_config, pool
-from sqlalchemy.engine import Engine
 
 from taskdog_core.infrastructure.persistence.database.models.task_model import Base
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Engine
 
 # This is the Alembic Config object, which provides access to values
 # within the .ini file (or programmatic config) in use.

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_audit_log_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_audit_log_repository.py
@@ -7,10 +7,9 @@ SQLAlchemy 2.0 ORM. It stores all API operations for accountability and review.
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import delete, func, select
-from sqlalchemy.engine import Engine
 
 from taskdog_core.application.dto.audit_log_dto import (
     AuditEvent,
@@ -25,6 +24,9 @@ from taskdog_core.infrastructure.persistence.database.base_repository import (
 from taskdog_core.infrastructure.persistence.database.models.audit_log_model import (
     AuditLogModel,
 )
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Engine
 
 
 class SqliteAuditLogRepository(SqliteBaseRepository, AuditLogRepository):

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_notes_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_notes_repository.py
@@ -9,20 +9,25 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from sqlalchemy import delete, select
-from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 
 from taskdog_core.domain.repositories.notes_repository import NotesRepository
-from taskdog_core.domain.services.time_provider import ITimeProvider
 from taskdog_core.infrastructure.persistence.database.base_repository import (
     SqliteBaseRepository,
 )
 from taskdog_core.infrastructure.persistence.database.models.note_model import (
     NoteModel,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from sqlalchemy.engine import Engine
+
+    from taskdog_core.domain.services.time_provider import ITimeProvider
 
 
 @dataclass

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_task_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_task_repository.py
@@ -10,11 +10,9 @@ The repository uses TagResolver to manage tag relationships when saving tasks.
 
 from __future__ import annotations
 
-from datetime import date
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import func, select
-from sqlalchemy.engine import Engine
 
 from taskdog_core.domain.entities.task import Task, TaskStatus
 from taskdog_core.domain.exceptions.tag_exceptions import TagNotFoundException
@@ -42,6 +40,10 @@ from taskdog_core.infrastructure.persistence.mappers.tag_resolver import TagReso
 from taskdog_core.infrastructure.persistence.mappers.task_db_mapper import TaskDbMapper
 
 if TYPE_CHECKING:
+    from datetime import date
+
+    from sqlalchemy.engine import Engine
+
     from taskdog_core.domain.services.time_provider import ITimeProvider
 
 

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/mappers/task_db_mapper.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/mappers/task_db_mapper.py
@@ -12,11 +12,13 @@ Writes are handled by DailyAllocationBuilder in the repository.
 """
 
 import json
-from datetime import date
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from taskdog_core.domain.entities.task import Task, TaskStatus
 from taskdog_core.infrastructure.persistence.database.models.task_model import TaskModel
+
+if TYPE_CHECKING:
+    from datetime import date
 
 
 class TaskDbMapper:

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_audit.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_audit.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from mcp.server.fastmcp import FastMCP
-
 if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
     from taskdog_client import TaskdogApiClient
 
 

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_crud.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_crud.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from mcp.server.fastmcp import FastMCP
-
 if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
     from taskdog_client import TaskdogApiClient
 
 

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_decomposition.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_decomposition.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from mcp.server.fastmcp import FastMCP
-
 if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
     from taskdog_client import TaskdogApiClient
 
 

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_lifecycle.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_lifecycle.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from mcp.server.fastmcp import FastMCP
-
 if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
     from taskdog_client import TaskdogApiClient
 
 

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_query.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_query.py
@@ -7,9 +7,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from mcp.server.fastmcp import FastMCP
-
 if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
     from taskdog_client import TaskdogApiClient
 
 

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_tags.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_tags.py
@@ -7,9 +7,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from mcp.server.fastmcp import FastMCP
-
 if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
     from taskdog_client import TaskdogApiClient
 
 

--- a/packages/taskdog-ui/src/taskdog/cli/commands/add.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/add.py
@@ -1,12 +1,15 @@
 """Add command - Add a new task."""
 
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 import click
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_task_errors
 from taskdog_core.domain.exceptions.task_exceptions import TaskValidationError
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 @click.command(name="add", help="Add a new task.")

--- a/packages/taskdog-ui/src/taskdog/cli/commands/add_dependency.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/add_dependency.py
@@ -1,9 +1,13 @@
 """Add-dependency command - Add a task dependency."""
 
+from typing import TYPE_CHECKING
+
 import click
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_task_errors
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 @click.command(name="add-dependency", help="Add a dependency to a task.")

--- a/packages/taskdog-ui/src/taskdog/cli/commands/audit_logs.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/audit_logs.py
@@ -1,11 +1,11 @@
 """Audit logs command - Display operation history."""
 
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 import click
 from rich.table import Table
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_command_errors
 from taskdog.constants.audit_log import (
     AUDIT_CHANGES_WIDTH,
@@ -29,6 +29,9 @@ from taskdog.constants.common import HEADER_ID, TABLE_HEADER_STYLE
 from taskdog.constants.formatting import format_table_title
 from taskdog.tui.widgets.audit_log_entry_builder import format_audit_changes
 from taskdog_core.application.dto.audit_log_dto import AuditLogOutput
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 def _parse_date_filter(date_str: str, end_of_day: bool = False) -> datetime:

--- a/packages/taskdog-ui/src/taskdog/cli/commands/cancel.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/cancel.py
@@ -1,10 +1,14 @@
 """Cancel command - Mark a task as canceled."""
 
+from typing import TYPE_CHECKING
+
 import click
 
 from taskdog.cli.commands.batch_helpers import execute_batch_operation
-from taskdog.cli.context import CliContext
 from taskdog_core.shared.constants import StatusVerbs
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 @click.command(name="cancel", help="Mark task(s) as canceled.")

--- a/packages/taskdog-ui/src/taskdog/cli/commands/done.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/done.py
@@ -1,10 +1,14 @@
 """Done command - Mark a task as completed."""
 
+from typing import TYPE_CHECKING
+
 import click
 
 from taskdog.cli.commands.batch_helpers import execute_batch_operation
-from taskdog.cli.context import CliContext
 from taskdog_core.shared.constants import StatusVerbs
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 @click.command(name="done", help="Mark task(s) as completed.")

--- a/packages/taskdog-ui/src/taskdog/cli/commands/export.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/export.py
@@ -2,11 +2,11 @@
 
 from datetime import datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 
 from taskdog.cli.commands.common_options import date_range_options, filter_options
-from taskdog.cli.context import CliContext
 from taskdog.exporters import (
     CsvTaskExporter,
     JsonTaskExporter,
@@ -14,6 +14,9 @@ from taskdog.exporters import (
     TaskExporter,
 )
 from taskdog.shared.click_types.field_list import FieldList
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 # Valid fields for export
 VALID_FIELDS = {

--- a/packages/taskdog-ui/src/taskdog/cli/commands/fix_actual.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/fix_actual.py
@@ -1,12 +1,14 @@
 """Fix-actual command - Correct actual start/end timestamps and duration."""
 
 from datetime import datetime
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import click
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_task_errors
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 # Sentinel value for "clear" - distinct from None (not provided)
 CLEAR_SENTINEL = "CLEAR"
@@ -32,7 +34,7 @@ class ClearableDateTimeType(click.ParamType):
             return None
         if value == "" or value == CLEAR_SENTINEL:
             return CLEAR_SENTINEL
-        return cast(datetime, self._inner.convert(value, param, ctx))
+        return cast("datetime", self._inner.convert(value, param, ctx))
 
 
 class ClearableFloatType(click.ParamType):

--- a/packages/taskdog-ui/src/taskdog/cli/commands/gantt.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/gantt.py
@@ -1,11 +1,11 @@
 """Gantt command - Display tasks in Gantt chart format."""
 
 from datetime import date, datetime, timedelta
+from typing import TYPE_CHECKING
 
 import click
 
 from taskdog.cli.commands.common_options import filter_options, sort_options
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_command_errors
 from taskdog.constants.gantt import (
     CHARS_PER_DAY,
@@ -14,6 +14,9 @@ from taskdog.constants.gantt import (
 )
 from taskdog.presenters.gantt_presenter import GanttPresenter
 from taskdog.renderers.rich_gantt_renderer import RichGanttRenderer
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 @click.command(

--- a/packages/taskdog-ui/src/taskdog/cli/commands/note.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/note.py
@@ -5,11 +5,11 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 from taskdog_client import TaskdogApiClient
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_task_errors
 from taskdog.console.console_writer import ConsoleWriter
 from taskdog.infrastructure.cli_config_manager import CliConfig
@@ -17,6 +17,9 @@ from taskdog.utils.editor import get_editor
 from taskdog.utils.notes_template import get_note_template
 from taskdog_core.application.dto.task_dto import TaskDetailDto
 from taskdog_core.domain.exceptions.task_exceptions import TaskNotFoundException
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 def _read_content_from_source(

--- a/packages/taskdog-ui/src/taskdog/cli/commands/optimize.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/optimize.py
@@ -1,13 +1,16 @@
 """Optimize command - Auto-generate optimal task schedules."""
 
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 import click
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_command_errors
 from taskdog.console.console_writer import ConsoleWriter
 from taskdog_core.application.dto.optimization_output import OptimizationOutput
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 def _show_failed_tasks(

--- a/packages/taskdog-ui/src/taskdog/cli/commands/pause.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/pause.py
@@ -1,10 +1,14 @@
 """Pause command - Pause a task and reset its time tracking."""
 
+from typing import TYPE_CHECKING
+
 import click
 
 from taskdog.cli.commands.batch_helpers import execute_batch_operation
-from taskdog.cli.context import CliContext
 from taskdog_core.shared.constants import StatusVerbs
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 @click.command(

--- a/packages/taskdog-ui/src/taskdog/cli/commands/remove_dependency.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/remove_dependency.py
@@ -1,9 +1,13 @@
 """Remove-dependency command - Remove a task dependency."""
 
+from typing import TYPE_CHECKING
+
 import click
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_task_errors
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 @click.command(name="remove-dependency", help="Remove a dependency from a task.")

--- a/packages/taskdog-ui/src/taskdog/cli/commands/reopen.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/reopen.py
@@ -1,10 +1,14 @@
 """Reopen command - Reopen completed or canceled task(s)."""
 
+from typing import TYPE_CHECKING
+
 import click
 
 from taskdog.cli.commands.batch_helpers import execute_batch_operation
-from taskdog.cli.context import CliContext
 from taskdog_core.shared.constants import StatusVerbs
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 @click.command(name="reopen", help="Reopen completed or canceled task(s).")

--- a/packages/taskdog-ui/src/taskdog/cli/commands/restore.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/restore.py
@@ -1,10 +1,14 @@
 """Restore command - Restore archived (soft deleted) task(s)."""
 
+from typing import TYPE_CHECKING
+
 import click
 
 from taskdog.cli.commands.batch_helpers import execute_batch_operation
-from taskdog.cli.context import CliContext
 from taskdog_core.shared.constants import StatusVerbs
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 @click.command(name="restore", help="Restore archived task(s).")

--- a/packages/taskdog-ui/src/taskdog/cli/commands/rm.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/rm.py
@@ -1,9 +1,13 @@
 """Rm command - Remove a task."""
 
+from typing import TYPE_CHECKING
+
 import click
 
 from taskdog.cli.commands.batch_helpers import execute_batch_operation
-from taskdog.cli.context import CliContext
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 @click.command(

--- a/packages/taskdog-ui/src/taskdog/cli/commands/show.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/show.py
@@ -1,10 +1,14 @@
 """Show command - Display task details and notes."""
 
+from typing import TYPE_CHECKING
+
 import click
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_task_errors
 from taskdog.renderers.rich_detail_renderer import RichDetailRenderer
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 @click.command(name="show", help="Show task details and notes with markdown rendering.")

--- a/packages/taskdog-ui/src/taskdog/cli/commands/start.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/start.py
@@ -1,10 +1,14 @@
 """Start command - Start working on a task."""
 
+from typing import TYPE_CHECKING
+
 import click
 
 from taskdog.cli.commands.batch_helpers import execute_batch_operation
-from taskdog.cli.context import CliContext
 from taskdog_core.shared.constants import StatusVerbs
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 @click.command(

--- a/packages/taskdog-ui/src/taskdog/cli/commands/stats.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/stats.py
@@ -1,11 +1,15 @@
 """Stats command - Display task statistics and analytics."""
 
+from typing import TYPE_CHECKING
+
 import click
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_command_errors
 from taskdog.presenters.statistics_presenter import StatisticsPresenter
 from taskdog.renderers.rich_statistics_renderer import RichStatisticsRenderer
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 @click.command(

--- a/packages/taskdog-ui/src/taskdog/cli/commands/table.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/table.py
@@ -1,6 +1,7 @@
 """Table command - Display tasks in flat table format."""
 
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 import click
 
@@ -10,9 +11,11 @@ from taskdog.cli.commands.common_options import (
     sort_options,
 )
 from taskdog.cli.commands.table_helpers import render_table
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_command_errors
 from taskdog.shared.click_types.field_list import FieldList
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 @click.command(

--- a/packages/taskdog-ui/src/taskdog/cli/commands/tags.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/tags.py
@@ -1,10 +1,14 @@
 """Tags command - Manage task tags."""
 
+from typing import TYPE_CHECKING
+
 import click
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_task_errors
 from taskdog_core.domain.exceptions.task_exceptions import TaskNotFoundException
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 @click.command(name="tags", help="View, set, or delete task tags.")

--- a/packages/taskdog-ui/src/taskdog/cli/commands/timeline.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/timeline.py
@@ -1,13 +1,16 @@
 """Timeline command - Display actual work times for a day."""
 
 from datetime import date, datetime
+from typing import TYPE_CHECKING
 
 import click
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_command_errors
 from taskdog.presenters.timeline_presenter import TimelinePresenter
 from taskdog.renderers.rich_timeline_renderer import RichTimelineRenderer
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 @click.command(

--- a/packages/taskdog-ui/src/taskdog/cli/commands/tui.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/tui.py
@@ -1,12 +1,15 @@
 """TUI command - Launch the Text User Interface."""
 
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse, urlunparse
 
 import click
 from taskdog_client import WebSocketClient
 
-from taskdog.cli.context import CliContext
 from taskdog.tui.app import TaskdogTUI
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 def _get_websocket_url(base_url: str) -> str:

--- a/packages/taskdog-ui/src/taskdog/cli/commands/update.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/update.py
@@ -1,12 +1,15 @@
 """Update command - Update task properties."""
 
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 import click
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_task_errors
 from taskdog_core.domain.entities.task import TaskStatus
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 def _validate_name(

--- a/packages/taskdog-ui/src/taskdog/cli/commands/update_helpers.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/update_helpers.py
@@ -1,11 +1,13 @@
 """Helper functions for update commands to reduce duplication."""
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import click
 
-from taskdog.cli.context import CliContext
 from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 def execute_single_field_update(

--- a/packages/taskdog-ui/src/taskdog/cli/error_handler.py
+++ b/packages/taskdog-ui/src/taskdog/cli/error_handler.py
@@ -2,17 +2,19 @@
 
 from collections.abc import Callable
 from functools import wraps
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import click
 
-from taskdog.cli.context import CliContext
 from taskdog_core.domain.exceptions.task_exceptions import (
     AuthenticationError,
     ServerConnectionError,
     ServerError,
     TaskNotFoundException,
 )
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -52,7 +54,7 @@ def handle_task_errors(action_name: str) -> Callable[[F], F]:
             except Exception as e:
                 console_writer.error(action_name, e)
 
-        return cast(F, wrapper)
+        return cast("F", wrapper)
 
     return decorator
 
@@ -90,6 +92,6 @@ def handle_command_errors(action_name: str) -> Callable[[F], F]:
             except Exception as e:
                 console_writer.error(action_name, e)
 
-        return cast(F, wrapper)
+        return cast("F", wrapper)
 
     return decorator

--- a/packages/taskdog-ui/src/taskdog/renderers/rich_table_renderer.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/rich_table_renderer.py
@@ -1,5 +1,4 @@
-from collections.abc import Callable
-from typing import ClassVar, Literal, cast
+from typing import TYPE_CHECKING, ClassVar, Literal, cast
 
 from rich.table import Table
 
@@ -71,6 +70,9 @@ from taskdog.formatters.date_time_formatter import DateTimeFormatter
 from taskdog.formatters.duration_formatter import DurationFormatter
 from taskdog.renderers.rich_renderer_base import RichRendererBase
 from taskdog.view_models.task_view_model import TaskRowViewModel
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 # Type alias for Rich table justify method
 JustifyMethod = Literal["default", "left", "center", "right", "full"]
@@ -270,7 +272,7 @@ class RichTableRenderer(RichRendererBase):
             justify_val = field_config.get("justify")
             valid_justify = {"default", "left", "center", "right", "full"}
             justify: JustifyMethod = (
-                cast(JustifyMethod, justify_val)
+                cast("JustifyMethod", justify_val)
                 if isinstance(justify_val, str) and justify_val in valid_justify
                 else "left"
             )

--- a/packages/taskdog-ui/src/taskdog/tui/commands/base.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/base.py
@@ -96,7 +96,7 @@ class TUICommandBase(ABC):  # noqa: B024
                 self.notify_error(f"Error {action_name}", e)
                 return None
 
-        return cast(F, wrapper)
+        return cast("F", wrapper)
 
     def get_action_name(self) -> str:
         """Return the action name for error messages (e.g., "adding task").

--- a/packages/taskdog-ui/src/taskdog/tui/commands/decorators.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/decorators.py
@@ -34,4 +34,4 @@ def require_selected_task[F: Callable[..., Any]](func: F) -> F:
             return None
         return func(self, *args, **kwargs)
 
-    return cast(F, wrapper)
+    return cast("F", wrapper)

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/stats_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/stats_dialog.py
@@ -1,7 +1,7 @@
 """Statistics dialog for TUI."""
 
 import asyncio
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import Any, ClassVar
 
 from taskdog_client.taskdog_api_client import TaskdogApiClient
 from textual.app import ComposeResult
@@ -16,9 +16,6 @@ from taskdog.tui.widgets.vi_navigation_mixin import ViNavigationMixin
 from taskdog.view_models.statistics_view_model import (
     StatisticsViewModel,
 )
-
-if TYPE_CHECKING:
-    pass
 
 # Mapping from tab pane ID to its VerticalScroll child ID
 _TAB_SCROLL_MAP: dict[str, str] = {

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/task_detail_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/task_detail_dialog.py
@@ -1,7 +1,7 @@
 """Task detail dialog for TUI."""
 
 import asyncio
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from taskdog_client.taskdog_api_client import TaskdogApiClient
 from textual.app import ComposeResult
@@ -16,8 +16,10 @@ from taskdog.tui.dialogs.base_dialog import BaseModalDialog
 from taskdog.tui.widgets.audit_log_entry_builder import create_audit_log_table
 from taskdog.tui.widgets.vi_navigation_mixin import ViNavigationMixin
 from taskdog_core.application.dto.task_detail_output import TaskDetailOutput
-from taskdog_core.application.dto.task_dto import TaskDetailDto
 from taskdog_core.shared.constants.formats import DATETIME_FORMAT
+
+if TYPE_CHECKING:
+    from taskdog_core.application.dto.task_dto import TaskDetailDto
 
 # Mapping from tab pane ID to its VerticalScroll child ID
 _TAB_SCROLL_MAP: dict[str, str] = {

--- a/packages/taskdog-ui/src/taskdog/tui/palette/providers/base.py
+++ b/packages/taskdog-ui/src/taskdog/tui/palette/providers/base.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from collections.abc import Callable
 from typing import TYPE_CHECKING, cast
 
 from textual.command import DiscoveryHit, Hit, Hits, Provider
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from taskdog.tui.app import TaskdogTUI
 
 

--- a/packages/taskdog-ui/src/taskdog/tui/palette/providers/export_providers.py
+++ b/packages/taskdog-ui/src/taskdog/tui/palette/providers/export_providers.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from functools import partial
 from typing import TYPE_CHECKING
 
@@ -12,6 +11,8 @@ from taskdog.tui.palette.providers.base import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from taskdog.tui.app import TaskdogTUI
 
 

--- a/packages/taskdog-ui/src/taskdog/tui/palette/providers/help_provider.py
+++ b/packages/taskdog-ui/src/taskdog/tui/palette/providers/help_provider.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from taskdog.tui.palette.providers.base import BaseListProvider
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from taskdog.tui.app import TaskdogTUI
 
 

--- a/packages/taskdog-ui/src/taskdog/tui/palette/providers/optimize_providers.py
+++ b/packages/taskdog-ui/src/taskdog/tui/palette/providers/optimize_providers.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from taskdog.tui.palette.providers.base import BaseListProvider
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from taskdog.tui.app import TaskdogTUI
 
 

--- a/packages/taskdog-ui/src/taskdog/tui/palette/providers/sort_providers.py
+++ b/packages/taskdog-ui/src/taskdog/tui/palette/providers/sort_providers.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from functools import partial
 from typing import TYPE_CHECKING, ClassVar
 
@@ -12,6 +11,8 @@ from taskdog.tui.palette.providers.base import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from taskdog.tui.app import TaskdogTUI
 
 

--- a/packages/taskdog-ui/src/taskdog/tui/state/tui_state.py
+++ b/packages/taskdog-ui/src/taskdog/tui/state/tui_state.py
@@ -5,7 +5,6 @@ eliminating duplication and synchronization issues across components.
 """
 
 from dataclasses import dataclass, field
-from datetime import date
 from typing import TYPE_CHECKING
 
 from taskdog.view_models.gantt_view_model import GanttViewModel, TaskGanttRowViewModel
@@ -13,6 +12,8 @@ from taskdog.view_models.task_view_model import TaskRowViewModel
 from taskdog_core.application.dto.task_dto import TaskRowDto
 
 if TYPE_CHECKING:
+    from datetime import date
+
     from taskdog.tui.widgets.task_search_filter import TaskSearchFilter
 
 

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
@@ -5,10 +5,7 @@ like date range management and automatic resizing.
 """
 
 from datetime import date, timedelta
-from typing import TYPE_CHECKING, Any, ClassVar
-
-if TYPE_CHECKING:
-    pass
+from typing import Any, ClassVar
 
 from textual.app import ComposeResult
 from textual.binding import Binding

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/task_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/task_table.py
@@ -7,15 +7,12 @@ This module provides a data table widget for displaying tasks with:
 - Automatic formatting for all task fields
 """
 
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import Any, ClassVar
 
 from rich.text import Text
 from textual.binding import Binding
 from textual.coordinate import Coordinate
 from textual.widgets import DataTable
-
-if TYPE_CHECKING:
-    pass
 
 from taskdog.constants.common import (
     HEADER_ESTIMATED,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ select = [
   "PTH",  # flake8-use-pathlib
   "FURB",  # refurb modernization
   "RUF",  # ruff-specific rules
+  "TC",  # flake8-type-checking
 ]
 ignore = [
   "E501",  # line too long (handled by formatter)
@@ -132,6 +133,7 @@ ignore = [
 "packages/*/tests/**/*.py" = ["SIM115", "RUF015"]  # Test code patterns are acceptable
 "scripts/**/*.py" = ["B904", "C901"]  # Migration scripts: exception chaining and complexity acceptable
 "packages/taskdog-server/src/taskdog_server/api/error_handlers.py" = ["UP047"]  # Type parameters require Python 3.12+
+"packages/taskdog-server/src/taskdog_server/api/models/**/*.py" = ["TC001", "TC003"]  # Pydantic models need runtime type access
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10


### PR DESCRIPTION
## Summary
- Enable ruff `TC` (flake8-type-checking) rule to move type-hint-only imports into `if TYPE_CHECKING:` blocks
- Fix all 78 violations across 60 files in all 5 packages (core, server, client, ui, mcp)
- Add per-file ignore for Pydantic response models (`TC001`, `TC003`) which require types at runtime for validation

This reduces runtime import overhead and improves module initialization performance.

Closes #701

## Test plan
- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] `make test` passes (all packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)