### PR TITLE
refactor(mcp): enable ruff TC rule - taskdog-mcp

### DIFF
--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_audit.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_audit.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from mcp.server.fastmcp import FastMCP
-
 if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
     from taskdog_client import TaskdogApiClient
 
 

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_crud.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_crud.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from mcp.server.fastmcp import FastMCP
-
 if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
     from taskdog_client import TaskdogApiClient
 
 

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_decomposition.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_decomposition.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from mcp.server.fastmcp import FastMCP
-
 if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
     from taskdog_client import TaskdogApiClient
 
 

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_lifecycle.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_lifecycle.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from mcp.server.fastmcp import FastMCP
-
 if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
     from taskdog_client import TaskdogApiClient
 
 

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_query.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_query.py
@@ -7,9 +7,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from mcp.server.fastmcp import FastMCP
-
 if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
     from taskdog_client import TaskdogApiClient
 
 

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_tags.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_tags.py
@@ -7,9 +7,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from mcp.server.fastmcp import FastMCP
-
 if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
     from taskdog_client import TaskdogApiClient
 
 


### PR DESCRIPTION
## Summary
- Move `FastMCP` imports behind `if TYPE_CHECKING:` guards in all 6 tool files
- Fixes TC002 violations

Part of #701 — enabling ruff TC rule across all packages.

## Test plan
- [x] `make test-mcp` — 74 passed
- [x] `make lint` — passed
- [x] `make typecheck` — passed