### PR TITLE
refactor(client): enable ruff TC rule - taskdog-client

### DIFF
--- a/packages/taskdog-client/src/taskdog_client/base_client.py
+++ b/packages/taskdog-client/src/taskdog_client/base_client.py
@@ -1,8 +1,12 @@
 """Base HTTP client infrastructure for Taskdog API."""
 
+from __future__ import annotations
+
 import contextlib
-from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 import httpx  # type: ignore[import-not-found]
 
@@ -47,7 +51,7 @@ class BaseApiClient:
         """Close the HTTP client."""
         self.client.close()
 
-    def __enter__(self) -> "BaseApiClient":
+    def __enter__(self) -> BaseApiClient:
         """Context manager entry."""
         return self
 

--- a/packages/taskdog-client/src/taskdog_client/converters/optimization_converters.py
+++ b/packages/taskdog-client/src/taskdog_client/converters/optimization_converters.py
@@ -1,8 +1,12 @@
 """Optimization data converters."""
 
-from datetime import date as date_type
-from datetime import datetime
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from datetime import date as date_type
+    from datetime import datetime
 
 from taskdog_core.application.dto.optimization_output import (
     OptimizationOutput,


### PR DESCRIPTION
## Summary
- Move `Callable`, `date`, `datetime` imports behind `if TYPE_CHECKING:` guards (2 files)
- Add `from __future__ import annotations`

Part of #701 — enabling ruff TC rule across all packages.

## Test plan
- [x] `make lint` — passed
- [x] `make typecheck` — passed