### PR TITLE
fix(server,ui): replace per-task WebSocket events with single bulk_operation_completed event

### DIFF
--- a/packages/taskdog-server/src/taskdog_server/api/routers/bulk.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/bulk.py
@@ -91,10 +91,6 @@ def _execute_bulk_lifecycle(
             controller_method = getattr(controller, method_name)
             result = controller_method(task_id)
 
-            broadcaster.task_status_changed(
-                result.task, result.old_status.value, client_name
-            )
-
             audit_controller.log_operation(
                 operation=f"{operation_name}_task",
                 resource_type="task",
@@ -122,6 +118,16 @@ def _execute_bulk_lifecycle(
                 )
             )
 
+    success_ids = [r.task_id for r in results if r.success]
+    failure_count = sum(1 for r in results if not r.success)
+    broadcaster.bulk_operation_completed(
+        operation=operation_name,
+        success_count=len(success_ids),
+        failure_count=failure_count,
+        task_ids=task_ids,
+        source_user_name=client_name,
+    )
+
     return BulkOperationResponse(results=results)
 
 
@@ -141,7 +147,6 @@ def _execute_bulk_crud(
         try:
             if operation_name == "archive":
                 result = controller.archive_task(task_id)
-                broadcaster.task_updated(result, ["is_archived"], client_name)
                 audit_controller.log_operation(
                     operation="archive_task",
                     resource_type="task",
@@ -162,7 +167,6 @@ def _execute_bulk_crud(
 
             elif operation_name == "restore":
                 result = controller.restore_task(task_id)
-                broadcaster.task_updated(result, ["is_archived"], client_name)
                 audit_controller.log_operation(
                     operation="restore_task",
                     resource_type="task",
@@ -187,7 +191,6 @@ def _execute_bulk_crud(
                     raise TaskNotFoundException(f"Task {task_id} not found")
                 task_name = task_output.task.name
                 controller.remove_task(task_id)
-                broadcaster.task_deleted(task_id, task_name, client_name)
                 audit_controller.log_operation(
                     operation="delete_task",
                     resource_type="task",
@@ -214,6 +217,16 @@ def _execute_bulk_crud(
                     error=str(e),
                 )
             )
+
+    success_ids = [r.task_id for r in results if r.success]
+    failure_count = sum(1 for r in results if not r.success)
+    broadcaster.bulk_operation_completed(
+        operation=operation_name,
+        success_count=len(success_ids),
+        failure_count=failure_count,
+        task_ids=task_ids,
+        source_user_name=client_name,
+    )
 
     return BulkOperationResponse(results=results)
 

--- a/packages/taskdog-server/src/taskdog_server/websocket/broadcaster.py
+++ b/packages/taskdog-server/src/taskdog_server/websocket/broadcaster.py
@@ -153,6 +153,31 @@ class WebSocketEventBroadcaster:
         }
         self._schedule_broadcast("schedule_optimized", payload, source_user_name)
 
+    def bulk_operation_completed(
+        self,
+        operation: str,
+        success_count: int,
+        failure_count: int,
+        task_ids: list[int],
+        source_user_name: str | None = None,
+    ) -> None:
+        """Schedule a bulk operation completed broadcast.
+
+        Args:
+            operation: The bulk operation name (e.g., "start", "archive")
+            success_count: Number of successfully processed tasks
+            failure_count: Number of failed tasks
+            task_ids: List of all task IDs in the bulk operation
+            source_user_name: User name who triggered the event (for payload info)
+        """
+        payload = {
+            "operation": operation,
+            "success_count": success_count,
+            "failure_count": failure_count,
+            "task_ids": task_ids,
+        }
+        self._schedule_broadcast("bulk_operation_completed", payload, source_user_name)
+
     def _schedule_broadcast(
         self,
         event_type: str,

--- a/packages/taskdog-server/tests/websocket/test_event_broadcaster.py
+++ b/packages/taskdog-server/tests/websocket/test_event_broadcaster.py
@@ -269,6 +269,49 @@ class TestWebSocketEventBroadcaster:
         call_args = self.mock_background_tasks.add_task.call_args
         assert call_args[0][2]["algorithm"] == algorithm
 
+    def test_bulk_operation_completed_schedules_broadcast(self):
+        """Test bulk_operation_completed schedules background task."""
+        # Arrange
+        task_ids = [1, 2, 3]
+        source_user_name = "test-client"
+
+        # Act
+        self.broadcaster.bulk_operation_completed(
+            operation="start",
+            success_count=2,
+            failure_count=1,
+            task_ids=task_ids,
+            source_user_name=source_user_name,
+        )
+
+        # Assert
+        self.mock_background_tasks.add_task.assert_called_once()
+        call_args = self.mock_background_tasks.add_task.call_args
+        assert call_args[0][0] == self.broadcaster._broadcast
+        assert call_args[0][1] == "bulk_operation_completed"
+        assert call_args[0][2] == {
+            "operation": "start",
+            "success_count": 2,
+            "failure_count": 1,
+            "task_ids": [1, 2, 3],
+        }
+        assert call_args[0][3] == "test-client"
+
+    def test_bulk_operation_completed_without_source_user(self):
+        """Test bulk_operation_completed with no source user."""
+        # Act
+        self.broadcaster.bulk_operation_completed(
+            operation="archive",
+            success_count=3,
+            failure_count=0,
+            task_ids=[1, 2, 3],
+        )
+
+        # Assert
+        self.mock_background_tasks.add_task.assert_called_once()
+        call_args = self.mock_background_tasks.add_task.call_args
+        assert call_args[0][3] is None
+
     def test_multiple_broadcasts_in_sequence(self):
         """Test multiple broadcast calls are scheduled correctly."""
         # Arrange

--- a/packages/taskdog-ui/src/taskdog/tui/services/event_handler_registry.py
+++ b/packages/taskdog-ui/src/taskdog/tui/services/event_handler_registry.py
@@ -36,6 +36,9 @@ class EventHandlerRegistry:
         self._handlers["task_deleted"] = self._handle_task_deleted
         self._handlers["task_status_changed"] = self._handle_task_status_changed
         self._handlers["schedule_optimized"] = self._handle_schedule_optimized
+        self._handlers["bulk_operation_completed"] = (
+            self._handle_bulk_operation_completed
+        )
 
     def dispatch(self, message: dict[str, Any]) -> None:
         """Dispatch event to registered handler.
@@ -134,6 +137,19 @@ class EventHandlerRegistry:
             algorithm, scheduled_count, failed_count
         )
         self.app.notify(msg, severity="information")
+
+    def _handle_bulk_operation_completed(self, message: dict[str, Any]) -> None:
+        """Handle bulk operation completed event."""
+        self._reload_tasks()
+        operation = message.get("operation", "unknown")
+        success_count = message.get("success_count", 0)
+        failure_count = message.get("failure_count", 0)
+        total = success_count + failure_count
+        msg = f"Bulk {operation}: {success_count}/{total} succeeded"
+        if failure_count > 0:
+            self.app.notify(msg, severity="warning")
+        else:
+            self.app.notify(msg, severity="information")
 
     def _reload_tasks(self) -> None:
         """Reload tasks via TaskUIManager."""

--- a/packages/taskdog-ui/tests/tui/services/test_event_handler_registry.py
+++ b/packages/taskdog-ui/tests/tui/services/test_event_handler_registry.py
@@ -34,6 +34,7 @@ class TestEventHandlerRegistry:
             "task_deleted",
             "task_status_changed",
             "schedule_optimized",
+            "bulk_operation_completed",
         ]
         for event_type in expected_handlers:
             assert event_type in self.registry._handlers
@@ -244,6 +245,47 @@ class TestEventHandlerRegistry:
         }
         self.registry.dispatch(message)
         self.mock_app.notify.assert_called_once()
+
+    def test_dispatch_bulk_operation_completed_all_success(self) -> None:
+        """Test bulk_operation_completed with all tasks succeeding."""
+        message = {
+            "type": "bulk_operation_completed",
+            "operation": "start",
+            "success_count": 3,
+            "failure_count": 0,
+            "task_ids": [1, 2, 3],
+        }
+        self.registry.dispatch(message)
+        self.mock_app.call_later.assert_called_once()
+        self.mock_app.notify.assert_called_once()
+        call_args = self.mock_app.notify.call_args
+        assert "3/3" in call_args[0][0]
+        assert call_args.kwargs.get("severity") == "information"
+
+    def test_dispatch_bulk_operation_completed_with_failures(self) -> None:
+        """Test bulk_operation_completed with some failures shows warning."""
+        message = {
+            "type": "bulk_operation_completed",
+            "operation": "archive",
+            "success_count": 2,
+            "failure_count": 1,
+            "task_ids": [1, 2, 3],
+        }
+        self.registry.dispatch(message)
+        self.mock_app.call_later.assert_called_once()
+        self.mock_app.notify.assert_called_once()
+        call_args = self.mock_app.notify.call_args
+        assert "2/3" in call_args[0][0]
+        assert call_args.kwargs.get("severity") == "warning"
+
+    def test_dispatch_bulk_operation_completed_defaults(self) -> None:
+        """Test bulk_operation_completed with missing fields uses defaults."""
+        message = {"type": "bulk_operation_completed"}
+        self.registry.dispatch(message)
+        self.mock_app.notify.assert_called_once()
+        call_args = self.mock_app.notify.call_args
+        assert "0/0" in call_args[0][0]
+        assert "unknown" in call_args[0][0]
 
     def test_reload_tasks_called_with_keep_scroll_position(self) -> None:
         """Test that reload_tasks is called with keep_scroll_position=True."""


### PR DESCRIPTION
## Summary

- Replace N individual WebSocket broadcasts (one per task) during bulk operations with a single `bulk_operation_completed` event sent after the loop completes
- Add `bulk_operation_completed` handler in TUI's `EventHandlerRegistry` to reload tasks once and show a summary notification
- Fixes duplicate task list reloads (N+1 GET requests) when performing bulk operations from the TUI

## Test plan

- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] `make test` passes (all packages)
- [ ] Manual: run TUI, bulk start/complete/archive multiple tasks, verify single reload and summary notification
- [ ] Manual: verify non-bulk single-task operations still send individual WebSocket events as before