### PR TITLE
refactor(tui): consolidate 3 error handlers into single _handle_api_error

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -336,9 +336,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
             state=self.state,
             task_data_loader=self.task_data_loader,
             main_screen_provider=lambda: self.main_screen,
-            on_connection_error=self._handle_connection_error,
-            on_auth_error=self._handle_auth_error,
-            on_server_error=self._handle_server_error,
+            on_error=self._handle_api_error,
         )
 
         # Load tasks after screen is fully mounted
@@ -361,43 +359,21 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         # Disconnect WebSocket
         await self.websocket_client.disconnect()
 
-    def _handle_connection_error(self, error: ServerConnectionError) -> None:
-        """Handle connection errors from TaskUIManager.
+    def _handle_api_error(
+        self, error: ServerConnectionError | AuthenticationError | ServerError
+    ) -> None:
+        """Handle API errors from TaskUIManager.
 
         Args:
-            error: ServerConnectionError from API call
+            error: API error (connection, auth, or server error)
         """
-        self.notify(
-            f"Server connection failed: {
-                error.original_error.__class__.__name__
-            }. Press 'r' to retry.",
-            severity="error",
-            timeout=10,
-        )
-
-    def _handle_auth_error(self, error: AuthenticationError) -> None:
-        """Handle authentication errors from TaskUIManager.
-
-        Args:
-            error: AuthenticationError from API call
-        """
-        self.notify(
-            f"Authentication failed: {error}. Check your API key.",
-            severity="error",
-            timeout=10,
-        )
-
-    def _handle_server_error(self, error: ServerError) -> None:
-        """Handle server errors (5xx) from TaskUIManager.
-
-        Args:
-            error: ServerError from API call
-        """
-        self.notify(
-            f"Server error: {error}. Press 'r' to retry.",
-            severity="error",
-            timeout=10,
-        )
+        if isinstance(error, ServerConnectionError):
+            msg = f"Server connection failed: {error.original_error.__class__.__name__}. Press 'r' to retry."
+        elif isinstance(error, AuthenticationError):
+            msg = f"Authentication failed: {error}. Check your API key."
+        else:
+            msg = f"Server error: {error}. Press 'r' to retry."
+        self.notify(msg, severity="error", timeout=10)
 
     def search_sort(self) -> None:
         """Show a fuzzy search command palette containing all sort options.

--- a/packages/taskdog-ui/src/taskdog/tui/services/task_ui_manager.py
+++ b/packages/taskdog-ui/src/taskdog/tui/services/task_ui_manager.py
@@ -35,9 +35,10 @@ class TaskUIManager:
         state: TUIState,
         task_data_loader: TaskDataLoader,
         main_screen_provider: Callable[[], "MainScreen | None"],
-        on_connection_error: Callable[[ServerConnectionError], None] | None = None,
-        on_auth_error: Callable[[AuthenticationError], None] | None = None,
-        on_server_error: Callable[[ServerError], None] | None = None,
+        on_error: Callable[
+            [ServerConnectionError | AuthenticationError | ServerError], None
+        ]
+        | None = None,
     ):
         """Initialize TaskUIManager.
 
@@ -45,33 +46,23 @@ class TaskUIManager:
             state: Shared TUIState instance
             task_data_loader: Service for loading task data
             main_screen_provider: Callable that returns current MainScreen (lazy access)
-            on_connection_error: Optional callback for connection errors
-            on_auth_error: Optional callback for authentication errors
-            on_server_error: Optional callback for server errors (5xx)
+            on_error: Optional callback for API errors (connection, auth, server)
         """
         self.state = state
         self.task_data_loader = task_data_loader
         self._get_main_screen = main_screen_provider
-        self._on_connection_error = on_connection_error
-        self._on_auth_error = on_auth_error
-        self._on_server_error = on_server_error
+        self._on_error = on_error
 
     def _handle_api_error(
         self, error: ServerConnectionError | AuthenticationError | ServerError
     ) -> None:
