### PR TITLE
refactor(core,server): return StatusChangeOutput from StatusChangeUseCase

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/dto/__init__.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/__init__.py
@@ -17,6 +17,7 @@ from taskdog_core.application.dto.statistics_output import (
     TimeStatistics,
     TrendStatistics,
 )
+from taskdog_core.application.dto.status_change_output import StatusChangeOutput
 from taskdog_core.application.dto.task_detail_output import TaskDetailOutput
 
 __all__ = [
@@ -30,6 +31,7 @@ __all__ = [
     "PriorityDistributionStatistics",
     "SingleTaskInput",
     "StatisticsOutput",
+    "StatusChangeOutput",
     "TaskDetailOutput",
     "TaskStatistics",
     "TimeRange",

--- a/packages/taskdog-core/src/taskdog_core/application/dto/status_change_output.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/status_change_output.py
@@ -1,0 +1,23 @@
+"""Output DTO for status change operations."""
+
+from dataclasses import dataclass
+
+from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
+from taskdog_core.domain.entities.task import TaskStatus
+
+
+@dataclass(frozen=True)
+class StatusChangeOutput:
+    """Output DTO that wraps TaskOperationOutput with the previous status.
+
+    Used by StatusChangeUseCase to return both the updated task and
+    the status before the change, eliminating the need for callers
+    to hardcode or guess the old status.
+
+    Attributes:
+        task: The updated task operation output
+        old_status: The task's status before the change
+    """
+
+    task: TaskOperationOutput
+    old_status: TaskStatus

--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/status_change_use_case.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/status_change_use_case.py
@@ -3,6 +3,7 @@
 from abc import ABC, abstractmethod
 
 from taskdog_core.application.dto.base import SingleTaskInput
+from taskdog_core.application.dto.status_change_output import StatusChangeOutput
 from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 from taskdog_core.application.services.task_status_service import TaskStatusService
 from taskdog_core.application.use_cases.base import UseCase
@@ -14,7 +15,7 @@ from taskdog_core.domain.repositories.task_repository import TaskRepository
 
 
 class StatusChangeUseCase[TInput: SingleTaskInput](
-    UseCase[TInput, TaskOperationOutput], ABC
+    UseCase[TInput, StatusChangeOutput], ABC
 ):
     """Base use case for status change operations.
 
@@ -49,7 +50,7 @@ class StatusChangeUseCase[TInput: SingleTaskInput](
         self.validator_registry = TaskFieldValidatorRegistry(repository)
         self.status_service = TaskStatusService()
 
-    def execute(self, input_dto: TInput) -> TaskOperationOutput:
+    def execute(self, input_dto: TInput) -> StatusChangeOutput:
         """Execute status change workflow (Template Method).
 
         This method defines the common workflow for all status changes.
@@ -59,7 +60,7 @@ class StatusChangeUseCase[TInput: SingleTaskInput](
             input_dto: Input data containing task_id
 
         Returns:
-            TaskOperationOutput DTO containing updated task information
+            StatusChangeOutput containing updated task and old status
 
         Raises:
             TaskNotFoundException: If task doesn't exist
@@ -67,6 +68,9 @@ class StatusChangeUseCase[TInput: SingleTaskInput](
         """
         # 1. Get task from repository
         task = self._get_task_or_raise(self.repository, input_dto.task_id)
+
+        # Record old status before any changes
+        old_status = task.status
 
         # 2. Pre-processing hook (optional)
         self._before_status_change(task)
@@ -86,7 +90,10 @@ class StatusChangeUseCase[TInput: SingleTaskInput](
         # 6. Post-processing hook (optional)
         self._after_status_change(task)
 
-        return TaskOperationOutput.from_task(task)
+        return StatusChangeOutput(
+            task=TaskOperationOutput.from_task(task),
+            old_status=old_status,
+        )
 
     @abstractmethod
     def _get_target_status(self) -> TaskStatus:

--- a/packages/taskdog-core/src/taskdog_core/controllers/task_lifecycle_controller.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/task_lifecycle_controller.py
@@ -14,6 +14,7 @@ from types import EllipsisType
 
 from taskdog_core.application.dto.base import SingleTaskInput
 from taskdog_core.application.dto.fix_actual_times_input import FixActualTimesInput
+from taskdog_core.application.dto.status_change_output import StatusChangeOutput
 from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 from taskdog_core.application.use_cases.cancel_task import CancelTaskUseCase
 from taskdog_core.application.use_cases.complete_task import CompleteTaskUseCase
@@ -55,7 +56,7 @@ class TaskLifecycleController(BaseTaskController):
         self,
         use_case_factory: StatusChangeUseCaseFactory,
         task_id: int,
-    ) -> TaskOperationOutput:
+    ) -> StatusChangeOutput:
         """Execute a status change use case.
 
         Args:
@@ -63,12 +64,12 @@ class TaskLifecycleController(BaseTaskController):
             task_id: ID of the task to modify
 
         Returns:
-            TaskOperationOutput containing the updated task information
+            StatusChangeOutput containing the updated task and old status
         """
         use_case = use_case_factory(self.repository)
         return use_case.execute(SingleTaskInput(task_id=task_id))
 
-    def start_task(self, task_id: int) -> TaskOperationOutput:
+    def start_task(self, task_id: int) -> StatusChangeOutput:
         """Start a task.
 
         Changes task status to IN_PROGRESS and records actual start time.
@@ -77,7 +78,7 @@ class TaskLifecycleController(BaseTaskController):
             task_id: ID of the task to start
 
         Returns:
-            TaskOperationOutput containing the updated task information
+            StatusChangeOutput containing the updated task and old status
 
         Raises:
             TaskNotFoundException: If task not found
@@ -85,7 +86,7 @@ class TaskLifecycleController(BaseTaskController):
         """
         return self._execute_status_change(StartTaskUseCase, task_id)
 
-    def complete_task(self, task_id: int) -> TaskOperationOutput:
+    def complete_task(self, task_id: int) -> StatusChangeOutput:
         """Complete a task.
 
         Changes task status to COMPLETED and records actual end time.
@@ -94,7 +95,7 @@ class TaskLifecycleController(BaseTaskController):
             task_id: ID of the task to complete
 
         Returns:
-            TaskOperationOutput containing the updated task information
+            StatusChangeOutput containing the updated task and old status
 
         Raises:
             TaskNotFoundException: If task not found
@@ -102,7 +103,7 @@ class TaskLifecycleController(BaseTaskController):
         """
         return self._execute_status_change(CompleteTaskUseCase, task_id)
 
-    def pause_task(self, task_id: int) -> TaskOperationOutput:
+    def pause_task(self, task_id: int) -> StatusChangeOutput:
         """Pause a task.
 
         Changes task status to PENDING and clears actual start/end times.
@@ -111,7 +112,7 @@ class TaskLifecycleController(BaseTaskController):
             task_id: ID of the task to pause
 
         Returns:
-            TaskOperationOutput containing the updated task information
+            StatusChangeOutput containing the updated task and old status
 
         Raises:
             TaskNotFoundException: If task not found
@@ -119,7 +120,7 @@ class TaskLifecycleController(BaseTaskController):
         """
         return self._execute_status_change(PauseTaskUseCase, task_id)
 
-    def cancel_task(self, task_id: int) -> TaskOperationOutput:
+    def cancel_task(self, task_id: int) -> StatusChangeOutput:
         """Cancel a task.
 
         Changes task status to CANCELED and records actual end time.
@@ -128,7 +129,7 @@ class TaskLifecycleController(BaseTaskController):
             task_id: ID of the task to cancel
 
         Returns:
-            TaskOperationOutput containing the updated task information
+            StatusChangeOutput containing the updated task and old status
 
         Raises:
             TaskNotFoundException: If task not found
@@ -136,7 +137,7 @@ class TaskLifecycleController(BaseTaskController):
         """
         return self._execute_status_change(CancelTaskUseCase, task_id)
 
-    def reopen_task(self, task_id: int) -> TaskOperationOutput:
+    def reopen_task(self, task_id: int) -> StatusChangeOutput:
         """Reopen a task.
 
         Changes task status to PENDING and clears actual start/end times.
@@ -145,7 +146,7 @@ class TaskLifecycleController(BaseTaskController):
             task_id: ID of the task to reopen
 
         Returns:
-            TaskOperationOutput containing the updated task information
+            StatusChangeOutput containing the updated task and old status
 
         Raises:
             TaskNotFoundException: If task not found

--- a/packages/taskdog-core/tests/application/use_cases/status_change_test_base.py
+++ b/packages/taskdog-core/tests/application/use_cases/status_change_test_base.py
@@ -61,7 +61,19 @@ class BaseStatusChangeUseCaseTest:
         input_dto = self.request_class(task_id=task.id)
         result = self.use_case.execute(input_dto)
 
-        assert result.status == self.target_status
+        assert result.task.status == self.target_status
+
+    def test_execute_returns_old_status(self):
+        """Test execute returns the old status before the change."""
+        kwargs = {"name": "Test Task", "priority": 1, "status": self.initial_status}
+        if self.initial_status == TaskStatus.IN_PROGRESS:
+            kwargs["actual_start"] = datetime(2024, 1, 1, 10, 0, 0)
+        task = self.repository.create(**kwargs)
+
+        input_dto = self.request_class(task_id=task.id)
+        result = self.use_case.execute(input_dto)
+
+        assert result.old_status == self.initial_status
 
     def test_execute_handles_timestamps_correctly(self):
         """Test execute handles actual_start/actual_end timestamps correctly."""
@@ -74,13 +86,13 @@ class BaseStatusChangeUseCaseTest:
         result = self.use_case.execute(input_dto)
 
         if self.sets_actual_start:
-            assert result.actual_start is not None
+            assert result.task.actual_start is not None
         if self.sets_actual_end:
-            assert result.actual_end is not None
+            assert result.task.actual_end is not None
         if self.clears_actual_start:
-            assert result.actual_start is None
+            assert result.task.actual_start is None
         if self.clears_actual_end:
-            assert result.actual_end is None
+            assert result.task.actual_end is None
 
     def test_execute_persists_changes(self):
         """Test execute saves changes to repository."""

--- a/packages/taskdog-core/tests/application/use_cases/test_cancel_task_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_cancel_task_use_case.py
@@ -30,9 +30,9 @@ class TestCancelTaskUseCase(BaseStatusChangeUseCaseTest):
         input_dto = SingleTaskInput(task_id=task.id)
         result = self.use_case.execute(input_dto)
 
-        assert result.status == TaskStatus.CANCELED
-        assert result.actual_end is not None
-        assert result.actual_start is None
+        assert result.task.status == TaskStatus.CANCELED
+        assert result.task.actual_end is not None
+        assert result.task.actual_start is None
 
     def test_execute_can_cancel_in_progress_task(self):
         """Test execute can cancel IN_PROGRESS task."""
@@ -46,6 +46,6 @@ class TestCancelTaskUseCase(BaseStatusChangeUseCaseTest):
         input_dto = SingleTaskInput(task_id=task.id)
         result = self.use_case.execute(input_dto)
 
-        assert result.status == TaskStatus.CANCELED
-        assert result.actual_start is not None
-        assert result.actual_end is not None
+        assert result.task.status == TaskStatus.CANCELED
+        assert result.task.actual_start is not None
+        assert result.task.actual_end is not None

--- a/packages/taskdog-core/tests/application/use_cases/test_complete_task_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_complete_task_use_case.py
@@ -38,7 +38,7 @@ class TestCompleteTaskUseCase(BaseStatusChangeUseCaseTest):
         result = self.use_case.execute(input_dto)
 
         # actual_start should remain unchanged
-        assert result.actual_start == datetime(2025, 10, 12, 10, 0, 0)
+        assert result.task.actual_start == datetime(2025, 10, 12, 10, 0, 0)
 
     def test_execute_with_pending_task_raises_error(self):
         """Test execute with PENDING task raises TaskNotStartedError."""

--- a/packages/taskdog-core/tests/application/use_cases/test_pause_task_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_pause_task_use_case.py
@@ -34,7 +34,7 @@ class TestPauseTaskUseCase(BaseStatusChangeUseCaseTest):
         input_dto = SingleTaskInput(task_id=task.id)
         result = self.use_case.execute(input_dto)
 
-        assert result.actual_start is None
+        assert result.task.actual_start is None
 
     def test_execute_clears_actual_end_time(self):
         """Test execute clears actual end timestamp if present."""
@@ -50,7 +50,7 @@ class TestPauseTaskUseCase(BaseStatusChangeUseCaseTest):
         input_dto = SingleTaskInput(task_id=task.id)
         result = self.use_case.execute(input_dto)
 
-        assert result.actual_end is None
+        assert result.task.actual_end is None
 
     def test_execute_with_pending_task_is_idempotent(self):
         """Test execute works correctly when task is already PENDING."""
@@ -61,9 +61,9 @@ class TestPauseTaskUseCase(BaseStatusChangeUseCaseTest):
         input_dto = SingleTaskInput(task_id=task.id)
         result = self.use_case.execute(input_dto)
 
-        assert result.status == TaskStatus.PENDING
-        assert result.actual_start is None
-        assert result.actual_end is None
+        assert result.task.status == TaskStatus.PENDING
+        assert result.task.actual_start is None
+        assert result.task.actual_end is None
 
     def test_execute_does_not_modify_finished_task_state(self):
         """Override: PauseTask raises error for finished tasks, so this test is not applicable."""

--- a/packages/taskdog-core/tests/application/use_cases/test_reopen_task_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_reopen_task_use_case.py
@@ -49,9 +49,9 @@ class TestReopenTaskUseCase:
         input_dto = SingleTaskInput(task_id=task.id)
         result = self.use_case.execute(input_dto)
 
-        assert result.status == TaskStatus.PENDING
-        assert result.actual_start is None
-        assert result.actual_end is None
+        assert result.task.status == TaskStatus.PENDING
+        assert result.task.actual_start is None
+        assert result.task.actual_end is None
 
     def test_execute_persists_changes(self):
         """Test execute saves changes to repository."""
@@ -124,7 +124,7 @@ class TestReopenTaskUseCase:
         result = self.use_case.execute(input_dto)
 
         # Should succeed even though dependency is not completed
-        assert result.status == TaskStatus.PENDING
+        assert result.task.status == TaskStatus.PENDING
 
     def test_execute_with_missing_dependency_succeeds(self):
         """Test that reopen succeeds even with missing dependencies."""
@@ -140,7 +140,7 @@ class TestReopenTaskUseCase:
         result = self.use_case.execute(input_dto)
 
         # Should succeed even though dependency doesn't exist
-        assert result.status == TaskStatus.PENDING
+        assert result.task.status == TaskStatus.PENDING
 
     def test_execute_with_no_dependencies_succeeds(self):
         """Test execute with no dependencies succeeds."""
@@ -151,4 +151,4 @@ class TestReopenTaskUseCase:
         input_dto = SingleTaskInput(task_id=task.id)
         result = self.use_case.execute(input_dto)
 
-        assert result.status == TaskStatus.PENDING
+        assert result.task.status == TaskStatus.PENDING

--- a/packages/taskdog-core/tests/application/use_cases/test_start_task_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_start_task_use_case.py
@@ -31,7 +31,7 @@ class TestStartTaskUseCase(BaseStatusChangeUseCaseTest):
         input_dto = SingleTaskInput(task_id=task.id)
         result = self.use_case.execute(input_dto)
 
-        assert result.actual_end is None
+        assert result.task.actual_end is None
 
     def test_execute_with_in_progress_task_raises_error(self):
         """Test that starting an already IN_PROGRESS task raises TaskAlreadyInProgressError."""
@@ -56,5 +56,5 @@ class TestStartTaskUseCase(BaseStatusChangeUseCaseTest):
         input_dto = SingleTaskInput(task_id=task.id)
         result = self.use_case.execute(input_dto)
 
-        assert result.status == TaskStatus.IN_PROGRESS
-        assert result.actual_start is not None
+        assert result.task.status == TaskStatus.IN_PROGRESS
+        assert result.task.actual_start is not None

--- a/packages/taskdog-core/tests/controllers/test_task_lifecycle_controller.py
+++ b/packages/taskdog-core/tests/controllers/test_task_lifecycle_controller.py
@@ -68,10 +68,10 @@ class TestTaskLifecycleController:
             ),
         ],
     )
-    def test_lifecycle_operation_returns_task_operation_output(
+    def test_lifecycle_operation_returns_status_change_output(
         self, operation_name, method_name, initial_status, actual_start, actual_end
     ):
-        """Test that lifecycle operations return TaskOperationOutput."""
+        """Test that lifecycle operations return StatusChangeOutput."""
         # Arrange
         task_id = 1
         task = Task(
@@ -91,8 +91,9 @@ class TestTaskLifecycleController:
 
         # Assert
         assert result is not None
-        assert result.id == task_id
-        assert result.name == "Test Task"
+        assert result.task.id == task_id
+        assert result.task.name == "Test Task"
+        assert result.old_status == initial_status
 
     def test_controller_inherits_from_base_controller(self):
         """Test that controller has repository and config from base class."""

--- a/packages/taskdog-server/src/taskdog_server/api/routers/lifecycle.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/lifecycle.py
@@ -23,21 +23,16 @@ class LifecycleOperation:
     """Configuration for a lifecycle endpoint."""
 
     name: str
-    old_status: str
     description: str
     returns: str
 
 
 OPERATIONS = [
-    LifecycleOperation("start", "PENDING", "Start a task", "actual_start timestamp"),
-    LifecycleOperation(
-        "complete", "IN_PROGRESS", "Complete a task", "actual_end timestamp"
-    ),
-    LifecycleOperation("pause", "IN_PROGRESS", "Pause a task", "cleared timestamps"),
-    LifecycleOperation(
-        "cancel", "IN_PROGRESS", "Cancel a task", "actual_end timestamp"
-    ),
-    LifecycleOperation("reopen", "COMPLETED", "Reopen a task", "cleared timestamps"),
+    LifecycleOperation("start", "Start a task", "actual_start timestamp"),
+    LifecycleOperation("complete", "Complete a task", "actual_end timestamp"),
+    LifecycleOperation("pause", "Pause a task", "cleared timestamps"),
+    LifecycleOperation("cancel", "Cancel a task", "actual_end timestamp"),
+    LifecycleOperation("reopen", "Reopen a task", "cleared timestamps"),
 ]
 
 
@@ -59,21 +54,23 @@ def _create_lifecycle_endpoint(op: LifecycleOperation) -> None:
     ) -> TaskOperationResponse:
         controller_method = getattr(controller, f"{op.name}_task")
         result = controller_method(task_id)
-        broadcaster.task_status_changed(result, op.old_status, client_name)
+        broadcaster.task_status_changed(
+            result.task, result.old_status.value, client_name
+        )
 
         # Audit log
         audit_controller.log_operation(
             operation=f"{op.name}_task",
             resource_type="task",
             resource_id=task_id,
-            resource_name=result.name,
+            resource_name=result.task.name,
             client_name=client_name,
-            old_values={"status": op.old_status},
-            new_values={"status": result.status.value},
+            old_values={"status": result.old_status.value},
+            new_values={"status": result.task.status.value},
             success=True,
         )
 
-        return TaskOperationResponse.from_dto(result)
+        return TaskOperationResponse.from_dto(result.task)
 
 
 # Generate all lifecycle endpoints


### PR DESCRIPTION
## Summary

- Introduce `StatusChangeOutput` DTO that wraps `TaskOperationOutput` with `old_status: TaskStatus`, allowing callers to know the pre-change status without hardcoding it
- Update `StatusChangeUseCase.execute()` to record `old_status` before any mutation and return `StatusChangeOutput`
- Update `TaskLifecycleController` (5 status-change methods) to propagate `StatusChangeOutput`
- Remove hardcoded `old_status` from lifecycle router's `LifecycleOperation` dataclass; use `result.old_status.value` instead

## Motivation

The lifecycle router was hardcoding `old_status` values (e.g., start → `"PENDING"`, cancel → `"IN_PROGRESS"`), which embeds domain knowledge in the presentation layer. This is incorrect for operations like `cancel` which can apply to multiple statuses (PENDING or IN_PROGRESS), and would become a larger problem with bulk APIs.

## Test plan

- [x] `make test-core` — 1101 passed
- [x] `make test-server` — 291 passed
- [x] `make lint` — passed
- [x] `make typecheck` — passed
- [x] No breaking changes to HTTP response format (server tests unchanged)