### PR TITLE
refactor(ui): use individual API for single-task TUI operations

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/commands/batch_command_base.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/batch_command_base.py
@@ -9,12 +9,15 @@ from abc import abstractmethod
 from taskdog.tui.commands.base import TUICommandBase
 from taskdog.tui.dialogs.confirmation_dialog import ConfirmationDialog
 from taskdog_core.application.dto.bulk_operation_output import BulkOperationOutput
+from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 
 
 class BatchCommandBase(TUICommandBase):
     """Template for batch task commands with optional confirmation.
 
     Subclasses implement execute_bulk() for the actual operation.
+    For single-task operations, override execute_single() to use individual API
+    endpoints for better WebSocket notification granularity.
     Override get_confirmation_config() to require confirmation before execution.
     """
 
@@ -25,6 +28,14 @@ class BatchCommandBase(TUICommandBase):
         Args:
             task_ids: IDs of tasks to operate on
         """
+
+    def execute_single(self, task_id: int) -> TaskOperationOutput:
+        """Execute operation on a single task via individual API.
+
+        Override this in subclasses that have individual API endpoints.
+        Default implementation falls back to execute_bulk.
+        """
+        raise NotImplementedError
 
     def get_confirmation_config(self) -> tuple[str, str, str] | None:
         """Return confirmation dialog config, or None to skip confirmation.
@@ -90,7 +101,21 @@ class BatchCommandBase(TUICommandBase):
             self._show_summary(success_count, failure_count)
 
     def _process_tasks(self, task_ids: list[int]) -> tuple[int, int]:
-        """Process tasks and return (success_count, failure_count)."""
+        """Process tasks and return (success_count, failure_count).
+
+        Uses individual API for single-task operations when execute_single
+        is implemented, falling back to bulk API otherwise.
+        """
+        if len(task_ids) == 1:
+            try:
+                self.execute_single(task_ids[0])
+                return 1, 0
+            except NotImplementedError:
+                pass
+            except Exception as e:
+                self.notify_error(f"Task {task_ids[0]}", e)
+                return 0, 1
+
         result = self.execute_bulk(task_ids)
         success_count = 0
         failure_count = 0

--- a/packages/taskdog-ui/src/taskdog/tui/commands/cancel.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/cancel.py
@@ -2,6 +2,7 @@
 
 from taskdog.tui.commands.batch_command_base import BatchCommandBase
 from taskdog_core.application.dto.bulk_operation_output import BulkOperationOutput
+from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 
 
 class CancelCommand(BatchCommandBase):
@@ -14,6 +15,9 @@ class CancelCommand(BatchCommandBase):
             "Are you sure you want to cancel this task?",
             "Are you sure you want to cancel {count} tasks?",
         )
+
+    def execute_single(self, task_id: int) -> TaskOperationOutput:
+        return self.context.api_client.cancel_task(task_id)
 
     def execute_bulk(self, task_ids: list[int]) -> BulkOperationOutput:
         """Cancel tasks via Bulk API."""

--- a/packages/taskdog-ui/src/taskdog/tui/commands/done.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/done.py
@@ -2,10 +2,14 @@
 
 from taskdog.tui.commands.batch_command_base import BatchCommandBase
 from taskdog_core.application.dto.bulk_operation_output import BulkOperationOutput
+from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 
 
 class DoneCommand(BatchCommandBase):
     """Command to complete the selected task(s)."""
+
+    def execute_single(self, task_id: int) -> TaskOperationOutput:
+        return self.context.api_client.complete_task(task_id)
 
     def execute_bulk(self, task_ids: list[int]) -> BulkOperationOutput:
         """Complete tasks via Bulk API."""

--- a/packages/taskdog-ui/src/taskdog/tui/commands/pause.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/pause.py
@@ -2,10 +2,14 @@
 
 from taskdog.tui.commands.batch_command_base import BatchCommandBase
 from taskdog_core.application.dto.bulk_operation_output import BulkOperationOutput
