### PR TITLE
refactor(core,server): move bulk operation logic to core layer

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/dto/bulk_operation_output.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/bulk_operation_output.py
@@ -13,6 +13,8 @@ class BulkTaskResultOutput:
     success: bool
     task: TaskOperationOutput | None
     error: str | None
+    old_status: str | None = None
+    task_name: str | None = None
 
 
 @dataclass

--- a/packages/taskdog-core/src/taskdog_core/controllers/__init__.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/__init__.py
@@ -1,6 +1,7 @@
 """Controllers package for shared business logic orchestration."""
 
 from taskdog_core.controllers.audit_log_controller import AuditLogController
+from taskdog_core.controllers.bulk_task_controller import BulkTaskController
 from taskdog_core.controllers.query_controller import QueryController
 
-__all__ = ["AuditLogController", "QueryController"]
+__all__ = ["AuditLogController", "BulkTaskController", "QueryController"]

--- a/packages/taskdog-core/src/taskdog_core/controllers/bulk_task_controller.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/bulk_task_controller.py
@@ -1,0 +1,177 @@
+"""Bulk task controller for batch operations.
+
+Moves loop + error handling logic from the server layer into core,
+keeping audit logging and WebSocket broadcasting in the server layer.
+"""
+
+from taskdog_core.application.dto.bulk_operation_output import (
+    BulkOperationOutput,
+    BulkTaskResultOutput,
+)
+from taskdog_core.controllers.query_controller import QueryController
+from taskdog_core.controllers.task_crud_controller import TaskCrudController
+from taskdog_core.controllers.task_lifecycle_controller import TaskLifecycleController
+from taskdog_core.domain.exceptions.task_exceptions import (
+    TaskAlreadyFinishedError,
+    TaskNotFoundException,
+    TaskNotStartedError,
+    TaskValidationError,
+)
+
+_TASK_ERRORS = (
+    TaskNotFoundException,
+    TaskValidationError,
+    TaskAlreadyFinishedError,
+    TaskNotStartedError,
+)
+
+_LIFECYCLE_OPERATIONS = frozenset({"start", "complete", "pause", "cancel", "reopen"})
+
+
+class BulkTaskController:
+    """Controller for batch task operations.
+
+    Encapsulates the loop + per-task error handling for bulk operations.
+    Returns core DTOs; the server layer is responsible for audit logging
+    and WebSocket broadcasting.
+    """
+
+    def __init__(
+        self,
+        lifecycle_controller: TaskLifecycleController,
+        crud_controller: TaskCrudController,
+        query_controller: QueryController,
+    ) -> None:
+        self._lifecycle = lifecycle_controller
+        self._crud = crud_controller
+        self._query = query_controller
+
+    def bulk_lifecycle(
+        self, task_ids: list[int], operation: str
+    ) -> BulkOperationOutput:
+        """Execute a lifecycle operation on multiple tasks.
+
+        Args:
+            task_ids: IDs of tasks to operate on.
+            operation: One of start, complete, pause, cancel, reopen.
+
+        Returns:
+            BulkOperationOutput with per-task results.
+
+        Raises:
+            ValueError: If operation is not a valid lifecycle operation.
+        """
+        if operation not in _LIFECYCLE_OPERATIONS:
+            raise ValueError(f"Invalid lifecycle operation: {operation}")
+
+        method_name = f"{operation}_task"
+        controller_method = getattr(self._lifecycle, method_name)
+
+        results: list[BulkTaskResultOutput] = []
+        for task_id in task_ids:
+            try:
+                result = controller_method(task_id)
+                results.append(
+                    BulkTaskResultOutput(
+                        task_id=task_id,
+                        success=True,
+                        task=result.task,
+                        error=None,
+                        old_status=result.old_status.value,
+                    )
+                )
+            except _TASK_ERRORS as e:
+                results.append(
+                    BulkTaskResultOutput(
+                        task_id=task_id,
+                        success=False,
+                        task=None,
+                        error=str(e),
+                    )
+                )
+
+        return BulkOperationOutput(results=results)
+
+    def bulk_archive(self, task_ids: list[int]) -> BulkOperationOutput:
+        """Archive multiple tasks (soft delete)."""
+        results: list[BulkTaskResultOutput] = []
+        for task_id in task_ids:
+            try:
+                result = self._crud.archive_task(task_id)
+                results.append(
+                    BulkTaskResultOutput(
+                        task_id=task_id,
+                        success=True,
+                        task=result,
+                        error=None,
+                    )
+                )
+            except _TASK_ERRORS as e:
+                results.append(
+                    BulkTaskResultOutput(
+                        task_id=task_id,
+                        success=False,
+                        task=None,
+                        error=str(e),
+                    )
+                )
+        return BulkOperationOutput(results=results)
+
+    def bulk_restore(self, task_ids: list[int]) -> BulkOperationOutput:
+        """Restore multiple archived tasks."""
+        results: list[BulkTaskResultOutput] = []
+        for task_id in task_ids:
+            try:
+                result = self._crud.restore_task(task_id)
+                results.append(
+                    BulkTaskResultOutput(
+                        task_id=task_id,
+                        success=True,
+                        task=result,
+                        error=None,
+                    )
+                )
+            except _TASK_ERRORS as e:
+                results.append(
+                    BulkTaskResultOutput(
+                        task_id=task_id,
+                        success=False,
+                        task=None,
+                        error=str(e),
+                    )
+                )
+        return BulkOperationOutput(results=results)
+
+    def bulk_delete(self, task_ids: list[int]) -> BulkOperationOutput:
+        """Hard delete multiple tasks.
+
+        Looks up the task name before deletion so callers can use it
+        for audit logging.
+        """
+        results: list[BulkTaskResultOutput] = []
+        for task_id in task_ids:
+            try:
+                task_output = self._query.get_task_by_id(task_id)
+                if task_output is None or task_output.task is None:
+                    raise TaskNotFoundException(f"Task {task_id} not found")
+                name = task_output.task.name
+                self._crud.remove_task(task_id)
+                results.append(
+                    BulkTaskResultOutput(
+                        task_id=task_id,
+                        success=True,
+                        task=None,
+                        error=None,
+                        task_name=name,
+                    )
+                )
+            except _TASK_ERRORS as e:
+                results.append(
+                    BulkTaskResultOutput(
+                        task_id=task_id,
+                        success=False,
+                        task=None,
+                        error=str(e),
+                    )
+                )
+        return BulkOperationOutput(results=results)

