### PR TITLE
fix(ui): escape square brackets in task names for Rich markup

### DIFF
--- a/packages/taskdog-ui/src/taskdog/presenters/gantt_presenter.py
+++ b/packages/taskdog-ui/src/taskdog/presenters/gantt_presenter.py
@@ -5,6 +5,8 @@ presentation logic (formatting, strikethrough) to create presentation-ready
 view models.
 """
 
+from rich.markup import escape
+
 from taskdog.view_models.gantt_view_model import GanttViewModel, TaskGanttRowViewModel
 from taskdog_core.application.dto.gantt_output import GanttOutput
 from taskdog_core.application.dto.task_dto import GanttTaskDto
@@ -57,9 +59,11 @@ class GanttPresenter:
             TaskGanttRowViewModel with presentation-ready data
         """
         # Apply strikethrough + dim for finished tasks
-        formatted_name = task.name
+        # Escape Rich markup characters (e.g. square brackets) in task names
+        escaped_name = escape(task.name)
+        formatted_name = escaped_name
         if task.is_finished:
-            formatted_name = f"[strike dim]{task.name}[/strike dim]"
+            formatted_name = f"[strike dim]{escaped_name}[/strike dim]"
 
         # Format estimated duration
         formatted_estimated_duration = self._format_estimated_duration(

--- a/packages/taskdog-ui/src/taskdog/presenters/timeline_presenter.py
+++ b/packages/taskdog-ui/src/taskdog/presenters/timeline_presenter.py
@@ -6,6 +6,8 @@ and creates presentation-ready view models for the Timeline chart.
 
 from datetime import date, datetime, time
 
+from rich.markup import escape
+
 from taskdog.constants.timeline import (
     DEFAULT_END_HOUR,
     DEFAULT_START_HOUR,
@@ -133,9 +135,11 @@ class TimelinePresenter:
         is_finished = task_row.is_finished
 
         # Apply strikethrough for finished tasks
-        formatted_name = task_row.name
+        # Escape Rich markup characters (e.g. square brackets) in task names
+        escaped_name = escape(task_row.name)
+        formatted_name = escaped_name
         if is_finished:
-            formatted_name = f"[strike dim]{task_row.name}[/strike dim]"
+            formatted_name = f"[strike dim]{escaped_name}[/strike dim]"
 
         return TimelineTaskRowViewModel(
             task_id=task_row.id,

--- a/packages/taskdog-ui/src/taskdog/renderers/rich_table_renderer.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/rich_table_renderer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar, Literal, cast
 
+from rich.markup import escape
 from rich.table import Table
 
 from taskdog.constants.common import (
@@ -308,9 +309,9 @@ class RichTableRenderer(RichRendererBase):
         field_extractors: dict[str, Callable[[TaskRowViewModel], str]] = {
             "id": lambda t: str(t.id),
             "name": lambda t: (
-                f"[{COLUMN_FINISHED_STYLE}]{t.name}[/{COLUMN_FINISHED_STYLE}]"
+                f"[{COLUMN_FINISHED_STYLE}]{escape(t.name)}[/{COLUMN_FINISHED_STYLE}]"
                 if t.is_finished
-                else t.name
+                else escape(t.name)
             ),
             "note": lambda t: EMOJI_NOTE if t.has_notes else "",
             "priority": lambda t: str(t.priority),

--- a/packages/taskdog-ui/tests/presentation/renderers/test_rich_table_renderer.py
+++ b/packages/taskdog-ui/tests/presentation/renderers/test_rich_table_renderer.py
@@ -145,6 +145,45 @@ class TestRichTableRenderer:
             assert "[strike dim]" not in result
 
     @pytest.mark.parametrize(
+        "name,is_finished,expected",
+        [
+            ("[tracker] Task", False, "\\[tracker] Task"),
+            (
+                "[tracker] Task",
+                True,
+                "[strike dim]\\[tracker] Task[/strike dim]",
+            ),
+        ],
+        ids=["brackets_unfinished", "brackets_finished"],
+    )
+    def test_get_field_value_name_with_square_brackets(
+        self, name, is_finished, expected
+    ):
+        """Test that square brackets in task names are escaped for Rich markup."""
+        task = TaskRowViewModel(
+            id=self.task1.id,
+            name=name,
+            priority=self.task1.priority,
+            status=TaskStatus.COMPLETED if is_finished else self.task1.status,
+            planned_start=self.task1.planned_start,
+            planned_end=self.task1.planned_end,
+            actual_start=self.task1.actual_start,
+            actual_end=self.task1.actual_end,
+            deadline=self.task1.deadline,
+            estimated_duration=self.task1.estimated_duration,
+            actual_duration_hours=self.task1.actual_duration_hours,
+            is_fixed=self.task1.is_fixed,
+            depends_on=self.task1.depends_on,
+            tags=self.task1.tags,
+            is_finished=is_finished,
+            has_notes=self.task1.has_notes,
+            created_at=self.task1.created_at,
+            updated_at=self.task1.updated_at,
+        )
+        result = self.renderer._get_field_value(task, "name")
+        assert result == expected
+
+    @pytest.mark.parametrize(
         "has_notes,expected",
         [
             (True, "📝"),

--- a/packages/taskdog-ui/tests/presenters/test_gantt_presenter.py
+++ b/packages/taskdog-ui/tests/presenters/test_gantt_presenter.py
@@ -80,6 +80,25 @@ class TestGanttPresenter:
         assert result.tasks[0].formatted_name == "[strike dim]Done task[/strike dim]"
         assert result.tasks[0].is_finished is True
 
+    def test_present_task_name_with_square_brackets_not_finished(self):
+        task = self._make_task(name="[tracker] My task", is_finished=False)
+        result = self.presenter.present(self._make_gantt_output([task]))
+
+        assert result.tasks[0].formatted_name == "\\[tracker] My task"
+
+    def test_present_task_name_with_square_brackets_finished(self):
+        task = self._make_task(
+            name="[tracker] Done task",
+            status=TaskStatus.COMPLETED,
+            is_finished=True,
+        )
+        result = self.presenter.present(self._make_gantt_output([task]))
+
+        assert (
+            result.tasks[0].formatted_name
+            == "[strike dim]\\[tracker] Done task[/strike dim]"
+        )
+
     def test_present_estimated_duration_formatted(self):
         task = self._make_task(estimated_duration=4.5)
         result = self.presenter.present(self._make_gantt_output([task]))

--- a/packages/taskdog-ui/tests/presenters/test_timeline_presenter.py
+++ b/packages/taskdog-ui/tests/presenters/test_timeline_presenter.py
@@ -104,6 +104,45 @@ class TestTimelinePresenter:
         assert row.actual_end == time(12, 0)
         assert row.duration_hours == 3.0
 
+    def test_present_task_name_with_square_brackets(self):
+        """Test that square brackets in task names are escaped for Rich markup."""
+        actual_start = datetime(2026, 1, 30, 9, 0, 0)
+        actual_end = datetime(2026, 1, 30, 12, 0, 0)
+        tasks = [
+            self._create_task_row_dto(
+                1,
+                "[tracker] My task",
+                TaskStatus.IN_PROGRESS,
+                actual_start,
+                actual_end,
+            ),
+        ]
+        task_list = self._create_task_list_output(tasks)
+        result = self.presenter.present(task_list, self.target_date)
+
+        assert result.rows[0].formatted_name == "\\[tracker] My task"
+
+    def test_present_task_name_with_square_brackets_finished(self):
+        """Test that square brackets are escaped even with strikethrough."""
+        actual_start = datetime(2026, 1, 30, 9, 0, 0)
+        actual_end = datetime(2026, 1, 30, 12, 0, 0)
+        tasks = [
+            self._create_task_row_dto(
+                1,
+                "[tracker] Done task",
+                TaskStatus.COMPLETED,
+                actual_start,
+                actual_end,
+            ),
+        ]
+        task_list = self._create_task_list_output(tasks)
+        result = self.presenter.present(task_list, self.target_date)
+
+        assert (
+            result.rows[0].formatted_name
+            == "[strike dim]\\[tracker] Done task[/strike dim]"
+        )
+
     def test_present_task_on_different_date(self):
         """Test with a task that has work on a different date."""
         actual_start = datetime(2026, 1, 29, 9, 0, 0)


### PR DESCRIPTION
## Summary
- Fix task names containing square brackets (e.g. `[tracker] Schedule`) being silently stripped because Rich interpreted them as markup tags
- Use `rich.markup.escape()` to escape task names in 3 presenter/renderer files
- Add test cases for task names with square brackets

## Changed files
- `gantt_presenter.py` — Escape task names in Gantt chart
- `timeline_presenter.py` — Escape task names in Timeline
- `rich_table_renderer.py` — Escape task names in Table
- 6 tests added across 3 test files

## Test plan
- [x] `make test-ui` — 939 passed
- [x] `make check` — lint, typecheck, codespell all passed

Closes #802