### PR TITLE
perf(tui): skip Gantt full rebuild on filter change when gantt_filter_enabled is false

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/screens/main_screen.py
+++ b/packages/taskdog-ui/src/taskdog/tui/screens/main_screen.py
@@ -128,9 +128,13 @@ class MainScreen(Screen[None]):
             if self.custom_footer:
                 self.custom_footer.update_result(len(filtered), self.state.total_count)
 
-        # Always refresh Gantt on filter changes so the title indicator updates
+        # Refresh Gantt on filter changes: full rebuild only when gantt filtering
+        # is enabled; otherwise just update the title indicator
         if self.gantt_widget and self.state:
-            self.gantt_widget.render_filtered_gantt()
+            if self.state.gantt_filter_enabled:
+                self.gantt_widget.render_filtered_gantt()
+            else:
+                self.gantt_widget.update_title_only()
 
     def on_custom_footer_submitted(self, event: CustomFooter.Submitted) -> None:
         """Handle Enter key press in search input.

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
@@ -424,6 +424,10 @@ class GanttWidget(Vertical, ViNavigationMixin, TUIWidget):
         """
         self._render_gantt()
 
+    def update_title_only(self) -> None:
+        """Update only the Gantt title without rebuilding the data table."""
+        self._update_title()
+
     # Public API methods for external access
 
     def get_selected_task_id(self) -> int | None:


### PR DESCRIPTION
## Summary
- Fixes #764
- When `gantt_filter_enabled` is `false` (default), filter changes now only update the Gantt title indicator instead of rebuilding the entire data table (`clear(columns=True)` + all rows)
- Adds `update_title_only()` public method to `GanttWidget` for lightweight title-only updates

## Test plan
- [x] `make test-ui` — 934 tests passed
- [x] `make lint` — clean
- [x] `make typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)