--- a/packages/taskdog-core/tests/controllers/test_bulk_task_controller.py
+++ b/packages/taskdog-core/tests/controllers/test_bulk_task_controller.py
@@ -1,0 +1,183 @@
+"""Tests for BulkTaskController."""
+
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from taskdog_core.application.dto.status_change_output import StatusChangeOutput
+from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
+from taskdog_core.controllers.bulk_task_controller import BulkTaskController
+from taskdog_core.controllers.query_controller import QueryController
+from taskdog_core.controllers.task_crud_controller import TaskCrudController
+from taskdog_core.controllers.task_lifecycle_controller import TaskLifecycleController
+from taskdog_core.domain.entities.task import Task, TaskStatus
+from taskdog_core.domain.exceptions.task_exceptions import TaskNotFoundException
+
+
+def _make_task_output(task_id=1, name="Task", status=TaskStatus.IN_PROGRESS):
+    task = Task(id=task_id, name=name, priority=1, status=status)
+    return TaskOperationOutput.from_task(task)
+
+
+def _make_status_change_output(
+    task_id=1,
+    name="Task",
+    old_status=TaskStatus.PENDING,
+    new_status=TaskStatus.IN_PROGRESS,
+):
+    task_output = _make_task_output(task_id=task_id, name=name, status=new_status)
+    return StatusChangeOutput(task=task_output, old_status=old_status)
+
+
+class TestBulkTaskController:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.lifecycle = Mock(spec=TaskLifecycleController)
+        self.crud = Mock(spec=TaskCrudController)
+        self.query = Mock(spec=QueryController)
+        self.controller = BulkTaskController(self.lifecycle, self.crud, self.query)
+
+    # ── bulk_lifecycle ──────────────────────────────────────────────
+
+    def test_bulk_lifecycle_all_success(self):
+        self.lifecycle.start_task.side_effect = [
+            _make_status_change_output(task_id=1),
+            _make_status_change_output(task_id=2),
+        ]
+
+        output = self.controller.bulk_lifecycle([1, 2], "start")
+
+        assert len(output.results) == 2
+        assert all(r.success for r in output.results)
+        assert all(r.task is not None for r in output.results)
+
+    def test_bulk_lifecycle_all_failure(self):
+        self.lifecycle.start_task.side_effect = TaskNotFoundException("not found")
+
+        output = self.controller.bulk_lifecycle([1, 2], "start")
+
+        assert len(output.results) == 2
+        assert all(not r.success for r in output.results)
+        assert all(r.error is not None for r in output.results)
+        assert all(r.task is None for r in output.results)
+
+    def test_bulk_lifecycle_mixed(self):
+        self.lifecycle.start_task.side_effect = [
+            _make_status_change_output(task_id=1),
+            TaskNotFoundException("not found"),
+        ]
+
+        output = self.controller.bulk_lifecycle([1, 2], "start")
+
+        assert len(output.results) == 2
+        assert output.results[0].success is True
+        assert output.results[1].success is False
+
+    def test_bulk_lifecycle_invalid_operation_raises_value_error(self):
+        with pytest.raises(ValueError, match="Invalid lifecycle operation"):
+            self.controller.bulk_lifecycle([1], "invalid_op")
+
+    def test_bulk_lifecycle_old_status_stored(self):
+        self.lifecycle.complete_task.return_value = _make_status_change_output(
+            task_id=1,
+            old_status=TaskStatus.IN_PROGRESS,
+            new_status=TaskStatus.COMPLETED,
+        )
+
+        output = self.controller.bulk_lifecycle([1], "complete")
+
+        assert output.results[0].old_status == "IN_PROGRESS"
+
+    @pytest.mark.parametrize(
+        "operation", ["start", "complete", "pause", "cancel", "reopen"]
+    )
+    def test_bulk_lifecycle_all_operations_accepted(self, operation):
+        method = getattr(self.lifecycle, f"{operation}_task")
+        method.return_value = _make_status_change_output(task_id=1)
+
+        output = self.controller.bulk_lifecycle([1], operation)
+
+        assert len(output.results) == 1
+        assert output.results[0].success is True
+
+    # ── bulk_archive ────────────────────────────────────────────────
+
+    def test_bulk_archive_all_success(self):
+        self.crud.archive_task.side_effect = [
+            _make_task_output(task_id=1),
+            _make_task_output(task_id=2),
+        ]
+
+        output = self.controller.bulk_archive([1, 2])
+
+        assert len(output.results) == 2
+        assert all(r.success for r in output.results)
+
+    def test_bulk_archive_mixed(self):
+        self.crud.archive_task.side_effect = [
+            _make_task_output(task_id=1),
+            TaskNotFoundException("not found"),
+        ]
+
+        output = self.controller.bulk_archive([1, 2])
+
+        assert output.results[0].success is True
+        assert output.results[1].success is False
+
+    # ── bulk_restore ────────────────────────────────────────────────
+
+    def test_bulk_restore_all_success(self):
+        self.crud.restore_task.side_effect = [
+            _make_task_output(task_id=1),
+            _make_task_output(task_id=2),
+        ]
+
+        output = self.controller.bulk_restore([1, 2])
+
+        assert len(output.results) == 2
+        assert all(r.success for r in output.results)
+
+    def test_bulk_restore_failure(self):
+        self.crud.restore_task.side_effect = TaskNotFoundException("not found")
+
+        output = self.controller.bulk_restore([1])
+
+        assert output.results[0].success is False
+
+    # ── bulk_delete ─────────────────────────────────────────────────
+
+    def test_bulk_delete_looks_up_task_name(self):
+        task_detail = MagicMock()
+        task_detail.task.name = "To Delete"
+        self.query.get_task_by_id.return_value = task_detail
+
+        output = self.controller.bulk_delete([1])
+
+        assert output.results[0].success is True
+        assert output.results[0].task is None
+        assert output.results[0].task_name == "To Delete"
+        self.query.get_task_by_id.assert_called_once_with(1)
+        self.crud.remove_task.assert_called_once_with(1)
+
+    def test_bulk_delete_nonexistent_task(self):
+        task_detail = MagicMock()
+        task_detail.task = None
+        self.query.get_task_by_id.return_value = task_detail
+
+        output = self.controller.bulk_delete([99])
+
+        assert output.results[0].success is False
+        assert "not found" in output.results[0].error.lower()
+
+    def test_bulk_delete_mixed(self):
+        task_detail = MagicMock()
+        task_detail.task.name = "OK"
+        self.query.get_task_by_id.side_effect = [
+            task_detail,
+            TaskNotFoundException("not found"),
+        ]
+
+        output = self.controller.bulk_delete([1, 2])
+
+        assert output.results[0].success is True
+        assert output.results[1].success is False

