### PR TITLE
refactor(tui): introduce SelectionProvider to decouple commands from widget types

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -36,6 +36,7 @@ from taskdog.tui.palette.providers import (
     SortOptionsProvider,
 )
 from taskdog.tui.screens.main_screen import MainScreen
+from taskdog.tui.selection import AppSelectionProvider
 from taskdog.tui.services import ConnectionMonitor, TaskUIManager, WebSocketHandler
 from taskdog.tui.state import ConnectionStatusManager, TUIState
 from taskdog.tui.utils.css_loader import get_css_paths
@@ -237,10 +238,11 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         # Initialize connection status manager (observer pattern)
         self.connection_manager = ConnectionStatusManager()
 
-        # Initialize TUIContext with API client, state, and config
+        # Initialize TUIContext with API client, state, selection, and config
         self.context = TUIContext(
             api_client=self.api_client,
             state=self.state,  # Share same state instance
+            selection=AppSelectionProvider(self),
             config=self._cli_config,
         )
 

--- a/packages/taskdog-ui/src/taskdog/tui/commands/base.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/base.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from taskdog.tui.context import TUIContext
 from taskdog.tui.events import TasksRefreshed
-from taskdog.tui.widgets.gantt_data_table import GanttDataTable
 from taskdog_core.domain.exceptions.task_exceptions import TaskError
 
 if TYPE_CHECKING:
@@ -127,61 +126,30 @@ class TUICommandBase(ABC):  # noqa: B024
     def get_selected_task_id(self) -> int | None:
         """Get the ID of the currently selected task.
 
-        When a GanttDataTable cell is focused, returns the task at the
-        Gantt cursor row. Otherwise falls back to TaskTable selection.
-
         Returns:
             The selected task ID, or None if no task is selected
         """
-        # If Gantt cell is focused, get task from Gantt cursor row
-        if isinstance(self.app.focused, GanttDataTable):
-            return self.app.focused.get_selected_task_id()
-
-        if not self.app.main_screen or not self.app.main_screen.task_table:
-            return None
-        return self.app.main_screen.task_table.get_selected_task_id()
+        return self.context.selection.get_selected_task_id()
 
     def get_selected_task_ids(self) -> list[int]:
         """Get all selected task IDs for batch operations.
 
-        When a GanttDataTable cell is focused, returns single task at cursor.
-        Otherwise returns TaskTable multi-selection or cursor fallback.
-
         Returns:
             List of selected task IDs, or [current_task_id] if none selected
         """
-        # Gantt: single selection only
-        if isinstance(self.app.focused, GanttDataTable):
-            task_id = self.app.focused.get_selected_task_id()
-            return [task_id] if task_id is not None else []
-
-        if not self.app.main_screen or not self.app.main_screen.task_table:
-            return []
-        return self.app.main_screen.task_table.get_selected_task_ids()
+        return self.context.selection.get_selected_task_ids()
 
     def get_explicitly_selected_task_ids(self) -> list[int]:
         """Get only explicitly selected task IDs (no cursor fallback).
 
-        Unlike get_selected_task_ids(), this method does NOT fall back to
-        the cursor position when no tasks are explicitly selected.
-        Use this when you need to distinguish between "no selection" and
-        "single task selected".
-
         Returns:
             List of explicitly selected task IDs, or empty list if none selected
         """
-        if not self.app.main_screen or not self.app.main_screen.task_table:
-            return []
-        return self.app.main_screen.task_table.get_explicitly_selected_task_ids()
+        return self.context.selection.get_explicitly_selected_task_ids()
 
     def clear_task_selection(self) -> None:
-        """Clear all task selections in the table.
-
-        Called after batch operations complete to reset selection state.
-        """
-        if not self.app.main_screen or not self.app.main_screen.task_table:
-            return
-        self.app.main_screen.task_table.clear_selection()
+        """Clear all task selections in the table."""
+        self.context.selection.clear_selection()
 
     def reload_tasks(self) -> None:
         """Reload the task list from the repository and refresh the UI.

--- a/packages/taskdog-ui/src/taskdog/tui/context.py
+++ b/packages/taskdog-ui/src/taskdog/tui/context.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from taskdog_client import TaskdogApiClient
 
     from taskdog.infrastructure.cli_config_manager import CliConfig
+    from taskdog.tui.selection import SelectionProvider
 
 
 @dataclass
@@ -25,8 +26,10 @@ class TUIContext:
         api_client: API client for server communication (required)
         state: TUI application state (shared with app instance)
         config: CLI configuration (optional, for custom templates etc.)
+        selection: Selection provider for resolving task selection from widgets
     """
 
     api_client: "TaskdogApiClient"
     state: TUIState
