### PR TITLE
feat(server): add bulk API foundation and bulk start endpoint

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/dto/__init__.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/__init__.py
@@ -1,6 +1,10 @@
 """Data Transfer Objects."""
 
 from taskdog_core.application.dto.base import SingleTaskInput
+from taskdog_core.application.dto.bulk_operation_output import (
+    BulkOperationOutput,
+    BulkTaskResultOutput,
+)
 from taskdog_core.application.dto.gantt_output import GanttDateRange, GanttOutput
 from taskdog_core.application.dto.query_inputs import (
     GetGanttDataInput,
@@ -20,6 +24,8 @@ from taskdog_core.application.dto.statistics_output import (
 from taskdog_core.application.dto.task_detail_output import TaskDetailOutput
 
 __all__ = [
+    "BulkOperationOutput",
+    "BulkTaskResultOutput",
     "CalculateStatisticsInput",
     "DeadlineComplianceStatistics",
     "EstimationAccuracyStatistics",

--- a/packages/taskdog-core/src/taskdog_core/application/dto/bulk_operation_output.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/bulk_operation_output.py
@@ -1,0 +1,45 @@
+"""Output DTOs for bulk task operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
+
+
+@dataclass(frozen=True)
+class BulkTaskResultOutput:
+    """Result for a single task within a bulk operation.
+
+    Attributes:
+        task_id: ID of the task that was operated on
+        success: Whether the operation succeeded
+        task: Task operation output if successful
+        error: Error message if failed
+    """
+
+    task_id: int
+    success: bool
+    task: TaskOperationOutput | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class BulkOperationOutput:
+    """Output for a bulk task operation.
+
+    Attributes:
+        operation: Name of the operation performed
+        total: Total number of tasks requested
+        succeeded: Number of successful operations
+        failed: Number of failed operations
+        results: Per-task results
+    """
+
+    operation: str
+    total: int
+    succeeded: int
+    failed: int
+    results: tuple[BulkTaskResultOutput, ...]

--- a/packages/taskdog-server/src/taskdog_server/api/app.py
+++ b/packages/taskdog-server/src/taskdog_server/api/app.py
@@ -12,6 +12,7 @@ from taskdog_server.api.middleware import LoggingMiddleware
 from taskdog_server.api.routers import (
     analytics_router,
     audit_router,
+    bulk_router,
     lifecycle_router,
     notes_router,
     relationships_router,
@@ -79,6 +80,7 @@ def create_app() -> FastAPI:
     app.include_router(analytics_router, prefix="/api/v1", tags=["analytics"])
     app.include_router(tags_router, prefix="/api/v1/tags", tags=["tags"])
     app.include_router(audit_router, prefix="/api/v1/audit-logs", tags=["audit"])
+    app.include_router(bulk_router, prefix="/api/v1/bulk/tasks", tags=["bulk"])
     app.include_router(websocket_router, tags=["websocket"])
 
     @app.get("/")

--- a/packages/taskdog-server/src/taskdog_server/api/models/requests.py
+++ b/packages/taskdog-server/src/taskdog_server/api/models/requests.py
@@ -166,6 +166,14 @@ class OptimizeScheduleRequest(BaseModel):
     )
 
 
+class BulkTaskIdsRequest(BaseModel):
+    """Request model for bulk operations that take a list of task IDs."""
+
+    task_ids: list[int] = Field(
+        ..., min_length=1, description="List of task IDs to operate on"
+    )
+
+
 class UpdateNotesRequest(BaseModel):
     """Request model for updating task notes."""
 

--- a/packages/taskdog-server/src/taskdog_server/api/models/responses.py
+++ b/packages/taskdog-server/src/taskdog_server/api/models/responses.py
@@ -383,3 +383,22 @@ class AuditLogListResponse(BaseModel):
     total_count: int
     limit: int
     offset: int
+
+
+class BulkTaskResult(BaseModel):
+    """Result for a single task within a bulk operation."""
+
+    task_id: int
+    success: bool
+    task: TaskOperationResponse | None = None
+    error: str | None = None
+
+
+class BulkOperationResponse(BaseModel):
+    """Response model for bulk task operations."""
+
+    operation: str
+    total: int
+    succeeded: int
+    failed: int
+    results: list[BulkTaskResult]

--- a/packages/taskdog-server/src/taskdog_server/api/routers/__init__.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/__init__.py
@@ -2,6 +2,7 @@
 
 from taskdog_server.api.routers.analytics import router as analytics_router
 from taskdog_server.api.routers.audit import router as audit_router
+from taskdog_server.api.routers.bulk import router as bulk_router
 from taskdog_server.api.routers.lifecycle import router as lifecycle_router
 from taskdog_server.api.routers.notes import router as notes_router
 from taskdog_server.api.routers.relationships import router as relationships_router
@@ -12,6 +13,7 @@ from taskdog_server.api.routers.websocket import router as websocket_router
 __all__ = [
     "analytics_router",
     "audit_router",
+    "bulk_router",
     "lifecycle_router",
     "notes_router",
     "relationships_router",

--- a/packages/taskdog-server/src/taskdog_server/api/routers/bulk.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/bulk.py
@@ -1,0 +1,146 @@
+"""Bulk task operation endpoints."""
+
+import logging
+from collections.abc import Callable
+
+from fastapi import APIRouter
+
+from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
+from taskdog_core.controllers.task_lifecycle_controller import TaskLifecycleController
+from taskdog_server.api.dependencies import (
+    AuditLogControllerDep,
+    AuthenticatedClientDep,
+    EventBroadcasterDep,
+    LifecycleControllerDep,
+)
+from taskdog_server.api.models.requests import BulkTaskIdsRequest
+from taskdog_server.api.models.responses import (
+    BulkOperationResponse,
+    BulkTaskResult,
+    TaskOperationResponse,
+)
+from taskdog_server.websocket.broadcaster import WebSocketEventBroadcaster
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _execute_bulk_operation(
+    *,
+    operation: str,
+    task_ids: list[int],
+    controller: TaskLifecycleController,
+    broadcaster: WebSocketEventBroadcaster,
+    audit_controller: AuditLogControllerDep,
+    client_name: str | None,
+    execute_fn: Callable[[int], TaskOperationOutput],
+    old_status: str,
+) -> BulkOperationResponse:
+    """Execute a bulk operation on multiple tasks.
+
+    Processes each task individually, collecting successes and failures.
+    Never raises on per-task errors — returns partial success results.
+
+    Args:
+        operation: Operation name (e.g., "start")
+        task_ids: List of task IDs to operate on
+        controller: Lifecycle controller
+        broadcaster: WebSocket event broadcaster
+        audit_controller: Audit log controller
+        client_name: Authenticated client name
+        execute_fn: Function that executes the operation on a single task ID
+        old_status: Previous status string for broadcast/audit
+
+    Returns:
+        BulkOperationResponse with per-task results
+    """
+    results: list[BulkTaskResult] = []
+    succeeded = 0
+    failed = 0
+
+    for task_id in task_ids:
+        try:
+            result = execute_fn(task_id)
+            broadcaster.task_status_changed(result, old_status, client_name)
+            audit_controller.log_operation(
+                operation=f"{operation}_task",
+                resource_type="task",
+                resource_id=task_id,
+                resource_name=result.name,
+                client_name=client_name,
+                old_values={"status": old_status},
+                new_values={"status": result.status.value},
+                success=True,
+            )
+            results.append(
+                BulkTaskResult(
+                    task_id=task_id,
+                    success=True,
+                    task=TaskOperationResponse.from_dto(result),
+                )
+            )
+            succeeded += 1
+        except Exception as e:
+            audit_controller.log_operation(
+                operation=f"{operation}_task",
+                resource_type="task",
+                resource_id=task_id,
+                resource_name=None,
+                client_name=client_name,
+                old_values=None,
+                new_values=None,
+                success=False,
+                error_message=str(e),
+            )
+            results.append(
+                BulkTaskResult(
+                    task_id=task_id,
+                    success=False,
+                    error=str(e),
+                )
+            )
+            failed += 1
+
+    return BulkOperationResponse(
+        operation=operation,
+        total=len(task_ids),
+        succeeded=succeeded,
+        failed=failed,
+        results=results,
+    )
+
+
+@router.post("/start", response_model=BulkOperationResponse)
+async def bulk_start(
+    request: BulkTaskIdsRequest,
+    controller: LifecycleControllerDep,
+    broadcaster: EventBroadcasterDep,
+    audit_controller: AuditLogControllerDep,
+    client_name: AuthenticatedClientDep,
+) -> BulkOperationResponse:
+    """Start multiple tasks in a single request.
+
+    Processes each task individually. Returns partial success results
+    if some tasks fail (e.g., not found, already started).
+
+    Args:
+        request: Request with list of task IDs
+        controller: Lifecycle controller dependency
+        broadcaster: Event broadcaster dependency
+        audit_controller: Audit log controller dependency
+        client_name: Authenticated client name
+
+    Returns:
+        BulkOperationResponse with per-task results
+    """
+    return _execute_bulk_operation(
+        operation="start",
+        task_ids=request.task_ids,
+        controller=controller,
+        broadcaster=broadcaster,
+        audit_controller=audit_controller,
+        client_name=client_name,
+        execute_fn=controller.start_task,
+        old_status="PENDING",
+    )

--- a/packages/taskdog-server/tests/api/routers/test_bulk.py
+++ b/packages/taskdog-server/tests/api/routers/test_bulk.py
@@ -1,0 +1,161 @@
+"""Tests for bulk task operation endpoints."""
+
+from datetime import datetime
+
+from taskdog_core.domain.entities.task import TaskStatus
+
+
+class TestBulkStartRouter:
+    """Test cases for POST /api/v1/bulk/tasks/start."""
+
+    def test_bulk_start_all_succeed(self, client, repository, task_factory):
+        """Test starting multiple pending tasks."""
+        task1 = task_factory.create(
+            name="Task 1", priority=1, status=TaskStatus.PENDING
+        )
+        task2 = task_factory.create(
+            name="Task 2", priority=2, status=TaskStatus.PENDING
+        )
+
+        response = client.post(
+            "/api/v1/bulk/tasks/start",
+            json={"task_ids": [task1.id, task2.id]},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["operation"] == "start"
+        assert data["total"] == 2
+        assert data["succeeded"] == 2
+        assert data["failed"] == 0
+        assert len(data["results"]) == 2
+
+        for result in data["results"]:
+            assert result["success"] is True
+            assert result["task"]["status"] == "IN_PROGRESS"
+            assert result["task"]["actual_start"] is not None
+            assert result["error"] is None
+
+        # Verify in database
+        for task_id in [task1.id, task2.id]:
+            updated = repository.get_by_id(task_id)
+            assert updated.status == TaskStatus.IN_PROGRESS
+
+    def test_bulk_start_partial_failure(self, client, repository, task_factory):
+        """Test bulk start with mix of valid and invalid tasks."""
+        task = task_factory.create(
+            name="Valid Task", priority=1, status=TaskStatus.PENDING
+        )
+
+        response = client.post(
+            "/api/v1/bulk/tasks/start",
+            json={"task_ids": [task.id, 999]},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 2
+        assert data["succeeded"] == 1
+        assert data["failed"] == 1
+
+        # First result should succeed
+        assert data["results"][0]["task_id"] == task.id
+        assert data["results"][0]["success"] is True
+
+        # Second result should fail
+        assert data["results"][1]["task_id"] == 999
+        assert data["results"][1]["success"] is False
+        assert data["results"][1]["error"] is not None
+
+    def test_bulk_start_all_fail(self, client):
+        """Test bulk start when all tasks fail."""
+        response = client.post(
+            "/api/v1/bulk/tasks/start",
+            json={"task_ids": [997, 998, 999]},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 3
+        assert data["succeeded"] == 0
+        assert data["failed"] == 3
+
+        for result in data["results"]:
+            assert result["success"] is False
+            assert result["task"] is None
+
+    def test_bulk_start_already_started(self, client, repository, task_factory):
+        """Test bulk start with already in-progress tasks."""
+        task = task_factory.create(name="In Progress", priority=1)
+        task.status = TaskStatus.IN_PROGRESS
+        task.actual_start = datetime.now()
+        repository.save(task)
+
+        response = client.post(
+            "/api/v1/bulk/tasks/start",
+            json={"task_ids": [task.id]},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["succeeded"] == 0
+        assert data["failed"] == 1
+        assert data["results"][0]["success"] is False
+
+    def test_bulk_start_single_task(self, client, repository, task_factory):
+        """Test bulk start with a single task."""
+        task = task_factory.create(
+            name="Solo Task", priority=1, status=TaskStatus.PENDING
+        )
+
+        response = client.post(
+            "/api/v1/bulk/tasks/start",
+            json={"task_ids": [task.id]},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["succeeded"] == 1
+        assert data["results"][0]["task"]["status"] == "IN_PROGRESS"
+
+    def test_bulk_start_empty_task_ids_returns_422(self, client):
+        """Test bulk start with empty task_ids list returns validation error."""
+        response = client.post(
+            "/api/v1/bulk/tasks/start",
+            json={"task_ids": []},
+        )
+
+        assert response.status_code == 422
+
+    def test_bulk_start_missing_task_ids_returns_422(self, client):
+        """Test bulk start without task_ids field returns validation error."""
+        response = client.post(
+            "/api/v1/bulk/tasks/start",
+            json={},
+        )
+
+        assert response.status_code == 422
+
+    def test_bulk_start_preserves_order(self, client, repository, task_factory):
+        """Test that results maintain the same order as input task_ids."""
+        task1 = task_factory.create(
+            name="Task A", priority=1, status=TaskStatus.PENDING
+        )
+        task2 = task_factory.create(
+            name="Task B", priority=2, status=TaskStatus.PENDING
+        )
+        task3 = task_factory.create(
+            name="Task C", priority=3, status=TaskStatus.PENDING
+        )
+
+        response = client.post(
+            "/api/v1/bulk/tasks/start",
+            json={"task_ids": [task3.id, task1.id, task2.id]},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["results"][0]["task_id"] == task3.id
+        assert data["results"][1]["task_id"] == task1.id
+        assert data["results"][2]["task_id"] == task2.id

--- a/packages/taskdog-server/tests/conftest.py
+++ b/packages/taskdog-server/tests/conftest.py
@@ -258,6 +258,7 @@ def app(
     from taskdog_server.api.routers import (
         analytics_router,
         audit_router,
+        bulk_router,
         lifecycle_router,
         notes_router,
         relationships_router,
@@ -277,6 +278,7 @@ def app(
     test_app.include_router(analytics_router, prefix="/api/v1", tags=["analytics"])
     test_app.include_router(tags_router, prefix="/api/v1/tags", tags=["tags"])
     test_app.include_router(audit_router, prefix="/api/v1/audit-logs", tags=["audit"])
+    test_app.include_router(bulk_router, prefix="/api/v1/bulk/tasks", tags=["bulk"])
     test_app.include_router(websocket_router, tags=["websocket"])
 
     return test_app


### PR DESCRIPTION
## Summary

- Add `POST /api/v1/bulk/tasks/start` endpoint for starting multiple tasks in a single request
- Introduce bulk API foundation: `_execute_bulk_operation` helper, Pydantic models (`BulkTaskIdsRequest`, `BulkTaskResult`, `BulkOperationResponse`), and Core DTOs (`BulkTaskResultOutput`, `BulkOperationOutput`)
- Partial success semantics: always returns 200 with per-task success/failure results, enabling clients to handle mixed outcomes

## Test plan

- [x] `make test-server` — 299 tests passed (8 new bulk tests)
- [x] `make lint` — all checks passed
- [x] `make typecheck` — all checks passed
- [ ] Manual: start server → `curl -X POST /api/v1/bulk/tasks/start -d '{"task_ids": [1,2,3]}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)