--- a/packages/taskdog-server/src/taskdog_server/api/context.py
+++ b/packages/taskdog-server/src/taskdog_server/api/context.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from sqlalchemy.engine import Engine
 
 from taskdog_core.controllers.audit_log_controller import AuditLogController
+from taskdog_core.controllers.bulk_task_controller import BulkTaskController
 from taskdog_core.controllers.query_controller import QueryController
 from taskdog_core.controllers.task_analytics_controller import TaskAnalyticsController
 from taskdog_core.controllers.task_crud_controller import TaskCrudController
@@ -49,6 +50,7 @@ class ApiContext:
     holiday_checker: IHolidayChecker | None
     time_provider: ITimeProvider
     audit_log_controller: AuditLogController
+    bulk_controller: BulkTaskController | None = None
     engine: Engine | None = field(default=None, repr=False)
 
     def close(self) -> None:

--- a/packages/taskdog-server/src/taskdog_server/api/dependencies.py
+++ b/packages/taskdog-server/src/taskdog_server/api/dependencies.py
@@ -8,6 +8,7 @@ from fastapi import BackgroundTasks, Depends, HTTPException, Request, WebSocket
 from fastapi.security import APIKeyHeader
 
 from taskdog_core.controllers.audit_log_controller import AuditLogController
+from taskdog_core.controllers.bulk_task_controller import BulkTaskController
 from taskdog_core.controllers.query_controller import QueryController
 from taskdog_core.controllers.task_analytics_controller import TaskAnalyticsController
 from taskdog_core.controllers.task_crud_controller import TaskCrudController