+from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 
 
 class PauseCommand(BatchCommandBase):
     """Command to pause the selected task(s)."""
+
+    def execute_single(self, task_id: int) -> TaskOperationOutput:
+        return self.context.api_client.pause_task(task_id)
 
     def execute_bulk(self, task_ids: list[int]) -> BulkOperationOutput:
         """Pause tasks via Bulk API."""

--- a/packages/taskdog-ui/src/taskdog/tui/commands/reopen.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/reopen.py
@@ -2,6 +2,7 @@
 
 from taskdog.tui.commands.batch_command_base import BatchCommandBase
 from taskdog_core.application.dto.bulk_operation_output import BulkOperationOutput
+from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 
 
 class ReopenCommand(BatchCommandBase):
@@ -14,6 +15,9 @@ class ReopenCommand(BatchCommandBase):
             "Reopen this task?\n\nStatus will be set to: PENDING",
             "Reopen {count} tasks?\n\nAll will be set to: PENDING",
         )
+
+    def execute_single(self, task_id: int) -> TaskOperationOutput:
+        return self.context.api_client.reopen_task(task_id)
 
     def execute_bulk(self, task_ids: list[int]) -> BulkOperationOutput:
         """Reopen tasks via Bulk API."""

--- a/packages/taskdog-ui/src/taskdog/tui/commands/rm.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/rm.py
@@ -2,6 +2,7 @@
 
 from taskdog.tui.commands.batch_command_base import BatchCommandBase
 from taskdog_core.application.dto.bulk_operation_output import BulkOperationOutput
+from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 
 
 class RmCommand(BatchCommandBase):
@@ -18,6 +19,9 @@ class RmCommand(BatchCommandBase):
             "Tasks will be soft-deleted and can be restored later.\n"
             "(Use Shift+X for permanent deletion)",
         )
+
+    def execute_single(self, task_id: int) -> TaskOperationOutput:
+        return self.context.api_client.archive_task(task_id)
 
     def execute_bulk(self, task_ids: list[int]) -> BulkOperationOutput:
         """Archive tasks (soft delete) via Bulk API."""

--- a/packages/taskdog-ui/src/taskdog/tui/commands/start.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/start.py
@@ -2,10 +2,14 @@
 
 from taskdog.tui.commands.batch_command_base import BatchCommandBase
 from taskdog_core.application.dto.bulk_operation_output import BulkOperationOutput
+from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 
 
 class StartCommand(BatchCommandBase):
     """Command to start the selected task(s)."""
+
+    def execute_single(self, task_id: int) -> TaskOperationOutput:
+        return self.context.api_client.start_task(task_id)
 
     def execute_bulk(self, task_ids: list[int]) -> BulkOperationOutput:
         """Start tasks via Bulk API."""

--- a/packages/taskdog-ui/tests/tui/commands/test_batch_command_base.py
+++ b/packages/taskdog-ui/tests/tui/commands/test_batch_command_base.py
@@ -9,6 +9,7 @@ from taskdog_core.application.dto.bulk_operation_output import (
     BulkOperationOutput,
     BulkTaskResultOutput,
 )
