### PR TITLE
refactor(ui): enable ruff TC rule - taskdog-ui

### DIFF
--- a/packages/taskdog-ui/src/taskdog/cli/commands/add.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/add.py
@@ -1,11 +1,17 @@
 """Add command - Add a new task."""
 
-from datetime import datetime
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import click
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_task_errors
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from taskdog.cli.context import CliContext
 from taskdog_core.domain.exceptions.task_exceptions import TaskValidationError
 
 

--- a/packages/taskdog-ui/src/taskdog/cli/commands/add_dependency.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/add_dependency.py
@@ -1,9 +1,15 @@
 """Add-dependency command - Add a task dependency."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import click
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_task_errors
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 @click.command(name="add-dependency", help="Add a dependency to a task.")

--- a/packages/taskdog-ui/src/taskdog/cli/commands/audit_logs.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/audit_logs.py
@@ -1,11 +1,13 @@
 """Audit logs command - Display operation history."""
 
+from __future__ import annotations
+
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 import click
 from rich.table import Table
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_command_errors
 from taskdog.constants.audit_log import (
     AUDIT_CHANGES_WIDTH,
@@ -28,7 +30,10 @@ from taskdog.constants.audit_log import (
 from taskdog.constants.common import HEADER_ID, TABLE_HEADER_STYLE
 from taskdog.constants.formatting import format_table_title
 from taskdog.tui.widgets.audit_log_entry_builder import format_audit_changes
-from taskdog_core.application.dto.audit_log_dto import AuditLogOutput
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
+    from taskdog_core.application.dto.audit_log_dto import AuditLogOutput
 
 
 def _parse_date_filter(date_str: str, end_of_day: bool = False) -> datetime:

--- a/packages/taskdog-ui/src/taskdog/cli/commands/cancel.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/cancel.py
@@ -1,9 +1,15 @@
 """Cancel command - Mark a task as canceled."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import click
 
 from taskdog.cli.commands.batch_helpers import execute_batch_operation
-from taskdog.cli.context import CliContext
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 from taskdog_core.shared.constants import StatusVerbs
 
 

--- a/packages/taskdog-ui/src/taskdog/cli/commands/done.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/done.py
@@ -1,9 +1,15 @@
 """Done command - Mark a task as completed."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import click
 
 from taskdog.cli.commands.batch_helpers import execute_batch_operation
-from taskdog.cli.context import CliContext
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 from taskdog_core.shared.constants import StatusVerbs
 
 

--- a/packages/taskdog-ui/src/taskdog/cli/commands/export.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/export.py
@@ -1,12 +1,18 @@
 """Export command - Export tasks to various formats."""
 
-from datetime import datetime
+from __future__ import annotations
+
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 
 from taskdog.cli.commands.common_options import date_range_options, filter_options
-from taskdog.cli.context import CliContext
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from taskdog.cli.context import CliContext
 from taskdog.exporters import (
     CsvTaskExporter,
     JsonTaskExporter,

--- a/packages/taskdog-ui/src/taskdog/cli/commands/fix_actual.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/fix_actual.py
@@ -1,12 +1,17 @@
 """Fix-actual command - Correct actual start/end timestamps and duration."""
 
-from datetime import datetime
-from typing import Any, cast
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
 
 import click
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_task_errors
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from taskdog.cli.context import CliContext
 
 # Sentinel value for "clear" - distinct from None (not provided)
 CLEAR_SENTINEL = "CLEAR"
@@ -32,7 +37,7 @@ class ClearableDateTimeType(click.ParamType):
             return None
         if value == "" or value == CLEAR_SENTINEL:
             return CLEAR_SENTINEL
-        return cast(datetime, self._inner.convert(value, param, ctx))
+        return cast("datetime", self._inner.convert(value, param, ctx))
 
 
 class ClearableFloatType(click.ParamType):

--- a/packages/taskdog-ui/src/taskdog/cli/commands/gantt.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/gantt.py
@@ -1,12 +1,17 @@
 """Gantt command - Display tasks in Gantt chart format."""
 
+from __future__ import annotations
+
 from datetime import date, datetime, timedelta
+from typing import TYPE_CHECKING
 
 import click
 
 from taskdog.cli.commands.common_options import filter_options, sort_options
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_command_errors
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 from taskdog.constants.gantt import (
     CHARS_PER_DAY,
     GANTT_CLI_FIXED_COLUMNS_WIDTH,

--- a/packages/taskdog-ui/src/taskdog/cli/commands/note.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/note.py
@@ -1,22 +1,28 @@
 """Note command - Edit task notes in markdown."""
 
+from __future__ import annotations
+
 import select
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
-from taskdog_client import TaskdogApiClient
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_task_errors
-from taskdog.console.console_writer import ConsoleWriter
-from taskdog.infrastructure.cli_config_manager import CliConfig
 from taskdog.utils.editor import get_editor
 from taskdog.utils.notes_template import get_note_template
-from taskdog_core.application.dto.task_dto import TaskDetailDto
 from taskdog_core.domain.exceptions.task_exceptions import TaskNotFoundException
+
+if TYPE_CHECKING:
+    from taskdog_client import TaskdogApiClient
+
+    from taskdog.cli.context import CliContext
+    from taskdog.console.console_writer import ConsoleWriter
+    from taskdog.infrastructure.cli_config_manager import CliConfig
+    from taskdog_core.application.dto.task_dto import TaskDetailDto
 
 
 def _read_content_from_source(

--- a/packages/taskdog-ui/src/taskdog/cli/commands/optimize.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/optimize.py
@@ -1,13 +1,19 @@
 """Optimize command - Auto-generate optimal task schedules."""
 
-from datetime import datetime
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import click
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_command_errors
-from taskdog.console.console_writer import ConsoleWriter
-from taskdog_core.application.dto.optimization_output import OptimizationOutput
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from taskdog.cli.context import CliContext
+    from taskdog.console.console_writer import ConsoleWriter
+    from taskdog_core.application.dto.optimization_output import OptimizationOutput
 
 
 def _show_failed_tasks(

--- a/packages/taskdog-ui/src/taskdog/cli/commands/pause.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/pause.py
@@ -1,9 +1,15 @@
 """Pause command - Pause a task and reset its time tracking."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import click
 
 from taskdog.cli.commands.batch_helpers import execute_batch_operation
