### PR TITLE
fix(ui): run connection health check in background thread (#763)

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -36,7 +36,7 @@ from taskdog.tui.palette.providers import (
     SortOptionsProvider,
 )
 from taskdog.tui.screens.main_screen import MainScreen
-from taskdog.tui.services import TaskUIManager, WebSocketHandler
+from taskdog.tui.services import ConnectionMonitor, TaskUIManager, WebSocketHandler
 from taskdog.tui.state import ConnectionStatusManager, TUIState
 from taskdog.tui.utils.css_loader import get_css_paths
 from taskdog_core.domain.exceptions.task_exceptions import (
@@ -273,6 +273,14 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         self.websocket_client = websocket_client
         self.websocket_client.set_callback(self._handle_websocket_message)
 
+        # Initialize connection monitor (non-blocking health checks)
+        self.connection_monitor = ConnectionMonitor(
+            app=self,
+            api_client=self.api_client,
+            websocket_client=self.websocket_client,
+            connection_manager=self.connection_manager,
+        )
+
     def _handle_websocket_message(self, message: dict[str, Any]) -> None:
         """Handle incoming WebSocket messages.
 
@@ -345,11 +353,11 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         # Start auto-refresh timer for elapsed time updates
         self.set_interval(AUTO_REFRESH_INTERVAL_SECONDS, self._refresh_elapsed_time)
         # Start connection monitoring timer (check every 3 seconds)
-        self.set_interval(3.0, self._check_connection_status)
+        self.set_interval(3.0, self.connection_monitor.check)
         # Connect to WebSocket for real-time updates
         await self.websocket_client.connect()
         # Initial connection status check (delayed to allow WebSocket connection to stabilize)
-        self.call_later(self._check_connection_status)
+        self.call_later(self.connection_monitor.check)
 
     async def on_unmount(self) -> None:
         """Called when app is unmounted."""
@@ -540,18 +548,3 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         """
         if self.task_ui_manager:
             self.task_ui_manager.recalculate_gantt(event.start_date, event.end_date)
-
-    def _check_connection_status(self) -> None:
-        """Check API and WebSocket connection status.
-
-        Updates ConnectionStatusManager which notifies subscribed widgets
-        via observer pattern.
-        """
-        # Check API connection via health endpoint
-        api_connected = self.api_client.check_health()
-
-        # Check WebSocket connection
-        ws_connected = self.websocket_client.is_connected()
-
-        # Update connection manager (observers will be notified automatically)
-        self.connection_manager.update(api_connected, ws_connected)

--- a/packages/taskdog-ui/src/taskdog/tui/services/__init__.py
+++ b/packages/taskdog-ui/src/taskdog/tui/services/__init__.py
@@ -1,6 +1,7 @@
 """TUI service layer components."""
 
+from taskdog.tui.services.connection_monitor import ConnectionMonitor
 from taskdog.tui.services.task_ui_manager import TaskUIManager
 from taskdog.tui.services.websocket_handler import WebSocketHandler
 
-__all__ = ["TaskUIManager", "WebSocketHandler"]
+__all__ = ["ConnectionMonitor", "TaskUIManager", "WebSocketHandler"]

--- a/packages/taskdog-ui/src/taskdog/tui/services/connection_monitor.py
+++ b/packages/taskdog-ui/src/taskdog/tui/services/connection_monitor.py
@@ -1,0 +1,42 @@
+"""Connection monitoring service for TUI."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from taskdog_client import TaskdogApiClient, WebSocketClient
+
+    from taskdog.tui.app import TaskdogTUI
+    from taskdog.tui.state.connection_status_manager import ConnectionStatusManager
+
+
+class ConnectionMonitor:
+    """Monitors API and WebSocket connection status without blocking the UI.
+
+    Uses run_worker to execute health checks in a background thread,
+    preventing synchronous HTTP requests from freezing the event loop.
+    """
+
+    def __init__(
+        self,
+        app: TaskdogTUI,
+        api_client: TaskdogApiClient,
+        websocket_client: WebSocketClient,
+        connection_manager: ConnectionStatusManager,
+    ) -> None:
+        self._app = app
+        self._api_client = api_client
+        self._websocket_client = websocket_client
+        self._connection_manager = connection_manager
+
+    def check(self) -> None:
+        """Dispatch connection check to a background thread."""
+        self._app.run_worker(self._check_worker(), exclusive=True)
+
+    async def _check_worker(self) -> None:
+        """Check API and WebSocket connection status in background."""
+        api_connected = await asyncio.to_thread(self._api_client.check_health)
+        ws_connected = self._websocket_client.is_connected()
+        self._connection_manager.update(api_connected, ws_connected)


### PR DESCRIPTION
## Summary

- Extract `_check_connection_status` into `ConnectionMonitor` service to prevent synchronous HTTP requests from blocking the TUI event loop
- Use `run_worker` + `asyncio.to_thread` to delegate health checks to a background thread, following the existing TUI service pattern (`WebSocketHandler`, `TaskUIManager`)
- Remove inline `_check_connection_status` method from `app.py`

## Test plan

- [x] `make test-ui` — 934 tests passed
- [x] `make lint` — clean
- [x] `make typecheck` — clean

Closes #763

🤖 Generated with [Claude Code](https://claude.com/claude-code)