### PR TITLE
perf(ui): batch Gantt timeline cell formatting

### DIFF
--- a/packages/taskdog-ui/src/taskdog/renderers/gantt_cell_formatter.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/gantt_cell_formatter.py
@@ -6,6 +6,7 @@ consistent visualization across different interfaces.
 """
 
 import math
+from dataclasses import dataclass
 from datetime import date, timedelta
 from enum import Enum
 from typing import Any
@@ -41,6 +42,26 @@ from taskdog_core.shared.constants import (
     WORKLOAD_COMFORTABLE_HOURS,
     WORKLOAD_MODERATE_HOURS,
 )
+
+
+@dataclass(frozen=True)
+class DateMetadata:
+    """Pre-computed metadata for a single date in the Gantt timeline.
+
+    Caches weekday, holiday, and weekend lookups so they are computed once
+    per date instead of once per task x date.
+    """
+
+    date: date
+    weekday: int
+    is_holiday: bool
+    is_weekend: bool
+    is_today: bool
+    weekend_holiday_bg_color: str | None
+
+    @property
+    def is_weekend_or_holiday(self) -> bool:
+        return self.is_weekend or self.is_holiday
 
 
 class GanttCellFormatter:
@@ -364,6 +385,178 @@ class GanttCellFormatter:
             "actual_end": task.actual_end.date() if task.actual_end else None,
             "deadline": task.deadline.date() if task.deadline else None,
         }
+
+    @staticmethod
+    def precompute_date_metadata(
+        dates: list[date],
+        holidays: set[date],
+        today: date,
+    ) -> list[DateMetadata]:
+        """Pre-compute metadata for each date in the timeline.
+
+        Args:
+            dates: List of dates in the timeline
+            holidays: Set of holiday dates
+            today: Current date (computed once by caller)
+
+        Returns:
+            List of DateMetadata, one per date, in the same order as input
+        """
+        result: list[DateMetadata] = []
+        for d in dates:
+            wd = d.weekday()
+            is_holiday = d in holidays
+            is_weekend = wd in (SATURDAY, SUNDAY)
+
+            # Pre-compute weekend/holiday background color
+            if is_holiday:
+                bg = BACKGROUND_COLOR_HOLIDAY
+            elif wd == SATURDAY:
+                bg = BACKGROUND_COLOR_SATURDAY
+            elif wd == SUNDAY:
+                bg = BACKGROUND_COLOR_SUNDAY
+            else:
+                bg = None
+
+            result.append(
+                DateMetadata(
+                    date=d,
+                    weekday=wd,
+                    is_holiday=is_holiday,
+                    is_weekend=is_weekend,
+                    is_today=d == today,
+                    weekend_holiday_bg_color=bg,
+                )
+            )
+        return result
+
+    @staticmethod
+    def format_timeline_cells_batch(
+        dates: list[date],
+        date_metadata: list[DateMetadata],
+        task_daily_hours: dict[date, float],
+        status: TaskStatus,
+        planned_start: date | None,
+        planned_end: date | None,
+        actual_start: date | None,
+        actual_end: date | None,
+        deadline: date | None,
+        today: date,
+    ) -> list[tuple[str, str]]:
+        """Format all timeline cells for one task in batch.
+
+        This is a TUI-optimized version of format_timeline_cell() that avoids
+        redundant per-cell computations by using pre-computed DateMetadata and
+        resolving task-level constants once before the loop.
+
+        Args:
+            dates: List of dates in the timeline
+            date_metadata: Pre-computed metadata for each date
+            task_daily_hours: Daily hours allocation for this task
+            status: Task status
+            planned_start: Planned start date (or None)
+            planned_end: Planned end date (or None)
+            actual_start: Actual start date (or None)
+            actual_end: Actual end date (or None)
+            deadline: Deadline date (or None)
+            today: Current date
+
+        Returns:
+            List of (display_text, style_string) tuples, one per date
+        """
+        # Pre-compute task-level constants
+        is_finished = status in (TaskStatus.COMPLETED, TaskStatus.CANCELED)
+        has_planned_range = planned_start is not None and planned_end is not None
+
+        # Resolve actual_end for IN_PROGRESS tasks (use today)
+        effective_actual_end = actual_end
+        if actual_start and not actual_end:
+            effective_actual_end = today
+
+        # Pre-compute status symbol and color (used only in actual period)
+        status_symbol = GanttCellFormatter.get_status_symbol(status)
+        status_color = GanttCellFormatter.get_status_color(status)
+
+        results: list[tuple[str, str]] = []
+
+        for i, current_date in enumerate(dates):
+            meta = date_metadata[i]
+            hours = task_daily_hours.get(current_date, 0.0)
+
+            # Determine actual period membership (inlined _is_in_actual_period)
+            is_actual = False
+            if actual_start and effective_actual_end:
+                is_actual = actual_start <= current_date <= effective_actual_end
+            elif actual_end and not actual_start:
+                is_actual = current_date == actual_end
+
+            if is_actual:
+                display = f" {status_symbol} "
+                # Determine bg color for actual period
+                is_deadline = deadline is not None and current_date == deadline
+                bg_color = GanttCellFormatter._bg_color_batch(
+                    meta, hours, False, is_deadline, is_finished
+                )
+                style = f"{status_color} on {bg_color}" if bg_color else status_color
+                results.append((display, style))
+                continue
+
+            # Determine planned period membership (inlined _is_in_date_range)
+            is_planned = (
+                has_planned_range and planned_start <= current_date <= planned_end  # type: ignore[operator]
+            )
+            is_deadline = deadline is not None and current_date == deadline
+
+            # Determine background color (inlined _determine_cell_background_color)
+            bg_color = GanttCellFormatter._bg_color_batch(
+                meta, hours, is_planned, is_deadline, is_finished
+            )
+
+            # Format hours display (inlined _format_hours_display)
+            if is_finished:
+                display = SYMBOL_EMPTY
+            elif hours > 0:
+                display = (
+                    f"{int(hours):2d} " if hours == int(hours) else f"{hours:3.1f}"
+                )
+            else:
+                display = SYMBOL_EMPTY
+
+            style = f"on {bg_color}" if bg_color else "dim"
+            results.append((display, style))
+
+        return results
+
+    @staticmethod
+    def _bg_color_batch(
+        meta: DateMetadata,
+        hours: float,
+        is_planned: bool,
+        is_deadline: bool,
+        is_finished: bool,
+    ) -> str | None:
+        """Determine background color using pre-computed DateMetadata.
+
+        Same logic as _determine_cell_background_color but avoids redundant
+        weekday() and holiday set lookups.
+        """
+        if is_deadline:
+            return BACKGROUND_COLOR_DEADLINE
+
+        if is_finished:
+            return None
+
+        if hours > 0:
+            if meta.is_weekend_or_holiday:
+                return meta.weekend_holiday_bg_color
+            return BACKGROUND_COLOR
+
+        if is_planned:
+            if meta.is_weekend_or_holiday:
+                return meta.weekend_holiday_bg_color
+            return BACKGROUND_COLOR_PLANNED_LIGHT
+
+        return None
 
     @staticmethod
     def get_status_color(status: TaskStatus | str) -> str:

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_data_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_data_table.py
@@ -15,7 +15,7 @@ from textual.widgets import DataTable
 from taskdog.constants.common import HEADER_ESTIMATED, HEADER_ID, HEADER_NAME
 from taskdog.constants.gantt import CHARS_PER_DAY, GANTT_WORKLOAD_LABEL
 from taskdog.constants.task_table import ESTIMATED_COLUMN_WIDTH, TASK_NAME_COLUMN_WIDTH
-from taskdog.renderers.gantt_cell_formatter import GanttCellFormatter
+from taskdog.renderers.gantt_cell_formatter import DateMetadata, GanttCellFormatter
 from taskdog.view_models.gantt_view_model import GanttViewModel, TaskGanttRowViewModel
 from taskdog_core.shared.constants import (
     WORKLOAD_COMFORTABLE_HOURS,
@@ -164,15 +164,21 @@ class GanttDataTable(DataTable):  # type: ignore[type-arg]
             if gantt_view_model.is_empty():
                 return
 
+            # Pre-compute shared date metadata (once for all tasks)
+            today = date.today()
+            date_metadata = GanttCellFormatter.precompute_date_metadata(
+                self._date_columns, gantt_view_model.holidays, today
+            )
+
             # Add task rows
             for idx, task_vm in enumerate(gantt_view_model.tasks):
                 task_daily_hours = gantt_view_model.task_daily_hours.get(task_vm.id, {})
                 self._add_task_row(
                     task_vm,
                     task_daily_hours,
-                    gantt_view_model.start_date,
-                    gantt_view_model.end_date,
-                    gantt_view_model.holidays,
+                    self._date_columns,
+                    date_metadata,
+                    today,
                 )
                 self._task_map[idx + GANTT_HEADER_ROW_COUNT] = task_vm
 
@@ -230,22 +236,22 @@ class GanttDataTable(DataTable):  # type: ignore[type-arg]
         self,
         task_vm: TaskGanttRowViewModel,
         task_daily_hours: dict[date, float],
-        start_date: date,
-        end_date: date,
-        holidays: set[date],
+        dates: list[date],
+        date_metadata: list[DateMetadata],
+        today: date,
     ) -> None:
         """Add a task row to the Gantt table.
 
         Args:
             task_vm: Task ViewModel to add
             task_daily_hours: Daily hours allocation for this task