-        """Dispatch API error to the appropriate callback.
+        """Delegate API error to the error callback.
 
         Args:
             error: The API error to handle
         """
-        handlers: dict[type, Callable[..., None] | None] = {
-            ServerConnectionError: self._on_connection_error,
-            AuthenticationError: self._on_auth_error,
-            ServerError: self._on_server_error,
-        }
-        callback = handlers.get(type(error))
-        if callback:
-            callback(error)
+        if self._on_error:
+            self._on_error(error)
 
     def load_tasks(self, keep_scroll_position: bool = False) -> None:
         """Load tasks and update UI.

--- a/packages/taskdog-ui/tests/tui/services/test_task_ui_manager.py
+++ b/packages/taskdog-ui/tests/tui/services/test_task_ui_manager.py
@@ -114,13 +114,13 @@ class TestTaskUIManager:
         self.main_screen = MagicMock()
         self.main_screen.gantt_widget = MagicMock()
         self.main_screen.task_table = MagicMock()
-        self.on_connection_error = MagicMock()
+        self.on_error = MagicMock()
 
         self.manager = TaskUIManager(
             state=self.state,
             task_data_loader=self.task_data_loader,
             main_screen_provider=lambda: self.main_screen,
-            on_connection_error=self.on_connection_error,
+            on_error=self.on_error,
         )
 
     def test_init_with_dependencies(self):
@@ -128,7 +128,7 @@ class TestTaskUIManager:
         assert self.manager.state is self.state
         assert self.manager.task_data_loader is self.task_data_loader
         assert self.manager._get_main_screen is not None
-        assert self.manager._on_connection_error is self.on_connection_error
+        assert self.manager._on_error is self.on_error
 
     def test_load_tasks_updates_cache_and_ui(self):
         """Test load_tasks fetches data, updates cache, and refreshes UI."""
@@ -223,8 +223,10 @@ class TestTaskUIManager:
         # Execute
         result = self.manager._fetch_task_data()
 
-        # Verify error callback was called
-        self.on_connection_error.assert_called_once()
+        # Verify error callback was called with the error
+        self.on_error.assert_called_once()
+        error_arg = self.on_error.call_args[0][0]
+        assert isinstance(error_arg, ServerConnectionError)
 
         # Verify empty TaskData is returned
         assert result.all_tasks == []
@@ -328,7 +330,7 @@ class TestRecalculateGantt:
         # Setup default return values for gantt_widget methods
         self.main_screen.gantt_widget.get_filter_include_archived.return_value = False
         self.main_screen.gantt_widget.get_sort_by.return_value = "deadline"
-        self.on_connection_error = MagicMock()
+        self.on_error = MagicMock()
 
         # Setup mock API client and presenter on task_data_loader
         self.task_data_loader.api_client = MagicMock()
@@ -338,7 +340,7 @@ class TestRecalculateGantt:
             state=self.state,
             task_data_loader=self.task_data_loader,
             main_screen_provider=lambda: self.main_screen,
-            on_connection_error=self.on_connection_error,
+            on_error=self.on_error,
         )
 
     def test_recalculate_gantt_fetches_and_updates_widget(self):
@@ -417,8 +419,10 @@ class TestRecalculateGantt:
         # Execute
         self.manager.recalculate_gantt(date(2024, 1, 1), date(2024, 1, 31))
 
-        # Verify error callback was called
-        self.on_connection_error.assert_called_once()
+        # Verify error callback was called with the error
+        self.on_error.assert_called_once()
+        error_arg = self.on_error.call_args[0][0]
+        assert isinstance(error_arg, ServerConnectionError)
 
         # Verify widget was NOT updated
         self.main_screen.gantt_widget.update_view_model_and_render.assert_not_called()
@@ -430,7 +434,7 @@ class TestRecalculateGantt:
             state=self.state,
             task_data_loader=self.task_data_loader,
             main_screen_provider=lambda: None,
-            on_connection_error=self.on_connection_error,
+            on_error=self.on_error,
         )
 
         gantt = create_gantt_viewmodel()
@@ -486,9 +490,7 @@ class TestErrorHandling:
         )
         self.main_screen.gantt_widget.get_filter_include_archived.return_value = False
         self.main_screen.gantt_widget.get_sort_by.return_value = "deadline"
-        self.on_connection_error = MagicMock()
-        self.on_auth_error = MagicMock()
-        self.on_server_error = MagicMock()
+        self.on_error = MagicMock()
 
         # Setup mock API client and presenter on task_data_loader
         self.task_data_loader.api_client = MagicMock()
