### PR TITLE
perf(ui): reduce TUI search input latency

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/screens/main_screen.py
+++ b/packages/taskdog-ui/src/taskdog/tui/screens/main_screen.py
@@ -6,6 +6,7 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
 from textual.screen import Screen
+from textual.timer import Timer
 from textual.widgets import Header
 
 from taskdog.tui.events import FilterChanged, SearchQueryChanged
@@ -52,6 +53,7 @@ class MainScreen(Screen[None]):
         self.task_table: TaskTable | None = None
         self.gantt_widget: GanttWidget | None = None
         self.custom_footer: CustomFooter | None = None
+        self._search_debounce_timer: Timer | None = None
 
     def compose(self) -> ComposeResult:
         """Compose the screen layout.
@@ -89,37 +91,46 @@ class MainScreen(Screen[None]):
             self.task_table.focus()
 
     def on_search_query_changed(self, event: SearchQueryChanged) -> None:
-        """Handle search query changes.
+        """Handle search query changes with debounce.
 
-        Updates TUIState with the new query and posts FilterChanged
-        to notify all widgets.
+        Updates TUIState immediately but debounces FilterChanged posting
+        to avoid expensive re-renders on every keystroke.
 
         Args:
             event: SearchQueryChanged event with the new query string
         """
         if self.state:
             self.state.set_filter(event.query)
-            self.post_message(FilterChanged(query=event.query))
+
+            # Cancel previous debounce timer
+            if self._search_debounce_timer is not None:
+                self._search_debounce_timer.stop()
+
+            query = event.query
+
+            def _fire_filter_changed() -> None:
+                self.post_message(FilterChanged(query=query))
+
+            self._search_debounce_timer = self.set_timer(0.15, _fire_filter_changed)
 
     def on_filter_changed(self, event: FilterChanged) -> None:
         """Handle filter state changes.
 
-        Refreshes both TaskTable and GanttWidget with filtered data
-        from TUIState.
+        Refreshes TaskTable with filtered data. Only refreshes GanttWidget
+        when gantt_filter_enabled is True to avoid expensive re-renders.
 
         Args:
             event: FilterChanged event
         """
-        # Refresh TaskTable with filtered viewmodels
-        if self.task_table:
-            self.task_table.render_filtered_tasks()
+        if self.task_table and self.state:
+            filtered = self.state.filtered_viewmodels
+            self.task_table.render_filtered_tasks(filtered)
+            if self.custom_footer:
+                self.custom_footer.update_result(len(filtered), self.state.total_count)
 
-        # Refresh GanttWidget with filtered gantt
-        if self.gantt_widget:
+        # Only refresh Gantt when gantt filtering is enabled
+        if self.gantt_widget and self.state and self.state.gantt_filter_enabled:
             self.gantt_widget.render_filtered_gantt()
-
-        # Update search result count
-        self._update_search_result()
 
     def on_custom_footer_submitted(self, event: CustomFooter.Submitted) -> None:
         """Handle Enter key press in search input.

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/task_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/task_table.py
@@ -295,12 +295,19 @@ class TaskTable(DataTable, TUIWidget, ViNavigationMixin):  # type: ignore[type-a
             if saved_scroll_x is not None:
                 self.scroll_x = saved_scroll_x
 
-    def render_filtered_tasks(self) -> None:
+    def render_filtered_tasks(
+        self, viewmodels: list[TaskRowViewModel] | None = None
+    ) -> None:
         """Render tasks from TUIState.filtered_viewmodels.
 
         Called by MainScreen when filter state changes.
+
+        Args:
+            viewmodels: Pre-computed filtered viewmodels. If None, reads from TUIState.
         """
-        self._render_tasks(self.tui_state.filtered_viewmodels)
+        self._render_tasks(
+            viewmodels if viewmodels is not None else self.tui_state.filtered_viewmodels
+        )
 
     # Legacy methods kept for backward compatibility
     # Filter state is now managed by TUIState


### PR DESCRIPTION
## Summary

- **Debounce search input**: Add 150ms debounce timer to `FilterChanged` posting so rapid keystrokes batch into a single re-render instead of triggering the full filter pipeline on every character
- **Skip redundant Gantt rebuilds**: Guard `gantt_widget.render_filtered_gantt()` behind `gantt_filter_enabled` check — when disabled (the default), the expensive full-table clear+rebuild is skipped entirely since the output wouldn't change
- **Eliminate duplicate filtering**: Compute `filtered_viewmodels` once per `FilterChanged` and pass it to both `TaskTable.render_filtered_tasks()` and `CustomFooter.update_result()`, removing the redundant re-computation in `_update_search_result()`

## Test plan

- [x] `make test-ui` — all 934 tests pass
- [x] `make lint` — clean
- [x] `make typecheck` — clean
- [ ] Manual: rapid typing in TUI search bar (`/`) shows no visible lag
- [ ] Manual: with Gantt filter ON, search filters both table and Gantt
- [ ] Manual: Escape clears filter and restores both table and Gantt

🤖 Generated with [Claude Code](https://claude.com/claude-code)