+    selection: "SelectionProvider"
     config: "CliConfig | None" = None

--- a/packages/taskdog-ui/src/taskdog/tui/selection.py
+++ b/packages/taskdog-ui/src/taskdog/tui/selection.py
@@ -1,0 +1,69 @@
+"""Selection provider for decoupling commands from widget types."""
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from taskdog.tui.app import TaskdogTUI
+
+
+class SelectionProvider(Protocol):
+    """Protocol for providing task selection information."""
+
+    def get_selected_task_id(self) -> int | None: ...
+    def get_selected_task_ids(self) -> list[int]: ...
+    def get_explicitly_selected_task_ids(self) -> list[int]: ...
+    def clear_selection(self) -> None: ...
+
+
+class AppSelectionProvider:
+    """Selection provider that resolves selection from the TUI app.
+
+    Consolidates all widget-type-specific selection logic (GanttDataTable vs
+    TaskTable) in one place, keeping commands decoupled from widget types.
+    """
+
+    def __init__(self, app: "TaskdogTUI") -> None:
+        self._app = app
+
+    def get_selected_task_id(self) -> int | None:
+        """Get the ID of the currently selected task.
+
+        When a GanttDataTable cell is focused, returns the task at the
+        Gantt cursor row. Otherwise falls back to TaskTable selection.
+        """
+        from taskdog.tui.widgets.gantt_data_table import GanttDataTable
+
+        if isinstance(self._app.focused, GanttDataTable):
+            return self._app.focused.get_selected_task_id()
+
+        if not self._app.main_screen or not self._app.main_screen.task_table:
+            return None
+        return self._app.main_screen.task_table.get_selected_task_id()
+
+    def get_selected_task_ids(self) -> list[int]:
+        """Get all selected task IDs for batch operations.
+
+        When a GanttDataTable cell is focused, returns single task at cursor.
+        Otherwise returns TaskTable multi-selection or cursor fallback.
+        """
+        from taskdog.tui.widgets.gantt_data_table import GanttDataTable
+
+        if isinstance(self._app.focused, GanttDataTable):
+            task_id = self._app.focused.get_selected_task_id()
+            return [task_id] if task_id is not None else []
+
+        if not self._app.main_screen or not self._app.main_screen.task_table:
+            return []
+        return self._app.main_screen.task_table.get_selected_task_ids()
+
+    def get_explicitly_selected_task_ids(self) -> list[int]:
+        """Get only explicitly selected task IDs (no cursor fallback)."""
+        if not self._app.main_screen or not self._app.main_screen.task_table:
+            return []
+        return self._app.main_screen.task_table.get_explicitly_selected_task_ids()
+
+    def clear_selection(self) -> None:
+        """Clear all task selections in the table."""
+        if not self._app.main_screen or not self._app.main_screen.task_table:
+            return
+        self._app.main_screen.task_table.clear_selection()


### PR DESCRIPTION
## Summary

- Extract task selection logic from `TUICommandBase` into a `SelectionProvider` protocol and `AppSelectionProvider` implementation
- Remove direct `GanttDataTable` import from the command layer (`commands/base.py`)
- Add `selection: SelectionProvider` field to `TUIContext` for dependency injection

## Motivation

`TUICommandBase` directly imported `GanttDataTable` and accessed `self.app.focused` / `self.app.main_screen.task_table` to resolve task selection, coupling commands to specific widget types. This refactor moves all widget-type-aware selection logic into a dedicated provider, making commands testable and extensible without widget dependencies.

## Changes

| File | Change |
|------|--------|
| `tui/selection.py` (new) | `SelectionProvider` Protocol + `AppSelectionProvider` implementation |
| `tui/context.py` | Added `selection: SelectionProvider` field to `TUIContext` |
| `tui/app.py` | Create `AppSelectionProvider(self)` and pass to `TUIContext` |
| `tui/commands/base.py` | Replace 4 selection methods with delegation; remove `GanttDataTable` import |

## Test plan

- [x] `grep -r "GanttDataTable" packages/taskdog-ui/src/taskdog/tui/commands/` → 0 matches
- [x] `make test-ui` — 930 passed
- [x] `make check` — lint + typecheck passed

Closes #770