### PR TITLE
refactor(ui): use SimpleSingleCommandProvider for single-option palette providers

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/palette/providers/help_provider.py
+++ b/packages/taskdog-ui/src/taskdog/tui/palette/providers/help_provider.py
@@ -2,31 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import TYPE_CHECKING
-
-from taskdog.tui.palette.providers.base import BaseListProvider
-
-if TYPE_CHECKING:
-    from taskdog.tui.app import TaskdogTUI
+from taskdog.tui.palette.providers.base import SimpleSingleCommandProvider
 
 
-class HelpCommandProvider(BaseListProvider):
+class HelpCommandProvider(SimpleSingleCommandProvider):
     """Command provider for help command."""
 
-    def get_options(self, app: TaskdogTUI) -> list[tuple[str, Callable[[], None], str]]:
-        """Return help command option.
-
-        Args:
-            app: TaskdogTUI application instance
-
-        Returns:
-            List of (command_name, callback, help_text) tuples
-        """
-        return [
-            (
-                "Help",
-                app.search_help,
-                "Show keybindings and usage instructions",
-            ),
-        ]
+    COMMAND_NAME = "Help"
+    COMMAND_HELP = "Show keybindings and usage instructions"
+    COMMAND_CALLBACK_NAME = "search_help"

--- a/packages/taskdog-ui/src/taskdog/tui/palette/providers/optimize_providers.py
+++ b/packages/taskdog-ui/src/taskdog/tui/palette/providers/optimize_providers.py
@@ -2,31 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import TYPE_CHECKING
-
-from taskdog.tui.palette.providers.base import BaseListProvider
-
-if TYPE_CHECKING:
-    from taskdog.tui.app import TaskdogTUI
+from taskdog.tui.palette.providers.base import SimpleSingleCommandProvider
 
 
-class OptimizeCommandProvider(BaseListProvider):
+class OptimizeCommandProvider(SimpleSingleCommandProvider):
     """Command provider for optimization commands."""
 
-    def get_options(self, app: TaskdogTUI) -> list[tuple[str, Callable[[], None], str]]:
-        """Return optimize command options with callbacks.
-
-        Args:
-            app: TaskdogTUI application instance
-
-        Returns:
-            List of (command_name, callback, help_text) tuples
-        """
-        return [
-            (
-                "Optimize",
-                app.search_optimize,
-                "Optimize schedule with selected algorithm",
-            ),
-        ]
+    COMMAND_NAME = "Optimize"
+    COMMAND_HELP = "Optimize schedule with selected algorithm"
+    COMMAND_CALLBACK_NAME = "search_optimize"

--- a/packages/taskdog-ui/tests/presentation/tui/palette/providers/test_optimize_providers.py
+++ b/packages/taskdog-ui/tests/presentation/tui/palette/providers/test_optimize_providers.py
@@ -1,55 +1,18 @@
 """Tests for optimize command providers."""
 
-from unittest.mock import Mock
-
-import pytest
-
+from taskdog.tui.palette.providers.base import SimpleSingleCommandProvider
 from taskdog.tui.palette.providers.optimize_providers import OptimizeCommandProvider
 
 
 class TestOptimizeCommandProvider:
     """Test cases for OptimizeCommandProvider."""
 
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        """Set up test fixtures."""
-        self.mock_app = Mock()
-        self.mock_app.search_optimize = Mock()
-        self.mock_screen = Mock()
-        self.mock_screen.app = self.mock_app
-        self.provider = OptimizeCommandProvider(
-            screen=self.mock_screen, match_style=None
-        )
+    def test_inherits_simple_single_command_provider(self):
+        """Test that OptimizeCommandProvider uses SimpleSingleCommandProvider."""
+        assert issubclass(OptimizeCommandProvider, SimpleSingleCommandProvider)
 
-    def test_get_options_returns_single_command(self):
-        """Test that get_options returns single optimize command."""
-        options = self.provider.get_options(self.mock_app)
-
-        assert len(options) == 1
-
-        # Verify option name
-        option_names = [opt[0] for opt in options]
-        assert "Optimize" in option_names
-
-    def test_option_callback_calls_search_optimize(self):
-        """Test that selecting the option calls search_optimize."""
-        options = self.provider.get_options(self.mock_app)
-
-        # Find the Optimize option
-        option = next((opt for opt in options if opt[0] == "Optimize"), None)
-        assert option is not None
-
-        # Get callback and invoke it
-        callback = option[1]
-        callback()
-
-        # Verify search_optimize was called (no args, force is now in dialog)
-        self.mock_app.search_optimize.assert_called_once_with()
-
-    def test_options_have_descriptions(self):
-        """Test that all options have help text."""
-        options = self.provider.get_options(self.mock_app)
-
-        for _option_name, _callback, description in options:
-            assert description is not None
-            assert len(description) > 0
+    def test_command_attributes(self):
+        """Test that class attributes are correctly defined."""
+        assert OptimizeCommandProvider.COMMAND_NAME == "Optimize"
+        assert OptimizeCommandProvider.COMMAND_CALLBACK_NAME == "search_optimize"
+        assert len(OptimizeCommandProvider.COMMAND_HELP) > 0


### PR DESCRIPTION
## Summary

- Replace `BaseListProvider` with `SimpleSingleCommandProvider` in `OptimizeCommandProvider` and `HelpCommandProvider`, since both only expose a single command
- Remove unnecessary `get_options()` overrides and unused imports (`Callable`, `TYPE_CHECKING`, `TaskdogTUI`)
- Update tests for `OptimizeCommandProvider` to verify class attributes instead of the removed method

## Test plan

- [x] `make test-taskdog-ui` — 931 passed
- [x] `make lint` — all checks passed
- [x] `make typecheck` — no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)