### PR TITLE
chore(deps): upgrade textual from 7.x to 8.x

### DIFF
--- a/packages/taskdog-ui/pyproject.toml
+++ b/packages/taskdog-ui/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "taskdog-client==0.15.5",
     "click>=8.3.0",
     "rich>=14.2.0",
-    "textual>=0.88.0",
+    "textual>=8.0.0",
     "websockets>=14.0",
 ]
 

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/algorithm_selection_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/algorithm_selection_dialog.py
@@ -171,7 +171,7 @@ class AlgorithmSelectionDialog(
         self._clear_validation_error()
 
         # Validate algorithm selection
-        if algorithm_select.value is Select.BLANK:
+        if algorithm_select.value is Select.NULL:
             self._show_validation_error("Please select an algorithm", algorithm_select)
             return
         selected_algo = str(algorithm_select.value)

--- a/packages/taskdog-ui/tests/tui/dialogs/test_algorithm_selection_dialog.py
+++ b/packages/taskdog-ui/tests/tui/dialogs/test_algorithm_selection_dialog.py
@@ -179,7 +179,7 @@ class TestAlgorithmSelectionDialogSubmit:
         dialog._show_validation_error = MagicMock()
 
         mock_select = MagicMock()
-        mock_select.value = Select.BLANK
+        mock_select.value = Select.NULL
 
         def mock_query_one(selector: str, widget_type: type) -> MagicMock:
             if "algorithm" in selector:

--- a/uv.lock
+++ b/uv.lock
@@ -1463,7 +1463,7 @@ requires-dist = [
     { name = "taskdog-client", editable = "packages/taskdog-client" },
     { name = "taskdog-core", editable = "packages/taskdog-core" },
     { name = "taskdog-server", marker = "extra == 'server'", editable = "packages/taskdog-server" },
-    { name = "textual", specifier = ">=0.88.0" },
+    { name = "textual", specifier = ">=8.0.0" },
     { name = "websockets", specifier = ">=14.0" },
 ]
 provides-extras = ["dev", "server"]
@@ -1496,7 +1496,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "textual"
-version = "7.3.0"
+version = "8.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py", extra = ["linkify"] },
@@ -1506,9 +1506,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/ee/620c887bfad9d6eba062dfa3b6b0e735e0259102e2667b19f21625ef598d/textual-7.3.0.tar.gz", hash = "sha256:3169e8ba5518a979b0771e60be380ab1a6c344f30a2126e360e6f38d009a3de4", size = 1590692, upload-time = "2026-01-15T16:32:02.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/23/8c709655c5f2208ee82ab81b8104802421865535c278a7649b842b129db1/textual-8.1.1.tar.gz", hash = "sha256:eef0256a6131f06a20ad7576412138c1f30f92ddeedd055953c08d97044bc317", size = 1843002, upload-time = "2026-03-10T10:01:38.493Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/1f/abeb4e5cb36b99dd37db72beb2a74d58598ccb35aaadf14624ee967d4a6b/textual-7.3.0-py3-none-any.whl", hash = "sha256:db235cecf969c87fe5a9c04d83595f506affc9db81f3a53ab849534d726d330a", size = 716374, upload-time = "2026-01-15T16:31:58.233Z" },
+    { url = "https://files.pythonhosted.org/packages/50/21/421b02bf5943172b7a9320712a5e0d74a02a8f7597284e3f8b5b06c70b8d/textual-8.1.1-py3-none-any.whl", hash = "sha256:6712f96e335cd782e76193dee16b9c8875fe0699d923bc8d3f1228fd23e773a6", size = 719598, upload-time = "2026-03-10T10:01:48.318Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump `textual` minimum version from `>=0.88.0` to `>=8.0.0` (installed: 7.3.0 → 8.1.1)
- Adapt to the single breaking change: `Select.BLANK` renamed to `Select.NULL` in source and tests

## Test plan
- [x] `make test-ui` — 929 passed
- [x] `make lint` — passed
- [x] `make typecheck` — passed