### PR TITLE
perf(core): unify AND tag filter to use GROUP BY + HAVING

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/query_builders/task_query_builder.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/query_builders/task_query_builder.py
@@ -10,7 +10,7 @@ The builder supports the hybrid filtering architecture where simple filters
 
 from datetime import date
 
-from sqlalchemy import or_, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.sql.expression import ColumnElement
 from sqlalchemy.sql.selectable import Select
 
@@ -109,19 +109,24 @@ class TaskQueryBuilder:
 
         Note:
             Uses SQL JOIN with tags and task_tags tables for efficiency.
-            AND logic: Creates multiple subqueries (one per tag)
-            OR logic: Creates single subquery with IN clause
+            AND logic: Single subquery with GROUP BY + HAVING COUNT
+            OR logic: Single subquery with IN clause
         """
         if tags:
             if match_all:
                 # AND logic: task must have ALL specified tags
-                for tag in tags:
-                    tag_subquery = (
-                        select(TaskTagModel.task_id)
-                        .join(TagModel, TaskTagModel.tag_id == TagModel.id)
-                        .where(TagModel.name == tag)
+                # Single query with GROUP BY + HAVING COUNT instead of N subqueries
+                unique_tag_count = len(set(tags))
+                tag_subquery = (
+                    select(TaskTagModel.task_id)
+                    .join(TagModel, TaskTagModel.tag_id == TagModel.id)
+                    .where(TagModel.name.in_(tags))  # type: ignore[attr-defined]
+                    .group_by(TaskTagModel.task_id)
+                    .having(
+                        func.count(func.distinct(TagModel.name)) == unique_tag_count
                     )
-                    self._stmt = self._stmt.where(TaskModel.id.in_(tag_subquery))  # type: ignore[attr-defined]
+                )
+                self._stmt = self._stmt.where(TaskModel.id.in_(tag_subquery))  # type: ignore[attr-defined]
             else:
                 # OR logic: task must have ANY of the specified tags
                 tag_subquery = (


### PR DESCRIPTION
## Summary

- Replace N per-tag subqueries in `TaskQueryBuilder.with_tag_filter(match_all=True)` with a single `GROUP BY + HAVING COUNT(DISTINCT)` query
- Aligns with the existing approach in `SqliteTaskRepository.get_task_ids_by_tags()` for consistency

## Before / After

**Before (N subqueries):**
```sql
SELECT * FROM tasks
WHERE id IN (SELECT task_id FROM task_tags JOIN tags ... WHERE name = 'tag1')
  AND id IN (SELECT task_id FROM task_tags JOIN tags ... WHERE name = 'tag2')
  AND id IN (SELECT task_id FROM task_tags JOIN tags ... WHERE name = 'tagN')
```

**After (single subquery):**
```sql
SELECT * FROM tasks
WHERE id IN (
    SELECT task_id FROM task_tags JOIN tags ...
    WHERE name IN ('tag1', 'tag2', 'tagN')
    GROUP BY task_id
    HAVING COUNT(DISTINCT name) = N
)
```

## Test plan

- [x] All 132 tag-related tests pass
- [x] `make lint` passes
- [x] `make typecheck` passes