+from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 
 
 def _make_bulk_output(
@@ -35,6 +36,18 @@ def _make_bulk_output(
 
 class ConcreteBatchCommand(BatchCommandBase):
     """Concrete implementation without confirmation for testing."""
+
+    def execute_bulk(self, task_ids: list[int]) -> BulkOperationOutput:
+        """Execute bulk operation."""
+        return _make_bulk_output(task_ids)
+
+
+class ConcreteBatchCommandWithSingle(BatchCommandBase):
+    """Concrete implementation with execute_single for testing."""
+
+    def execute_single(self, task_id: int) -> TaskOperationOutput:
+        """Execute single operation."""
+        return MagicMock(spec=TaskOperationOutput)
 
     def execute_bulk(self, task_ids: list[int]) -> BulkOperationOutput:
         """Execute bulk operation."""
@@ -399,6 +412,72 @@ class TestBatchCommandBaseWithConfirmation:
         callback_wrapper(True)
 
         self.command.notify_warning.assert_not_called()
+
+
+class TestBatchCommandBaseSingleTaskApi:
+    """Test cases for single-task API dispatch via execute_single."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self) -> None:
+        """Set up test fixtures."""
+        self.mock_app = MagicMock()
+        self.mock_context = MagicMock()
+        self.command = ConcreteBatchCommandWithSingle(self.mock_app, self.mock_context)
+
+    def test_single_task_uses_execute_single(self) -> None:
+        """Test that single task calls execute_single instead of execute_bulk."""
+        self.command.execute_single = MagicMock(
+            return_value=MagicMock(spec=TaskOperationOutput)
+        )
+        self.command.execute_bulk = MagicMock()
+        self.command.get_selected_task_ids = MagicMock(return_value=[42])
+        self.command.clear_task_selection = MagicMock()
+        self.command.reload_tasks = MagicMock()
+
+        self.command.execute()
+
+        self.command.execute_single.assert_called_once_with(42)
+        self.command.execute_bulk.assert_not_called()
+
+    def test_multiple_tasks_uses_execute_bulk(self) -> None:
+        """Test that multiple tasks still use execute_bulk."""
+        self.command.execute_single = MagicMock()
+        self.command.execute_bulk = MagicMock(return_value=_make_bulk_output([1, 2]))
+        self.command.get_selected_task_ids = MagicMock(return_value=[1, 2])
+        self.command.clear_task_selection = MagicMock()
+        self.command.reload_tasks = MagicMock()
+
+        self.command.execute()
+
+        self.command.execute_single.assert_not_called()
+        self.command.execute_bulk.assert_called_once_with([1, 2])
+
+    def test_single_task_error_notifies(self) -> None:
+        """Test that execute_single errors are properly notified."""
+        self.command.execute_single = MagicMock(
+            side_effect=Exception("Task already started")
+        )
+        self.command.notify_error = MagicMock()
+        self.command.get_selected_task_ids = MagicMock(return_value=[42])
+        self.command.clear_task_selection = MagicMock()
+        self.command.reload_tasks = MagicMock()
+
+        self.command.execute()
+
+        self.command.notify_error.assert_called_once()
+        assert self.command.notify_error.call_args[0][0] == "Task 42"
+
+    def test_fallback_to_bulk_when_execute_single_not_implemented(self) -> None:
+        """Test fallback to execute_bulk when execute_single raises NotImplementedError."""
+        command = ConcreteBatchCommand(self.mock_app, self.mock_context)
+        command.get_selected_task_ids = MagicMock(return_value=[42])
+        command.execute_bulk = MagicMock(return_value=_make_bulk_output([42]))
+        command.clear_task_selection = MagicMock()
+        command.reload_tasks = MagicMock()
+
+        command.execute()
+
+        command.execute_bulk.assert_called_once_with([42])
 
 
 class TestBatchCommandBaseConfirmationConfig:


### PR DESCRIPTION
## Summary

- When a TUI batch command operates on a single task, use the individual API endpoint instead of the bulk API for better WebSocket notification granularity
- Add `execute_single()` to `BatchCommandBase` with `NotImplementedError` fallback to `execute_bulk()`
- Implement `execute_single()` in `StartCommand`, `DoneCommand`, `PauseCommand`, `CancelCommand`, `ReopenCommand`, and `RmCommand`
- `HardDeleteCommand` remains bulk-only (client's `remove_task()` returns `None`, not `TaskOperationOutput`)

## Motivation

Single-task operations via the bulk API produce a single `bulk_operation_completed` WebSocket event, while individual API endpoints produce granular events like `task_status_changed`. The individual events provide better notification display in the TUI for the common case of operating on one task.

## Test plan

- [x] All 28 existing + new tests pass (`test_batch_command_base.py`)
- [x] Lint and typecheck pass (`make check`)
- [x] Manual verification: single-task operations in TUI produce individual WebSocket events

🤖 Generated with [Claude Code](https://claude.com/claude-code)