-from taskdog.cli.context import CliContext
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 from taskdog_core.shared.constants import StatusVerbs
 
 

--- a/packages/taskdog-ui/src/taskdog/cli/commands/remove_dependency.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/remove_dependency.py
@@ -1,9 +1,15 @@
 """Remove-dependency command - Remove a task dependency."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import click
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_task_errors
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 @click.command(name="remove-dependency", help="Remove a dependency from a task.")

--- a/packages/taskdog-ui/src/taskdog/cli/commands/reopen.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/reopen.py
@@ -1,9 +1,15 @@
 """Reopen command - Reopen completed or canceled task(s)."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import click
 
 from taskdog.cli.commands.batch_helpers import execute_batch_operation
-from taskdog.cli.context import CliContext
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 from taskdog_core.shared.constants import StatusVerbs
 
 

--- a/packages/taskdog-ui/src/taskdog/cli/commands/restore.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/restore.py
@@ -1,9 +1,15 @@
 """Restore command - Restore archived (soft deleted) task(s)."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import click
 
 from taskdog.cli.commands.batch_helpers import execute_batch_operation
-from taskdog.cli.context import CliContext
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 from taskdog_core.shared.constants import StatusVerbs
 
 

--- a/packages/taskdog-ui/src/taskdog/cli/commands/rm.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/rm.py
@@ -1,9 +1,15 @@
 """Rm command - Remove a task."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import click
 
 from taskdog.cli.commands.batch_helpers import execute_batch_operation
