### PR TITLE
refactor: enable ruff TC rule in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ select = [
   "PTH",  # flake8-use-pathlib
   "FURB",  # refurb modernization
   "RUF",  # ruff-specific rules
+  "TC",  # flake8-type-checking
 ]
 ignore = [
   "E501",  # line too long (handled by formatter)
@@ -132,6 +133,9 @@ ignore = [
 "packages/*/tests/**/*.py" = ["SIM115", "RUF015"]  # Test code patterns are acceptable
 "scripts/**/*.py" = ["B904", "C901"]  # Migration scripts: exception chaining and complexity acceptable
 "packages/taskdog-server/src/taskdog_server/api/error_handlers.py" = ["UP047"]  # Type parameters require Python 3.12+
+
+[tool.ruff.lint.flake8-type-checking]
+runtime-evaluated-base-classes = ["pydantic.BaseModel"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10


### PR DESCRIPTION
## Summary
- Add `"TC"` to ruff lint select rules
- Configure `runtime-evaluated-base-classes = ["pydantic.BaseModel"]` to exempt Pydantic field annotations

**This PR should be merged last**, after all per-package TC fix PRs are merged:
- #786 taskdog-core
- #787 taskdog-client
- #788 taskdog-mcp
- #789 taskdog-ui

Closes #701

## Test plan
- [x] `uv run ruff check --select TC .` — 0 violations (with all fix PRs merged)
- [x] `make lint` — passed
- [x] `make typecheck` — passed
- [x] `make test` — passed