@@ -137,6 +138,10 @@ def initialize_api_context(
         audit_log_repository, audit_log_logger, time_provider
     )
 
+    bulk_controller = BulkTaskController(
+        lifecycle_controller, crud_controller, query_controller
+    )
+
     return ApiContext(
         repository=repository,
         config=config,
@@ -149,6 +154,7 @@ def initialize_api_context(
         holiday_checker=holiday_checker,
         time_provider=time_provider,
         audit_log_controller=audit_log_controller,
+        bulk_controller=bulk_controller,
         engine=engine,
     )
 
@@ -230,6 +236,13 @@ def get_audit_log_controller(context: ApiContextDep) -> AuditLogController:
     return context.audit_log_controller
 
 
+def get_bulk_controller(context: ApiContextDep) -> BulkTaskController:
+    """Get bulk task controller from context."""
+    if context.bulk_controller is None:
+        raise RuntimeError("BulkTaskController not initialized in ApiContext.")
+    return context.bulk_controller
+
+
 def get_connection_manager(request: Request) -> ConnectionManager:
     """Get the ConnectionManager instance from app.state for HTTP endpoints.
 
@@ -291,6 +304,7 @@ NotesRepositoryDep = Annotated[NotesRepository, Depends(get_notes_repository)]
 HolidayCheckerDep = Annotated[IHolidayChecker | None, Depends(get_holiday_checker)]
 TimeProviderDep = Annotated[ITimeProvider, Depends(get_time_provider)]
 AuditLogControllerDep = Annotated[AuditLogController, Depends(get_audit_log_controller)]
+BulkTaskControllerDep = Annotated[BulkTaskController, Depends(get_bulk_controller)]
 ConnectionManagerDep = Annotated[ConnectionManager, Depends(get_connection_manager)]
 ConnectionManagerWsDep = Annotated[
     ConnectionManager, Depends(get_connection_manager_ws)

--- a/packages/taskdog-server/src/taskdog_server/api/routers/bulk.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/bulk.py
@@ -4,23 +4,12 @@ from dataclasses import dataclass
 
 from fastapi import APIRouter
 
-from taskdog_core.controllers.audit_log_controller import AuditLogController
-from taskdog_core.controllers.query_controller import QueryController
-from taskdog_core.controllers.task_crud_controller import TaskCrudController
-from taskdog_core.controllers.task_lifecycle_controller import TaskLifecycleController
-from taskdog_core.domain.exceptions.task_exceptions import (
-    TaskAlreadyFinishedError,
-    TaskNotFoundException,
-    TaskNotStartedError,
-    TaskValidationError,
-)
+from taskdog_core.application.dto.bulk_operation_output import BulkOperationOutput
 from taskdog_server.api.dependencies import (
     AuditLogControllerDep,
     AuthenticatedClientDep,
-    CrudControllerDep,
+    BulkTaskControllerDep,
     EventBroadcasterDep,
-    LifecycleControllerDep,
-    QueryControllerDep,
 )
 from taskdog_server.api.models.requests import BulkTaskIdsRequest
 from taskdog_server.api.models.responses import (
@@ -31,13 +20,6 @@ from taskdog_server.api.models.responses import (
 from taskdog_server.websocket.broadcaster import WebSocketEventBroadcaster
 
 router = APIRouter()
-
-_TASK_ERRORS = (
-    TaskNotFoundException,
-    TaskValidationError,
-    TaskAlreadyFinishedError,
-    TaskNotStartedError,
-)
 
 
 @dataclass(frozen=True)
@@ -54,6 +36,7 @@ class BulkCrudOperation:
 
     name: str
     description: str
+    audit_operation: str
 
 
 LIFECYCLE_OPERATIONS = [
@@ -65,170 +48,44 @@ LIFECYCLE_OPERATIONS = [
 ]
 
 CRUD_OPERATIONS = [
-    BulkCrudOperation("archive", "Archive multiple tasks"),
-    BulkCrudOperation("restore", "Restore multiple tasks"),
-    BulkCrudOperation("delete", "Delete multiple tasks permanently"),
+    BulkCrudOperation("archive", "Archive multiple tasks", "archive_task"),
+    BulkCrudOperation("restore", "Restore multiple tasks", "restore_task"),
+    BulkCrudOperation("delete", "Delete multiple tasks permanently", "delete_task"),
 ]
 
 
-def _execute_bulk_lifecycle(
-    task_ids: list[int],
-    operation_name: str,
-    controller: TaskLifecycleController,
+def _to_response(output: BulkOperationOutput) -> BulkOperationResponse:
+    """Convert core DTO to Pydantic response model."""
+    return BulkOperationResponse(
+        results=[
+            BulkTaskResult(
+                task_id=r.task_id,
+                success=r.success,
+                task=TaskOperationResponse.from_dto(r.task) if r.task else None,
+                error=r.error,
+            )
+            for r in output.results
+        ]
+    )
+
+
+def _broadcast(
     broadcaster: WebSocketEventBroadcaster,
-    audit_controller: AuditLogController,
+    operation: str,
+    output: BulkOperationOutput,
+    task_ids: list[int],
     client_name: str | None,
-) -> BulkOperationResponse:
-    """Execute a lifecycle operation on multiple tasks."""
-    results: list[BulkTaskResult] = []
-
-    method_name = f"{operation_name}_task"
-    if not hasattr(controller, method_name):
-        raise ValueError(f"Invalid lifecycle operation: {operation_name}")
-
-    for task_id in task_ids:
-        try:
-            controller_method = getattr(controller, method_name)
-            result = controller_method(task_id)
-
-            audit_controller.log_operation(
-                operation=f"{operation_name}_task",
-                resource_type="task",
-                resource_id=task_id,
-                resource_name=result.task.name,
-                client_name=client_name,
-                old_values={"status": result.old_status.value},
-                new_values={"status": result.task.status.value},
-                success=True,
-            )
-
-            results.append(
-                BulkTaskResult(
-                    task_id=task_id,
-                    success=True,
-                    task=TaskOperationResponse.from_dto(result.task),
-                )
-            )
-        except _TASK_ERRORS as e:
-            results.append(
-                BulkTaskResult(
-                    task_id=task_id,
-                    success=False,
-                    error=str(e),
-                )
-            )
-
-    success_ids = [r.task_id for r in results if r.success]
-    failure_count = sum(1 for r in results if not r.success)
+) -> None:
+    """Send a single bulk_operation_completed WebSocket event."""
+    success_count = sum(1 for r in output.results if r.success)
+    failure_count = sum(1 for r in output.results if not r.success)
     broadcaster.bulk_operation_completed(
-        operation=operation_name,
-        success_count=len(success_ids),
+        operation=operation,
+        success_count=success_count,
         failure_count=failure_count,
         task_ids=task_ids,
         source_user_name=client_name,
     )
-
-    return BulkOperationResponse(results=results)
-
-
-def _execute_bulk_crud(
-    task_ids: list[int],
-    operation_name: str,
-    controller: TaskCrudController,
-    query_controller: QueryController,
-    broadcaster: WebSocketEventBroadcaster,
-    audit_controller: AuditLogController,
-    client_name: str | None,
-) -> BulkOperationResponse:
-    """Execute a CRUD operation (archive/restore/delete) on multiple tasks."""
-    results: list[BulkTaskResult] = []
-
-    for task_id in task_ids:
-        try:
-            if operation_name == "archive":
-                result = controller.archive_task(task_id)
-                audit_controller.log_operation(
-                    operation="archive_task",
-                    resource_type="task",
-                    resource_id=task_id,
-                    resource_name=result.name,
-                    client_name=client_name,
-                    old_values={"is_archived": False},
-                    new_values={"is_archived": True},
-                    success=True,
-                )
-                results.append(
-                    BulkTaskResult(
-                        task_id=task_id,
-                        success=True,
-                        task=TaskOperationResponse.from_dto(result),
-                    )
-                )
-
-            elif operation_name == "restore":
-                result = controller.restore_task(task_id)
-                audit_controller.log_operation(
-                    operation="restore_task",
-                    resource_type="task",
-                    resource_id=task_id,
-                    resource_name=result.name,
-                    client_name=client_name,
-                    old_values={"is_archived": True},
-                    new_values={"is_archived": False},
-                    success=True,
-                )
-                results.append(
-                    BulkTaskResult(
-                        task_id=task_id,
-                        success=True,
-                        task=TaskOperationResponse.from_dto(result),
-                    )
-                )
-
-            elif operation_name == "delete":
-                task_output = query_controller.get_task_by_id(task_id)
-                if task_output is None or task_output.task is None:
-                    raise TaskNotFoundException(f"Task {task_id} not found")
-                task_name = task_output.task.name
-                controller.remove_task(task_id)
-                audit_controller.log_operation(
-                    operation="delete_task",
-                    resource_type="task",
-                    resource_id=task_id,
-                    resource_name=task_name,
-                    client_name=client_name,
-                    success=True,
-                )
-                results.append(
-                    BulkTaskResult(
-                        task_id=task_id,
-                        success=True,
-                    )
-                )
-
-            else:
-                raise ValueError(f"Invalid CRUD operation: {operation_name}")
-
-        except _TASK_ERRORS as e:
-            results.append(
-                BulkTaskResult(
-                    task_id=task_id,
-                    success=False,
-                    error=str(e),
-                )
-            )
-
-    success_ids = [r.task_id for r in results if r.success]
-    failure_count = sum(1 for r in results if not r.success)
-    broadcaster.bulk_operation_completed(
-        operation=operation_name,
-        success_count=len(success_ids),
-        failure_count=failure_count,
-        task_ids=task_ids,
-        source_user_name=client_name,
-    )
-
-    return BulkOperationResponse(results=results)
 
 
 def _create_bulk_lifecycle_endpoint(op: BulkLifecycleOperation) -> None:
@@ -241,19 +98,28 @@ def _create_bulk_lifecycle_endpoint(op: BulkLifecycleOperation) -> None:
     )
     async def endpoint(
         request: BulkTaskIdsRequest,
-        controller: LifecycleControllerDep,
+        bulk_controller: BulkTaskControllerDep,
         broadcaster: EventBroadcasterDep,
         audit_controller: AuditLogControllerDep,
         client_name: AuthenticatedClientDep,
     ) -> BulkOperationResponse:
-        return _execute_bulk_lifecycle(
-            request.task_ids,
-            op.name,
-            controller,
-            broadcaster,
-            audit_controller,
-            client_name,
-        )
+        output = bulk_controller.bulk_lifecycle(request.task_ids, op.name)
+
+        for r in output.results:
+            if r.success and r.task is not None:
+                audit_controller.log_operation(
+                    operation=f"{op.name}_task",
+                    resource_type="task",
+                    resource_id=r.task_id,
+                    resource_name=r.task.name,
+                    client_name=client_name,
+                    old_values={"status": r.old_status} if r.old_status else None,
+                    new_values={"status": r.task.status.value},
+                    success=True,
+                )
+
+        _broadcast(broadcaster, op.name, output, request.task_ids, client_name)
+        return _to_response(output)
 
 
 def _create_bulk_crud_endpoint(op: BulkCrudOperation) -> None:
@@ -266,21 +132,38 @@ def _create_bulk_crud_endpoint(op: BulkCrudOperation) -> None:
     )
     async def endpoint(
         request: BulkTaskIdsRequest,
-        controller: CrudControllerDep,
-        query_controller: QueryControllerDep,
+        bulk_controller: BulkTaskControllerDep,
         broadcaster: EventBroadcasterDep,
         audit_controller: AuditLogControllerDep,
         client_name: AuthenticatedClientDep,
     ) -> BulkOperationResponse:
-        return _execute_bulk_crud(
-            request.task_ids,
-            op.name,
-            controller,
-            query_controller,
-            broadcaster,
-            audit_controller,
-            client_name,
-        )
+        method = getattr(bulk_controller, f"bulk_{op.name}")
+        output: BulkOperationOutput = method(request.task_ids)
+
+        for r in output.results:
+            if r.success:
+                resource_name = r.task.name if r.task else r.task_name
+                old_values = None
+                new_values = None
+                if op.name == "archive":
+                    old_values = {"is_archived": False}
+                    new_values = {"is_archived": True}
+                elif op.name == "restore":
+                    old_values = {"is_archived": True}
+                    new_values = {"is_archived": False}
+                audit_controller.log_operation(
+                    operation=op.audit_operation,
+                    resource_type="task",
+                    resource_id=r.task_id,
+                    resource_name=resource_name,
+                    client_name=client_name,
+                    old_values=old_values,
+                    new_values=new_values,
+                    success=True,
+                )
+
+        _broadcast(broadcaster, op.name, output, request.task_ids, client_name)
+        return _to_response(output)
 
 
 # Generate all bulk endpoints

--- a/packages/taskdog-server/tests/conftest.py
+++ b/packages/taskdog-server/tests/conftest.py
@@ -37,6 +37,9 @@ from fixtures.repositories import InMemoryTaskRepository  # noqa: E402
 from taskdog_core.controllers.audit_log_controller import (  # noqa: E402
     AuditLogController,
 )
+from taskdog_core.controllers.bulk_task_controller import (  # noqa: E402
+    BulkTaskController,
+)
 from taskdog_core.controllers.query_controller import QueryController  # noqa: E402
 from taskdog_core.controllers.task_analytics_controller import (  # noqa: E402
     TaskAnalyticsController,
@@ -226,6 +229,9 @@ def app(
     audit_log_controller = AuditLogController(
         session_audit_log_repository, mock_logger, SystemTimeProvider()
     )
+    bulk_controller = BulkTaskController(
+        lifecycle_controller, crud_controller, query_controller
+    )
 
     # Create API context once
     api_context = ApiContext(
@@ -240,6 +246,7 @@ def app(
         holiday_checker=None,
         time_provider=SystemTimeProvider(),
         audit_log_controller=audit_log_controller,
+        bulk_controller=bulk_controller,
     )
 
     # Create FastAPI app once with all routers


### PR DESCRIPTION
## Summary

- Move bulk operation loop + error handling from server `bulk.py` into a new `BulkTaskController` in the core layer, following Clean Architecture principles
- Server `bulk.py` is now a thin wrapper that delegates to core and handles only audit logging + WebSocket broadcasting
- Add `old_status` and `task_name` fields to `BulkTaskResultOutput` DTO for audit logging support

## Changes

**Core layer (taskdog-core):**
- New `BulkTaskController` with `bulk_lifecycle()`, `bulk_archive()`, `bulk_restore()`, `bulk_delete()`
- `BulkTaskResultOutput` gains `old_status` (for lifecycle audit) and `task_name` (for delete audit)
- 17 unit tests covering all success/failure/mixed scenarios

**Server layer (taskdog-server):**
- `bulk.py` simplified: removed `_execute_bulk_lifecycle` and `_execute_bulk_crud`, replaced with core controller delegation
- DI wiring: `BulkTaskControllerDep` added to dependencies, `bulk_controller` field added to `ApiContext`
- Test conftest updated with `BulkTaskController` initialization

## Test plan

- [x] `make test-core` — 1118 passed
- [x] `make test-server` — 309 passed
- [x] `make check` — lint + typecheck all pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)