### PR TITLE
refactor(core): enable ruff TC rule - taskdog-core

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/dto/task_dto.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/task_dto.py
@@ -7,13 +7,12 @@ the Task entity directly to the presentation layer.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date, datetime
 from typing import TYPE_CHECKING
 
-from taskdog_core.domain.entities.task import TaskStatus
-
 if TYPE_CHECKING:
-    from taskdog_core.domain.entities.task import Task
+    from datetime import date, datetime
+
+    from taskdog_core.domain.entities.task import Task, TaskStatus
 
 
 @dataclass(frozen=True)

--- a/packages/taskdog-core/src/taskdog_core/application/queries/filters/task_filter.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/filters/task_filter.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
-from taskdog_core.domain.entities.task import Task
+if TYPE_CHECKING:
+    from taskdog_core.domain.entities.task import Task
 
 
 class TaskFilter(ABC):

--- a/packages/taskdog-core/src/taskdog_core/application/queries/task_filter_builder.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/task_filter_builder.py
@@ -7,15 +7,19 @@ previously duplicated across API routes.
 
 from __future__ import annotations
 
-from taskdog_core.application.dto.query_inputs import ListTasksInput
+from typing import TYPE_CHECKING
+
 from taskdog_core.application.queries.filters.date_range_filter import DateRangeFilter
 from taskdog_core.application.queries.filters.non_archived_filter import (
     NonArchivedFilter,
 )
 from taskdog_core.application.queries.filters.status_filter import StatusFilter
 from taskdog_core.application.queries.filters.tag_filter import TagFilter
-from taskdog_core.application.queries.filters.task_filter import TaskFilter
 from taskdog_core.domain.entities.task import TaskStatus
+
+if TYPE_CHECKING:
+    from taskdog_core.application.dto.query_inputs import ListTasksInput
+    from taskdog_core.application.queries.filters.task_filter import TaskFilter
 
 
 class TaskFilterBuilder:

--- a/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
@@ -2,18 +2,16 @@
 
 from __future__ import annotations
 
-from datetime import date
 from typing import TYPE_CHECKING, Any
 
 from taskdog_core.application.dto.gantt_output import GanttDateRange, GanttOutput
 from taskdog_core.application.dto.task_dto import GanttTaskDto, TaskRowDto
 from taskdog_core.application.queries.base import QueryService
-from taskdog_core.application.queries.filters.task_filter import TaskFilter
 from taskdog_core.application.sorters.task_sorter import TaskSorter
-from taskdog_core.domain.entities.task import Task
-from taskdog_core.domain.repositories.task_repository import TaskRepository
 
 if TYPE_CHECKING:
+    from datetime import date
+
     from taskdog_core.application.queries.filters.composite_filter import (
         CompositeFilter,
     )
@@ -22,6 +20,9 @@ if TYPE_CHECKING:
     )
     from taskdog_core.application.queries.filters.status_filter import StatusFilter
     from taskdog_core.application.queries.filters.tag_filter import TagFilter
+    from taskdog_core.application.queries.filters.task_filter import TaskFilter
+    from taskdog_core.domain.entities.task import Task
+    from taskdog_core.domain.repositories.task_repository import TaskRepository
     from taskdog_core.domain.services.holiday_checker import IHolidayChecker
     from taskdog_core.domain.services.time_provider import ITimeProvider
 

--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/optimize_schedule.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/optimize_schedule.py
@@ -1,6 +1,8 @@
 """Use case for optimizing task schedules."""
 
-from datetime import datetime
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from taskdog_core.application.dto.optimization_output import OptimizationOutput
 from taskdog_core.application.dto.optimize_params import OptimizeParams
@@ -19,8 +21,12 @@ from taskdog_core.domain.exceptions.task_exceptions import (
     TaskNotFoundException,
     TaskNotSchedulableError,
 )
-from taskdog_core.domain.repositories.task_repository import TaskRepository
-from taskdog_core.domain.services.holiday_checker import IHolidayChecker
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from taskdog_core.domain.repositories.task_repository import TaskRepository
+    from taskdog_core.domain.services.holiday_checker import IHolidayChecker
 
 
 class OptimizeScheduleUseCase(UseCase[OptimizeScheduleInput, OptimizationOutput]):

--- a/packages/taskdog-core/src/taskdog_core/application/validators/validator_registry.py
+++ b/packages/taskdog-core/src/taskdog_core/application/validators/validator_registry.py
@@ -1,15 +1,19 @@
 """Registry for field validators."""
 
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from taskdog_core.application.validators.datetime_validator import DateTimeValidator
-from taskdog_core.application.validators.field_validator import FieldValidator
 from taskdog_core.application.validators.numeric_field_validator import (
     NumericFieldValidator,
 )
 from taskdog_core.application.validators.status_validator import StatusValidator
