### PR TITLE
fix(tui): rebuild gantt chart when toggling gantt filter off

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -465,7 +465,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         """Toggle search filter for Gantt chart."""
         enabled = self.state.toggle_gantt_filter()
         # Post to current screen so MainScreen's on_filter_changed handler receives it
-        self.screen.post_message(FilterChanged())
+        self.screen.post_message(FilterChanged(gantt_filter_toggled=True))
         status = "enabled" if enabled else "disabled"
         self.notify(f"Gantt filter {status}")
 

--- a/packages/taskdog-ui/src/taskdog/tui/events.py
+++ b/packages/taskdog-ui/src/taskdog/tui/events.py
@@ -124,4 +124,12 @@ class FilterChanged(Message):
     This allows widgets to react to filter changes and refresh their display
     with filtered data from TUIState. The actual filter state is read from
     TUIState, not from this event.
+
+    Attributes:
+        gantt_filter_toggled: True when this event was triggered by toggling
+            the gantt filter on/off, requiring a full gantt rebuild.
     """
+
+    def __init__(self, gantt_filter_toggled: bool = False) -> None:
+        super().__init__()
+        self.gantt_filter_toggled = gantt_filter_toggled

--- a/packages/taskdog-ui/src/taskdog/tui/screens/main_screen.py
+++ b/packages/taskdog-ui/src/taskdog/tui/screens/main_screen.py
@@ -127,7 +127,7 @@ class MainScreen(Screen[None]):
         # Refresh Gantt on filter changes: full rebuild only when gantt filtering
         # is enabled; otherwise just update the title indicator
         if self.gantt_widget and self.state:
-            if self.state.gantt_filter_enabled:
+            if self.state.gantt_filter_enabled or event.gantt_filter_toggled:
                 self.gantt_widget.render_filtered_gantt()
             else:
                 self.gantt_widget.update_title_only()


### PR DESCRIPTION
## Summary
- Fix gantt chart staying filtered after pressing `t` to disable gantt filter while a search is active
- Add `gantt_filter_toggled` flag to `FilterChanged` event so `on_filter_changed` knows to do a full rebuild when the toggle itself fires the event
- Without this flag, the handler always skipped the full rebuild when `gantt_filter_enabled=False`, only updating the title

## Test plan
- [x] `make test-ui` — 930 passed
- [x] `make lint` — all checks passed
- [x] `make typecheck` — no issues
- [x] Manual: start TUI, search for text, press `t` (gantt filters), press `t` again (gantt shows all tasks)