### PR TITLE
refactor(client): deduplicate lifecycle_operation into BaseApiClient

### DIFF
--- a/packages/taskdog-client/src/taskdog_client/base_client.py
+++ b/packages/taskdog-client/src/taskdog_client/base_client.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
+
 import httpx  # type: ignore[import-not-found]
 
 from taskdog_core.domain.exceptions.task_exceptions import (
@@ -118,6 +120,28 @@ class BaseApiClient:
                 detail = response.json().get("detail", detail)
             raise ServerError(response.status_code, detail)
         response.raise_for_status()
+
+    def lifecycle_operation(self, task_id: int, operation: str) -> TaskOperationOutput:
+        """Execute a lifecycle operation on a task.
+
+        Generic helper for lifecycle operations (start, complete, pause, etc.)
+        that follow the same pattern: POST to /api/v1/tasks/{id}/{operation}.
+
+        Args:
+            task_id: Task ID
+            operation: Operation name (e.g., "start", "complete", "archive")
+
+        Returns:
+            TaskOperationOutput with updated task data
+
+        Raises:
+            TaskNotFoundException: If task not found
+            TaskValidationError: If validation fails
+        """
+        from taskdog_client.converters import convert_to_task_operation_output
+
+        data = self._request_json("post", f"/api/v1/tasks/{task_id}/{operation}")
+        return convert_to_task_operation_output(data)
 
     def _request_json(self, method: str, *args: Any, **kwargs: Any) -> Any:
         """Execute HTTP request and return JSON response, handling errors.

--- a/packages/taskdog-client/src/taskdog_client/lifecycle_client.py
+++ b/packages/taskdog-client/src/taskdog_client/lifecycle_client.py
@@ -12,7 +12,6 @@ class LifecycleClient:
 
     Operations:
     - Start, complete, pause, cancel, reopen tasks
-    - Generic lifecycle operation helper
     """
 
     def __init__(self, base_client: BaseApiClient):
@@ -22,26 +21,6 @@ class LifecycleClient:
             base_client: Base API client for HTTP operations
         """
         self._base = base_client
-
-    def _lifecycle_operation(self, task_id: int, operation: str) -> TaskOperationOutput:
-        """Execute a lifecycle operation on a task.
-
-        Generic helper for lifecycle operations (start, complete, pause, cancel, reopen)
-        that follow the same pattern.
-
-        Args:
-            task_id: Task ID
-            operation: Operation name (e.g., "start", "complete", "pause")
-
-        Returns:
-            TaskOperationOutput with updated task data
-
-        Raises:
-            TaskNotFoundException: If task not found
-            TaskValidationError: If validation fails
-        """
-        data = self._base._request_json("post", f"/api/v1/tasks/{task_id}/{operation}")
-        return convert_to_task_operation_output(data)
 
     def start_task(self, task_id: int) -> TaskOperationOutput:
         """Start a task.
@@ -56,7 +35,7 @@ class LifecycleClient:
             TaskNotFoundException: If task not found
             TaskValidationError: If validation fails
         """
-        return self._lifecycle_operation(task_id, "start")
+        return self._base.lifecycle_operation(task_id, "start")
 
     def complete_task(self, task_id: int) -> TaskOperationOutput:
         """Complete a task.
@@ -71,7 +50,7 @@ class LifecycleClient:
             TaskNotFoundException: If task not found
             TaskValidationError: If validation fails
         """
-        return self._lifecycle_operation(task_id, "complete")
+        return self._base.lifecycle_operation(task_id, "complete")
 
     def pause_task(self, task_id: int) -> TaskOperationOutput:
         """Pause a task.
@@ -86,7 +65,7 @@ class LifecycleClient:
             TaskNotFoundException: If task not found
             TaskValidationError: If validation fails
         """
-        return self._lifecycle_operation(task_id, "pause")
+        return self._base.lifecycle_operation(task_id, "pause")
 
     def cancel_task(self, task_id: int) -> TaskOperationOutput:
         """Cancel a task.
@@ -101,7 +80,7 @@ class LifecycleClient:
             TaskNotFoundException: If task not found
             TaskValidationError: If validation fails
         """
-        return self._lifecycle_operation(task_id, "cancel")
+        return self._base.lifecycle_operation(task_id, "cancel")
 
     def reopen_task(self, task_id: int) -> TaskOperationOutput:
         """Reopen a task.
@@ -116,7 +95,7 @@ class LifecycleClient:
             TaskNotFoundException: If task not found
             TaskValidationError: If validation fails
         """
-        return self._lifecycle_operation(task_id, "reopen")
+        return self._base.lifecycle_operation(task_id, "reopen")
 
     def fix_actual_times(
         self,

--- a/packages/taskdog-client/src/taskdog_client/task_client.py
+++ b/packages/taskdog-client/src/taskdog_client/task_client.py
@@ -172,26 +172,6 @@ class TaskClient:
         )
         return convert_to_update_task_output(data)
 
-    def _lifecycle_operation(self, task_id: int, operation: str) -> TaskOperationOutput:
-        """Execute a lifecycle operation on a task.
-
-        Generic helper for lifecycle operations (archive, restore)
-        that follow the same pattern.
-
-        Args:
-            task_id: Task ID
-            operation: Operation name (e.g., "archive", "restore")
-
-        Returns:
-            TaskOperationOutput with updated task data
-
-        Raises:
-            TaskNotFoundException: If task not found
-            TaskValidationError: If validation fails
-        """
-        data = self._base._request_json("post", f"/api/v1/tasks/{task_id}/{operation}")
-        return convert_to_task_operation_output(data)
-
     def archive_task(self, task_id: int) -> TaskOperationOutput:
         """Archive (soft delete) a task.
 
@@ -204,7 +184,7 @@ class TaskClient:
         Raises:
             TaskNotFoundException: If task not found
         """
-        return self._lifecycle_operation(task_id, "archive")
+        return self._base.lifecycle_operation(task_id, "archive")
 
     def restore_task(self, task_id: int) -> TaskOperationOutput:
         """Restore an archived task.
@@ -219,7 +199,7 @@ class TaskClient:
             TaskNotFoundException: If task not found
             TaskValidationError: If not archived
         """
-        return self._lifecycle_operation(task_id, "restore")
+        return self._base.lifecycle_operation(task_id, "restore")
 
     def remove_task(self, task_id: int) -> None:
         """Permanently delete a task.

--- a/packages/taskdog-client/tests/test_lifecycle_client.py
+++ b/packages/taskdog-client/tests/test_lifecycle_client.py
@@ -1,6 +1,6 @@
 """Tests for LifecycleClient."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 from taskdog_client.lifecycle_client import LifecycleClient
@@ -16,38 +16,36 @@ class TestLifecycleClient:
         self.client = LifecycleClient(self.mock_base)
 
     @pytest.mark.parametrize(
-        "method_name,expected_endpoint",
+        "method_name,expected_operation",
         [
-            ("start_task", "/api/v1/tasks/1/start"),
-            ("complete_task", "/api/v1/tasks/1/complete"),
-            ("pause_task", "/api/v1/tasks/1/pause"),
-            ("cancel_task", "/api/v1/tasks/1/cancel"),
-            ("reopen_task", "/api/v1/tasks/1/reopen"),
+            ("start_task", "start"),
+            ("complete_task", "complete"),
+            ("pause_task", "pause"),
+            ("cancel_task", "cancel"),
+            ("reopen_task", "reopen"),
         ],
         ids=["start_task", "complete_task", "pause_task", "cancel_task", "reopen_task"],
     )
-    @patch("taskdog_client.lifecycle_client.convert_to_task_operation_output")
-    def test_lifecycle_operation_makes_correct_api_call(
-        self, mock_convert, method_name, expected_endpoint
+    def test_lifecycle_operation_delegates_to_base(
+        self, method_name, expected_operation
     ):
-        """Test lifecycle operations make correct API calls."""
-        self.mock_base._request_json.return_value = {"id": 1}
-
+        """Test lifecycle operations delegate to base client."""
         mock_output = Mock()
-        mock_convert.return_value = mock_output
+        self.mock_base.lifecycle_operation.return_value = mock_output
 
         method = getattr(self.client, method_name)
         result = method(task_id=1)
 
-        self.mock_base._request_json.assert_called_once_with("post", expected_endpoint)
+        self.mock_base.lifecycle_operation.assert_called_once_with(
+            1, expected_operation
+        )
         assert result == mock_output
 
-    @patch("taskdog_client.lifecycle_client.convert_to_task_operation_output")
-    def test_lifecycle_operation_error_handling(self, mock_convert):
-        """Test lifecycle operations propagate errors from _request_json."""
+    def test_lifecycle_operation_error_handling(self):
+        """Test lifecycle operations propagate errors from base client."""
         from taskdog_core.domain.exceptions.task_exceptions import TaskNotFoundException
 
-        self.mock_base._request_json.side_effect = TaskNotFoundException(
+        self.mock_base.lifecycle_operation.side_effect = TaskNotFoundException(
             "Task not found"
         )
 

--- a/packages/taskdog-client/tests/test_task_client.py
+++ b/packages/taskdog-client/tests/test_task_client.py
@@ -118,27 +118,24 @@ class TestTaskClient:
         assert result == mock_output
 
     @pytest.mark.parametrize(
-        "method_name,expected_endpoint",
+        "method_name,expected_operation",
         [
-            ("archive_task", "/api/v1/tasks/1/archive"),
-            ("restore_task", "/api/v1/tasks/1/restore"),
+            ("archive_task", "archive"),
+            ("restore_task", "restore"),
         ],
         ids=["archive_task", "restore_task"],
     )
-    @patch("taskdog_client.task_client.convert_to_task_operation_output")
-    def test_archive_restore_operations(
-        self, mock_convert, method_name, expected_endpoint
-    ):
-        """Test archive/restore operations make correct API calls."""
-        self.mock_base._request_json.return_value = {"id": 1}
-
+    def test_archive_restore_operations(self, method_name, expected_operation):
+        """Test archive/restore operations delegate to base client."""
         mock_output = Mock()
-        mock_convert.return_value = mock_output
+        self.mock_base.lifecycle_operation.return_value = mock_output
 
         method = getattr(self.client, method_name)
         result = method(task_id=1)
 
-        self.mock_base._request_json.assert_called_once_with("post", expected_endpoint)
+        self.mock_base.lifecycle_operation.assert_called_once_with(
+            1, expected_operation
+        )
         assert result == mock_output
 
     def test_remove_task(self):


### PR DESCRIPTION
## Summary

- Move the duplicated `_lifecycle_operation` method from `TaskClient` and `LifecycleClient` into `BaseApiClient` as a shared `lifecycle_operation` method
- Both `TaskClient` (archive/restore) and `LifecycleClient` (start/complete/pause/cancel/reopen) now delegate to `BaseApiClient.lifecycle_operation()`
- Update tests to verify delegation instead of mocking internal HTTP calls

## Test plan

- [x] All 237 client package tests pass
- [x] Full test suite passes (`make test`)
- [x] Lint passes (`make lint`)
- [x] Type check passes (`make typecheck`)