-from taskdog_core.domain.entities.task import Task
-from taskdog_core.domain.repositories.task_repository import TaskRepository
+
+if TYPE_CHECKING:
+    from taskdog_core.application.validators.field_validator import FieldValidator
+    from taskdog_core.domain.entities.task import Task
+    from taskdog_core.domain.repositories.task_repository import TaskRepository
 
 
 class TaskFieldValidatorRegistry:

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/base_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/base_repository.py
@@ -6,13 +6,16 @@ used by all SQLite repository implementations.
 
 from __future__ import annotations
 
-from sqlalchemy.engine import Engine
-from sqlalchemy.orm import Session, sessionmaker
+from typing import TYPE_CHECKING
 
 from taskdog_core.infrastructure.persistence.database.engine_factory import (
     create_session_factory,
     create_sqlite_engine,
 )
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Engine
+    from sqlalchemy.orm import Session, sessionmaker
 
 
 class SqliteBaseRepository:

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/migration_runner.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/migration_runner.py
@@ -9,12 +9,15 @@ from __future__ import annotations
 
 import threading
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from alembic import command
 from alembic.config import Config as AlembicConfig
 from alembic.script import ScriptDirectory
 from sqlalchemy import inspect, text
-from sqlalchemy.engine import Engine
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Engine
 
 # Lock for thread-safe migration execution
 _migration_lock = threading.Lock()

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/migrations/env.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/migrations/env.py
@@ -9,13 +9,17 @@ This is necessary for in-memory SQLite databases where new connections
 create separate databases.
 """
 
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from alembic import context
 from sqlalchemy import engine_from_config, pool
-from sqlalchemy.engine import Engine
 
 from taskdog_core.infrastructure.persistence.database.models.task_model import Base
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Engine
 
 # This is the Alembic Config object, which provides access to values
 # within the .ini file (or programmatic config) in use.

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_audit_log_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_audit_log_repository.py
@@ -7,10 +7,12 @@ SQLAlchemy 2.0 ORM. It stores all API operations for accountability and review.
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import delete, func, select
-from sqlalchemy.engine import Engine
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Engine
 
 from taskdog_core.application.dto.audit_log_dto import (
     AuditEvent,

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_notes_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_notes_repository.py
@@ -9,20 +9,25 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from sqlalchemy import delete, select
-from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 
 from taskdog_core.domain.repositories.notes_repository import NotesRepository
-from taskdog_core.domain.services.time_provider import ITimeProvider
 from taskdog_core.infrastructure.persistence.database.base_repository import (
     SqliteBaseRepository,
 )
 from taskdog_core.infrastructure.persistence.database.models.note_model import (
     NoteModel,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from sqlalchemy.engine import Engine
+
+    from taskdog_core.domain.services.time_provider import ITimeProvider
 
 
 @dataclass

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_task_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_task_repository.py
@@ -10,11 +10,9 @@ The repository uses TagResolver to manage tag relationships when saving tasks.
 
 from __future__ import annotations
 
-from datetime import date
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import func, select
-from sqlalchemy.engine import Engine
 
 from taskdog_core.domain.entities.task import Task, TaskStatus
 from taskdog_core.domain.exceptions.tag_exceptions import TagNotFoundException
@@ -42,6 +40,10 @@ from taskdog_core.infrastructure.persistence.mappers.tag_resolver import TagReso
 from taskdog_core.infrastructure.persistence.mappers.task_db_mapper import TaskDbMapper
 
 if TYPE_CHECKING:
+    from datetime import date
+
+    from sqlalchemy.engine import Engine
+
     from taskdog_core.domain.services.time_provider import ITimeProvider
 
 

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/mappers/task_db_mapper.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/mappers/task_db_mapper.py
@@ -11,12 +11,16 @@ The mapper reads via TaskModel.allocation_models relationship.
 Writes are handled by DailyAllocationBuilder in the repository.
 """
 
+from __future__ import annotations
+
 import json
-from datetime import date
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from taskdog_core.domain.entities.task import Task, TaskStatus
 from taskdog_core.infrastructure.persistence.database.models.task_model import TaskModel
+
+if TYPE_CHECKING:
+    from datetime import date
 
 
 class TaskDbMapper:


### PR DESCRIPTION
## Summary
- Move type-hint-only imports behind `if TYPE_CHECKING:` guards in taskdog-core (13 files)
- Add `from __future__ import annotations` where needed
- Fixes TC001 (app imports), TC002 (third-party imports), TC003 (stdlib imports)

Part of #701 — enabling ruff TC rule across all packages.

## Test plan
- [x] `make test-core` — 1097 passed
- [x] `make lint` — passed
- [x] `make typecheck` — passed