@@ -498,24 +500,23 @@ class TestErrorHandling:
             state=self.state,
             task_data_loader=self.task_data_loader,
             main_screen_provider=lambda: self.main_screen,
-            on_connection_error=self.on_connection_error,
-            on_auth_error=self.on_auth_error,
-            on_server_error=self.on_server_error,
+            on_error=self.on_error,
         )
 
     def test_fetch_task_data_handles_authentication_error(self):
-        """Test _fetch_task_data calls auth error callback."""
+        """Test _fetch_task_data calls error callback with AuthenticationError."""
         self.task_data_loader.load_tasks.side_effect = AuthenticationError(
             message="Unauthorized",
         )
 
         result = self.manager._fetch_task_data()
 
-        self.on_auth_error.assert_called_once()
+        self.on_error.assert_called_once()
+        assert isinstance(self.on_error.call_args[0][0], AuthenticationError)
         assert result.all_tasks == []
 
     def test_fetch_task_data_handles_server_error(self):
-        """Test _fetch_task_data calls server error callback."""
+        """Test _fetch_task_data calls error callback with ServerError."""
         self.task_data_loader.load_tasks.side_effect = ServerError(
             status_code=500,
             message="Internal Server Error",
@@ -523,22 +524,24 @@ class TestErrorHandling:
 
         result = self.manager._fetch_task_data()
 
-        self.on_server_error.assert_called_once()
+        self.on_error.assert_called_once()
+        assert isinstance(self.on_error.call_args[0][0], ServerError)
         assert result.all_tasks == []
 
     def test_recalculate_gantt_handles_authentication_error(self):
-        """Test recalculate_gantt calls auth error callback."""
+        """Test recalculate_gantt calls error callback with AuthenticationError."""
         self.task_data_loader.api_client.list_tasks.side_effect = AuthenticationError(
             message="Unauthorized",
         )
 
         self.manager.recalculate_gantt(date(2024, 1, 1), date(2024, 1, 31))
 
-        self.on_auth_error.assert_called_once()
+        self.on_error.assert_called_once()
+        assert isinstance(self.on_error.call_args[0][0], AuthenticationError)
         self.main_screen.gantt_widget.update_view_model_and_render.assert_not_called()
 
     def test_recalculate_gantt_handles_server_error(self):
-        """Test recalculate_gantt calls server error callback."""
+        """Test recalculate_gantt calls error callback with ServerError."""
         self.task_data_loader.api_client.list_tasks.side_effect = ServerError(
             status_code=500,
             message="Internal Server Error",
@@ -546,7 +549,8 @@ class TestErrorHandling:
 
         self.manager.recalculate_gantt(date(2024, 1, 1), date(2024, 1, 31))
 
-        self.on_server_error.assert_called_once()
+        self.on_error.assert_called_once()
+        assert isinstance(self.on_error.call_args[0][0], ServerError)
         self.main_screen.gantt_widget.update_view_model_and_render.assert_not_called()
 
 
@@ -657,7 +661,6 @@ class TestTaskUIManagerWithoutErrorCallback:
             state=state,
             task_data_loader=task_data_loader,
             main_screen_provider=lambda: main_screen,
-            on_connection_error=None,  # No callback
         )
 
         original_error = ConnectionError("Connection refused")


### PR DESCRIPTION
## Summary
- Replaced 3 nearly-identical error handler methods (`_handle_connection_error`, `_handle_auth_error`, `_handle_server_error`) in `app.py` with a single `_handle_api_error` that uses `isinstance`-based message formatting
- Simplified `TaskUIManager` constructor from 3 separate callback parameters (`on_connection_error`, `on_auth_error`, `on_server_error`) to a single `on_error` callback
- Simplified `TaskUIManager._handle_api_error` from a type-dispatch dict to a direct callback invocation

Closes #773

## Test plan
- [x] All 24 existing `test_task_ui_manager.py` tests pass
- [x] Tests updated to use single `on_error` mock and assert correct error types
- [x] Lint and typecheck pass
- [x] Pre-commit hooks pass (ruff, mypy, codespell, unit tests)