-from taskdog.cli.context import CliContext
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 
 
 @click.command(

--- a/packages/taskdog-ui/src/taskdog/cli/commands/show.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/show.py
@@ -1,9 +1,15 @@
 """Show command - Display task details and notes."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import click
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_task_errors
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 from taskdog.renderers.rich_detail_renderer import RichDetailRenderer
 
 

--- a/packages/taskdog-ui/src/taskdog/cli/commands/start.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/start.py
@@ -1,9 +1,15 @@
 """Start command - Start working on a task."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import click
 
 from taskdog.cli.commands.batch_helpers import execute_batch_operation
-from taskdog.cli.context import CliContext
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 from taskdog_core.shared.constants import StatusVerbs
 
 

--- a/packages/taskdog-ui/src/taskdog/cli/commands/stats.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/stats.py
@@ -1,9 +1,15 @@
 """Stats command - Display task statistics and analytics."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import click
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_command_errors
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 from taskdog.presenters.statistics_presenter import StatisticsPresenter
 from taskdog.renderers.rich_statistics_renderer import RichStatisticsRenderer
 

--- a/packages/taskdog-ui/src/taskdog/cli/commands/table.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/table.py
@@ -1,6 +1,8 @@
 """Table command - Display tasks in flat table format."""
 
-from datetime import datetime
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import click
 
@@ -10,8 +12,12 @@ from taskdog.cli.commands.common_options import (
     sort_options,
 )
 from taskdog.cli.commands.table_helpers import render_table
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_command_errors
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from taskdog.cli.context import CliContext
 from taskdog.shared.click_types.field_list import FieldList
 
 

--- a/packages/taskdog-ui/src/taskdog/cli/commands/tags.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/tags.py
@@ -1,9 +1,15 @@
 """Tags command - Manage task tags."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import click
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_task_errors
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 from taskdog_core.domain.exceptions.task_exceptions import TaskNotFoundException
 
 

--- a/packages/taskdog-ui/src/taskdog/cli/commands/timeline.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/timeline.py
@@ -1,11 +1,16 @@
 """Timeline command - Display actual work times for a day."""
 
+from __future__ import annotations
+
 from datetime import date, datetime
+from typing import TYPE_CHECKING
 
 import click
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_command_errors
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 from taskdog.presenters.timeline_presenter import TimelinePresenter
 from taskdog.renderers.rich_timeline_renderer import RichTimelineRenderer
 

--- a/packages/taskdog-ui/src/taskdog/cli/commands/tui.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/tui.py
@@ -1,11 +1,15 @@
 """TUI command - Launch the Text User Interface."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse, urlunparse
 
 import click
 from taskdog_client import WebSocketClient
 
-from taskdog.cli.context import CliContext
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 from taskdog.tui.app import TaskdogTUI
 
 

--- a/packages/taskdog-ui/src/taskdog/cli/commands/update.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/update.py
@@ -1,11 +1,17 @@
 """Update command - Update task properties."""
 
-from datetime import datetime
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import click
 
-from taskdog.cli.context import CliContext
 from taskdog.cli.error_handler import handle_task_errors
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from taskdog.cli.context import CliContext
 from taskdog_core.domain.entities.task import TaskStatus
 
 

--- a/packages/taskdog-ui/src/taskdog/cli/commands/update_helpers.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/update_helpers.py
@@ -1,11 +1,14 @@
 """Helper functions for update commands to reduce duplication."""
 
-from typing import Any
+from __future__ import annotations
 
-import click
+from typing import TYPE_CHECKING, Any
 
-from taskdog.cli.context import CliContext
-from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
+if TYPE_CHECKING:
+    import click
+
+    from taskdog.cli.context import CliContext
+    from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 
 
 def execute_single_field_update(

--- a/packages/taskdog-ui/src/taskdog/cli/error_handler.py
+++ b/packages/taskdog-ui/src/taskdog/cli/error_handler.py
@@ -1,12 +1,15 @@
 """Common error handling decorators for CLI commands."""
 
+from __future__ import annotations
+
 from collections.abc import Callable
 from functools import wraps
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import click
 
-from taskdog.cli.context import CliContext
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
 from taskdog_core.domain.exceptions.task_exceptions import (
     AuthenticationError,
     ServerConnectionError,
@@ -52,7 +55,7 @@ def handle_task_errors(action_name: str) -> Callable[[F], F]:
             except Exception as e:
                 console_writer.error(action_name, e)
 
-        return cast(F, wrapper)
+        return cast("F", wrapper)
 
     return decorator
 
@@ -90,6 +93,6 @@ def handle_command_errors(action_name: str) -> Callable[[F], F]:
             except Exception as e:
                 console_writer.error(action_name, e)
 
-        return cast(F, wrapper)
+        return cast("F", wrapper)
 
     return decorator

--- a/packages/taskdog-ui/src/taskdog/renderers/rich_table_renderer.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/rich_table_renderer.py
@@ -1,9 +1,9 @@
-from collections.abc import Callable
-from typing import ClassVar, Literal, cast
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar, Literal, cast
 
 from rich.table import Table
 
-from taskdog.console.console_writer import ConsoleWriter
 from taskdog.constants.common import (
     COLUMN_DATETIME_NO_WRAP,
     COLUMN_FINISHED_STYLE,
@@ -70,7 +70,12 @@ from taskdog.constants.task_table import (
 from taskdog.formatters.date_time_formatter import DateTimeFormatter
 from taskdog.formatters.duration_formatter import DurationFormatter
 from taskdog.renderers.rich_renderer_base import RichRendererBase
-from taskdog.view_models.task_view_model import TaskRowViewModel
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from taskdog.console.console_writer import ConsoleWriter
+    from taskdog.view_models.task_view_model import TaskRowViewModel
 
 # Type alias for Rich table justify method
 JustifyMethod = Literal["default", "left", "center", "right", "full"]
@@ -270,7 +275,7 @@ class RichTableRenderer(RichRendererBase):
             justify_val = field_config.get("justify")
             valid_justify = {"default", "left", "center", "right", "full"}
             justify: JustifyMethod = (
-                cast(JustifyMethod, justify_val)
+                cast("JustifyMethod", justify_val)
                 if isinstance(justify_val, str) and justify_val in valid_justify
                 else "left"
             )

--- a/packages/taskdog-ui/src/taskdog/tui/commands/base.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/base.py
@@ -96,7 +96,7 @@ class TUICommandBase(ABC):  # noqa: B024
                 self.notify_error(f"Error {action_name}", e)
                 return None
 
-        return cast(F, wrapper)
+        return cast("F", wrapper)
 
     def get_action_name(self) -> str:
         """Return the action name for error messages (e.g., "adding task").

--- a/packages/taskdog-ui/src/taskdog/tui/commands/decorators.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/decorators.py
@@ -34,4 +34,4 @@ def require_selected_task[F: Callable[..., Any]](func: F) -> F:
             return None
         return func(self, *args, **kwargs)
 
-    return cast(F, wrapper)
+    return cast("F", wrapper)

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/stats_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/stats_dialog.py
@@ -1,7 +1,7 @@
 """Statistics dialog for TUI."""
 
 import asyncio
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import Any, ClassVar
 
 from taskdog_client.taskdog_api_client import TaskdogApiClient
 from textual.app import ComposeResult
@@ -16,9 +16,6 @@ from taskdog.tui.widgets.vi_navigation_mixin import ViNavigationMixin
 from taskdog.view_models.statistics_view_model import (
     StatisticsViewModel,
 )
-
-if TYPE_CHECKING:
-    pass
 
 # Mapping from tab pane ID to its VerticalScroll child ID
 _TAB_SCROLL_MAP: dict[str, str] = {

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/task_detail_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/task_detail_dialog.py
@@ -1,10 +1,10 @@
 """Task detail dialog for TUI."""
 
-import asyncio
-from typing import Any, ClassVar
+from __future__ import annotations
 
-from taskdog_client.taskdog_api_client import TaskdogApiClient
-from textual.app import ComposeResult
+import asyncio
+from typing import TYPE_CHECKING, Any, ClassVar
+
 from textual.binding import Binding
 from textual.containers import Container, VerticalScroll
 from textual.css.query import NoMatches
@@ -15,9 +15,14 @@ from taskdog.formatters.date_time_formatter import DateTimeFormatter
 from taskdog.tui.dialogs.base_dialog import BaseModalDialog
 from taskdog.tui.widgets.audit_log_entry_builder import create_audit_log_table
 from taskdog.tui.widgets.vi_navigation_mixin import ViNavigationMixin
-from taskdog_core.application.dto.task_detail_output import TaskDetailOutput
-from taskdog_core.application.dto.task_dto import TaskDetailDto
 from taskdog_core.shared.constants.formats import DATETIME_FORMAT
+
+if TYPE_CHECKING:
+    from taskdog_client.taskdog_api_client import TaskdogApiClient
+    from textual.app import ComposeResult
+
+    from taskdog_core.application.dto.task_detail_output import TaskDetailOutput
+    from taskdog_core.application.dto.task_dto import TaskDetailDto
 
 # Mapping from tab pane ID to its VerticalScroll child ID
 _TAB_SCROLL_MAP: dict[str, str] = {

--- a/packages/taskdog-ui/src/taskdog/tui/palette/providers/base.py
+++ b/packages/taskdog-ui/src/taskdog/tui/palette/providers/base.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from collections.abc import Callable
 from typing import TYPE_CHECKING, cast
 
 from textual.command import DiscoveryHit, Hit, Hits, Provider
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from taskdog.tui.app import TaskdogTUI
 
 

--- a/packages/taskdog-ui/src/taskdog/tui/palette/providers/export_providers.py
+++ b/packages/taskdog-ui/src/taskdog/tui/palette/providers/export_providers.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from functools import partial
 from typing import TYPE_CHECKING
 
@@ -12,6 +11,8 @@ from taskdog.tui.palette.providers.base import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from taskdog.tui.app import TaskdogTUI
 
 

--- a/packages/taskdog-ui/src/taskdog/tui/palette/providers/sort_providers.py
+++ b/packages/taskdog-ui/src/taskdog/tui/palette/providers/sort_providers.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from functools import partial
 from typing import TYPE_CHECKING, ClassVar
 
@@ -12,6 +11,8 @@ from taskdog.tui.palette.providers.base import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from taskdog.tui.app import TaskdogTUI
 
 

--- a/packages/taskdog-ui/src/taskdog/tui/screens/main_screen.py
+++ b/packages/taskdog-ui/src/taskdog/tui/screens/main_screen.py
@@ -1,19 +1,24 @@
 """Main screen for the TUI."""
 
-from typing import ClassVar
+from __future__ import annotations
 
-from textual.app import ComposeResult
+from typing import TYPE_CHECKING, ClassVar
+
 from textual.binding import Binding
 from textual.containers import Vertical
 from textual.screen import Screen
-from textual.timer import Timer
 from textual.widgets import Header
 
 from taskdog.tui.events import FilterChanged, SearchQueryChanged
-from taskdog.tui.state import TUIState
 from taskdog.tui.widgets.custom_footer import CustomFooter
 from taskdog.tui.widgets.gantt_widget import GanttWidget
 from taskdog.tui.widgets.task_table import TaskTable
+
+if TYPE_CHECKING:
+    from textual.app import ComposeResult
+    from textual.timer import Timer
+
+    from taskdog.tui.state import TUIState
 
 
 class MainScreen(Screen[None]):

--- a/packages/taskdog-ui/src/taskdog/tui/state/tui_state.py
+++ b/packages/taskdog-ui/src/taskdog/tui/state/tui_state.py
@@ -4,16 +4,19 @@ This module provides centralized state management for the TUI application,
 eliminating duplication and synchronization issues across components.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from datetime import date
 from typing import TYPE_CHECKING
 
 from taskdog.view_models.gantt_view_model import GanttViewModel, TaskGanttRowViewModel
-from taskdog.view_models.task_view_model import TaskRowViewModel
-from taskdog_core.application.dto.task_dto import TaskRowDto
 
 if TYPE_CHECKING:
+    from datetime import date
+
     from taskdog.tui.widgets.task_search_filter import TaskSearchFilter
+    from taskdog.view_models.task_view_model import TaskRowViewModel
+    from taskdog_core.application.dto.task_dto import TaskRowDto
 
 
 @dataclass
@@ -61,7 +64,7 @@ class TUIState:
     """Cache of Gantt ViewModel for current date range."""
 
     # === Internal State (not exposed) ===
-    _search_filter: "TaskSearchFilter | None" = field(
+    _search_filter: TaskSearchFilter | None = field(
         default=None, repr=False, compare=False
     )
     """Lazily initialized search filter instance."""
@@ -71,7 +74,7 @@ class TUIState:
     )
     """Cached result of filtered_viewmodels computation."""
 
-    def _get_search_filter(self) -> "TaskSearchFilter":
+    def _get_search_filter(self) -> TaskSearchFilter:
         """Get or create the search filter instance (lazy initialization).
 
         Returns:

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/task_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/task_table.py
@@ -7,15 +7,12 @@ This module provides a data table widget for displaying tasks with:
 - Automatic formatting for all task fields
 """
 
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import Any, ClassVar
 
 from rich.text import Text
 from textual.binding import Binding
 from textual.coordinate import Coordinate
 from textual.widgets import DataTable
-
-if TYPE_CHECKING:
-    pass
 
 from taskdog.constants.common import (
     HEADER_ESTIMATED,


### PR DESCRIPTION
## Summary
- Move type-hint-only imports behind `if TYPE_CHECKING:` guards in 36 files
- CLI commands: `CliContext` imports (25 files)
- TUI: `Timer`, `TaskDetailDto`, `Callable`, etc.
- Renderers: `Callable`, `ConsoleWriter`, `TaskRowViewModel`
- Add `from __future__ import annotations` where needed

Part of #701 — enabling ruff TC rule across all packages.

## Test plan
- [x] `make test-ui` — 930 passed
- [x] `make lint` — passed
- [x] `make typecheck` — passed