-            start_date: Start date of the chart
-            end_date: End date of the chart
-            holidays: Set of holiday dates for styling
+            dates: Pre-computed list of dates in the timeline
+            date_metadata: Pre-computed metadata for each date
+            today: Current date (computed once by caller)
         """
         task_id, task_name, est_hours = self._format_task_metadata(task_vm)
         date_cells = self._build_timeline_cells(
-            task_vm, task_daily_hours, start_date, end_date, holidays
+            task_vm, task_daily_hours, dates, date_metadata, today
         )
 
         self.add_row(
@@ -277,49 +283,40 @@ class GanttDataTable(DataTable):  # type: ignore[type-arg]
         self,
         task_vm: TaskGanttRowViewModel,
         task_daily_hours: dict[date, float],
-        start_date: date,
-        end_date: date,
-        holidays: set[date],
+        dates: list[date],
+        date_metadata: list[DateMetadata],
+        today: date,
     ) -> list[Text]:
         """Build timeline cells for a task, one Text per date.
+
+        Uses the batch formatter to avoid redundant per-cell computations.
 
         Args:
             task_vm: Task ViewModel to build timeline for
             task_daily_hours: Daily hours allocation
-            start_date: Start date of timeline
-            end_date: End date of timeline
-            holidays: Set of holiday dates for styling
+            dates: Pre-computed list of dates in the timeline
+            date_metadata: Pre-computed metadata for each date
+            today: Current date (computed once by caller)
 
         Returns:
             List of Rich Text objects, one per date
         """
-        days = (end_date - start_date).days + 1
+        cell_data = GanttCellFormatter.format_timeline_cells_batch(
+            dates,
+            date_metadata,
+            task_daily_hours,
+            task_vm.status,
+            task_vm.planned_start,
+            task_vm.planned_end,
+            task_vm.actual_start,
+            task_vm.actual_end,
+            task_vm.deadline,
+            today,
+        )
 
-        # Create parsed_dates dict from ViewModel (dates are already converted)
-        parsed_dates = {
-            "planned_start": task_vm.planned_start,
-            "planned_end": task_vm.planned_end,
-            "actual_start": task_vm.actual_start,
-            "actual_end": task_vm.actual_end,
-            "deadline": task_vm.deadline,
-        }
-
-        cells: list[Text] = []
-
-        for day_offset in range(days):
-            current_date = start_date + timedelta(days=day_offset)
-            hours = task_daily_hours.get(current_date, 0.0)
-
-            display, style = GanttCellFormatter.format_timeline_cell(
-                current_date,
-                hours,
-                parsed_dates,
-                task_vm.status,
-                holidays,
-            )
-            cells.append(Text(display, style=style, justify="center"))
-
-        return cells
+        return [
+            Text(display, style=style, justify="center") for display, style in cell_data
+        ]
 
     def _add_workload_row(
         self,


### PR DESCRIPTION
## Summary

- Add `DateMetadata` frozen dataclass and `precompute_date_metadata()` to pre-compute per-date properties (weekday, is_holiday, is_weekend, bg_color) once instead of once per task x date
- Add `format_timeline_cells_batch()` that processes all timeline cells for one task in a single call, resolving task-level constants (status symbol/color, effective actual_end, is_finished) once before the inner loop
- Update `GanttDataTable.load_gantt()` to call `date.today()` once and share `DateMetadata` across all task rows

## Motivation

`load_gantt()` rebuilds all cells on every task operation, resize, or filter change. The hot loop in `_build_timeline_cells()` called `format_timeline_cell()` per cell, redundantly computing `weekday()`, `date.today()`, holiday set lookups, and `timedelta` constructions for every task x date combination.

For a typical 30 tasks x 60 days scenario (1,800 cells), this eliminates:
- ~1,740 redundant `weekday()` calls (60 instead of 1,800)
- ~1,740 redundant holiday set lookups (60 instead of 1,800)
- ~1,770 `timedelta` constructions (0, reuses `_date_columns`)
- ~1,770 `date.today()` calls (1 instead of up to 1,800)
- ~5,370 static method dispatches (30 batch calls instead of 5,400 per-cell calls)

The existing per-cell API (`format_timeline_cell`) is preserved unchanged for CLI use.

## Test plan

- [x] `make test-ui` — all 934 tests pass
- [x] `make lint` — clean
- [x] `make typecheck` — clean
- [ ] Manual: TUI Gantt chart displays identically to before
- [ ] Manual: Resize, filter, and sort changes render correctly