### PR TITLE
perf(ui): update only elapsed column instead of rebuilding all rows

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -505,21 +505,9 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
             self.push_screen(AuditLogScreen(api_client=self.api_client))
 
     def _refresh_elapsed_time(self) -> None:
-        """Refresh the task table to update elapsed time for IN_PROGRESS tasks.
-
-        This is called every second by the auto-refresh timer.
-        Only updates the table display without reloading from repository.
-        """
+        """Refresh elapsed time for IN_PROGRESS tasks only."""
         if self.main_screen and self.main_screen.task_table:
-            # Get current ViewModels from the table (already loaded in memory)
-            view_models = self.main_screen.task_table.all_viewmodels
-            if view_models:
-                # Refresh the table display with current ViewModels
-                # This will recalculate elapsed time for IN_PROGRESS tasks
-                # Keep scroll position to avoid stuttering during user navigation
-                self.main_screen.task_table.refresh_tasks(
-                    view_models, keep_scroll_position=True
-                )
+            self.main_screen.task_table.refresh_elapsed_only()
 
     # Event handlers for task operations
     def _handle_task_change_event(self, event: Any) -> None:

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/task_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/task_table.py
@@ -59,6 +59,10 @@ from taskdog.tui.widgets.base_widget import TUIWidget
 from taskdog.tui.widgets.task_table_row_builder import TaskTableRowBuilder
 from taskdog.tui.widgets.vi_navigation_mixin import ViNavigationMixin
 from taskdog.view_models.task_view_model import TaskRowViewModel
+from taskdog_core.domain.entities.task import TaskStatus
+
+# Column index for elapsed time (0=checkbox, 1=ID, ..., 13=Elapsed)
+_ELAPSED_COL_INDEX = 13
 
 
 class TaskTable(DataTable, TUIWidget, ViNavigationMixin):  # type: ignore[type-arg]
@@ -523,6 +527,16 @@ class TaskTable(DataTable, TUIWidget, ViNavigationMixin):  # type: ignore[type-a
             List of explicitly selected task IDs, or empty list if none selected
         """
         return sorted(self._selected_task_ids) if self._selected_task_ids else []
+
+    def refresh_elapsed_only(self) -> None:
+        """Update only the elapsed column for IN_PROGRESS tasks."""
+        for idx, task_vm in self._viewmodel_map.items():
+            if task_vm.status == TaskStatus.IN_PROGRESS:
+                elapsed_text = Text(
+                    self._row_builder.duration_formatter.format_elapsed_time(task_vm),
+                    justify=JUSTIFY_ELAPSED,
+                )
+                self.update_cell_at(Coordinate(idx, _ELAPSED_COL_INDEX), elapsed_text)
 
     def clear_selection(self) -> None:
         """Clear all selections (called after batch operations)."""


### PR DESCRIPTION
## Summary
- The 1-second `_refresh_elapsed_time()` timer was rebuilding all cells (16 columns × N rows) every tick via `refresh_tasks()`
- Added `TaskTable.refresh_elapsed_only()` that updates only the elapsed column for IN_PROGRESS tasks via `update_cell_at()`
- For 30 tasks: reduces from 480 `update_cell_at()` + 30 `build_row()` calls per second to just a few `update_cell_at()` calls for active tasks

## Test plan
- [x] `make test-ui` — 934 tests passed
- [x] `make lint` — passed
- [x] `make typecheck` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)