### PR TITLE
chore(tui): remove stale comments and unused method

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -237,11 +237,6 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         # Initialize connection status manager (observer pattern)
         self.connection_manager = ConnectionStatusManager()
 
-        # NOTE: All legacy state fields migrated to self.state (Phase 2 complete)
-        # - _gantt_sort_by, _gantt_reverse → state (Step 2-3)
-        # - _all_tasks, _gantt_view_model → state (Step 4)
-        # - viewmodels → state (Step 5)
-
         # Initialize TUIContext with API client, state, and config
         self.context = TUIContext(
             api_client=self.api_client,

--- a/packages/taskdog-ui/src/taskdog/tui/commands/base.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/base.py
@@ -60,11 +60,11 @@ class TUICommandBase(ABC):  # noqa: B024
         Subclasses should override this method to define their specific behavior.
         This method is called by execute() within a try-except block.
 
-        For backwards compatibility, if not overridden, this will do nothing.
+        If not overridden, this will do nothing.
         Commands that override execute() directly (like StatusChangeCommandBase
         or dialog-based commands) don't need to implement this.
         """
-        # Default implementation for backwards compatibility
+        # Default: no-op
         # Subclasses should override this method
 
     def handle_error(self, callback_fn: F) -> F:

--- a/packages/taskdog-ui/src/taskdog/tui/screens/main_screen.py
+++ b/packages/taskdog-ui/src/taskdog/tui/screens/main_screen.py
@@ -45,7 +45,7 @@ class MainScreen(Screen[None]):
         """Initialize the main screen.
 
         Args:
-            state: TUI state for connection status (optional for backward compatibility)
+            state: TUI state for connection status (optional)
         """
         super().__init__()
         self.state = state

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_data_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_data_table.py
@@ -73,7 +73,6 @@ class GanttDataTable(DataTable):  # type: ignore[type-arg]
         self._task_map: dict[
             int, TaskGanttRowViewModel
         ] = {}  # Maps row index to TaskViewModel
-        # NOTE: _gantt_view_model removed - data passed as parameter to load_gantt (Step 4)
         self._date_columns: list[date] = []  # Columns representing dates
 
     def setup_columns(
@@ -138,7 +137,6 @@ class GanttDataTable(DataTable):  # type: ignore[type-arg]
             self.cursor_column if keep_scroll_position else None
         )
 
-        # NOTE: No longer storing view model locally - just use parameter (Step 4)
         self._task_map.clear()
 
         # Batch all table mutations to trigger a single layout reflow

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
@@ -389,20 +389,6 @@ class GanttWidget(Vertical, TUIWidget):
         self._keep_scroll_position = keep_scroll_position
         self.call_after_refresh(self._render_gantt)
 
-    def calculate_display_days(self, widget_width: int | None = None) -> int:
-        """Calculate optimal number of days to display based on widget width.
-
-        Public interface for display day calculation. This is useful for
-        determining date ranges before loading gantt data.
-
-        Args:
-            widget_width: Widget width to use for calculation. If None, uses self.size.width.
-
-        Returns:
-            Number of days to display (rounded to weeks)
-        """
-        return self._calculate_display_days(widget_width)
-
     def calculate_date_range(
         self, widget_width: int | None = None
     ) -> tuple[date, date]:


### PR DESCRIPTION
## Summary
- Remove migration/step comments left over from prior TUI state refactoring (`app.py`, `gantt_data_table.py`)
- Delete unused `calculate_display_days()` public method from `GanttWidget`
- Trim outdated "backward compatibility" wording from docstrings (`main_screen.py`, `commands/base.py`)

## Test plan
- [x] `make test-ui` — 930 tests pass
- [x] `make check` — lint + typecheck clean

Closes #774