### PR TITLE
refactor(ui): move Rich markup formatting from Presenters to Renderers

### DIFF
--- a/packages/taskdog-ui/src/taskdog/presenters/gantt_presenter.py
+++ b/packages/taskdog-ui/src/taskdog/presenters/gantt_presenter.py
@@ -5,8 +5,6 @@ presentation logic (formatting, strikethrough) to create presentation-ready
 view models.
 """
 
-from rich.markup import escape
-
 from taskdog.view_models.gantt_view_model import GanttViewModel, TaskGanttRowViewModel
 from taskdog_core.application.dto.gantt_output import GanttOutput
 from taskdog_core.application.dto.task_dto import GanttTaskDto
@@ -49,7 +47,6 @@ class GanttPresenter:
         """Convert a GanttTaskDto to TaskGanttRowViewModel.
 
         Applies presentation logic:
-        - Adds strikethrough to task name if finished
         - Formats estimated duration as string
 
         Args:
@@ -58,13 +55,6 @@ class GanttPresenter:
         Returns:
             TaskGanttRowViewModel with presentation-ready data
         """
-        # Apply strikethrough + dim for finished tasks
-        # Escape Rich markup characters (e.g. square brackets) in task names
-        escaped_name = escape(task.name)
-        formatted_name = escaped_name
-        if task.is_finished:
-            formatted_name = f"[strike dim]{escaped_name}[/strike dim]"
-
         # Format estimated duration
         formatted_estimated_duration = self._format_estimated_duration(
             task.estimated_duration
@@ -72,7 +62,7 @@ class GanttPresenter:
 
         return TaskGanttRowViewModel(
             id=task.id,
-            formatted_name=formatted_name,
+            name=task.name,
             formatted_estimated_duration=formatted_estimated_duration,
             status=task.status,
             planned_start=task.planned_start.date() if task.planned_start else None,

--- a/packages/taskdog-ui/src/taskdog/presenters/timeline_presenter.py
+++ b/packages/taskdog-ui/src/taskdog/presenters/timeline_presenter.py
@@ -6,8 +6,6 @@ and creates presentation-ready view models for the Timeline chart.
 
 from datetime import date, datetime, time
 
-from rich.markup import escape
-
 from taskdog.constants.timeline import (
     DEFAULT_END_HOUR,
     DEFAULT_START_HOUR,
@@ -134,16 +132,9 @@ class TimelinePresenter:
         # Use is_finished from DTO (consistent with other presenters)
         is_finished = task_row.is_finished
 
-        # Apply strikethrough for finished tasks
-        # Escape Rich markup characters (e.g. square brackets) in task names
-        escaped_name = escape(task_row.name)
-        formatted_name = escaped_name
-        if is_finished:
-            formatted_name = f"[strike dim]{escaped_name}[/strike dim]"
-
         return TimelineTaskRowViewModel(
             task_id=task_row.id,
-            formatted_name=formatted_name,
+            name=task_row.name,
             actual_start=start_time,
             actual_end=end_time,
             duration_hours=duration_hours,

--- a/packages/taskdog-ui/src/taskdog/renderers/rich_gantt_renderer.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/rich_gantt_renderer.py
@@ -1,6 +1,7 @@
 from datetime import date, timedelta
 from typing import Any
 
+from rich.markup import escape
 from rich.table import Table
 from rich.text import Text
 
@@ -262,8 +263,13 @@ class RichGanttRenderer(RichRendererBase):
             end_date: End date of the chart
             holidays: Set of holiday dates for styling
         """
-        # Use pre-formatted name (strikethrough already applied by mapper)
-        task_name = task_vm.formatted_name
+        # Apply Rich markup escape and strikethrough for finished tasks
+        escaped_name = escape(task_vm.name)
+        task_name = (
+            f"[strike dim]{escaped_name}[/strike dim]"
+            if task_vm.is_finished
+            else escaped_name
+        )
 
         # Use pre-formatted estimated duration
         estimated_hours = task_vm.formatted_estimated_duration

--- a/packages/taskdog-ui/src/taskdog/renderers/rich_timeline_renderer.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/rich_timeline_renderer.py
@@ -4,6 +4,7 @@ This module renders the Timeline chart as a Rich Table, showing
 actual work times on a horizontal time axis for a specific day.
 """
 
+from rich.markup import escape
 from rich.table import Table
 from rich.text import Text
 
@@ -162,9 +163,17 @@ class RichTimelineRenderer(RichRendererBase):
         # Format duration
         duration_str = TimelineCellFormatter.format_duration(row_vm.duration_hours)
 
+        # Apply Rich markup escape and strikethrough for finished tasks
+        escaped_name = escape(row_vm.name)
+        task_name = (
+            f"[strike dim]{escaped_name}[/strike dim]"
+            if row_vm.is_finished
+            else escaped_name
+        )
+
         table.add_row(
             str(row_vm.task_id),
-            row_vm.formatted_name,
+            task_name,
             timeline_bar,
             duration_str,
         )

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_data_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_data_table.py
@@ -8,6 +8,7 @@ like task selection, date range adjustment, and filtering.
 from datetime import date, timedelta
 from typing import Any, ClassVar
 
+from rich.markup import escape
 from rich.text import Text
 from textual.binding import Binding
 from textual.coordinate import Coordinate
@@ -494,9 +495,14 @@ class GanttDataTable(DataTable):  # type: ignore[type-arg]
         Returns:
             Tuple of (task_id, task_name, estimated_hours)
         """
-        # Use pre-formatted values from ViewModel
+        # Apply Rich markup escape and strikethrough for finished tasks
         task_id = str(task_vm.id)
-        task_name = task_vm.formatted_name
+        escaped_name = escape(task_vm.name)
+        task_name = (
+            f"[strike dim]{escaped_name}[/strike dim]"
+            if task_vm.is_finished
+            else escaped_name
+        )
         est_hours = task_vm.formatted_estimated_duration
 
         return task_id, task_name, est_hours

--- a/packages/taskdog-ui/src/taskdog/view_models/gantt_view_model.py
+++ b/packages/taskdog-ui/src/taskdog/view_models/gantt_view_model.py
@@ -21,7 +21,7 @@ class TaskGanttRowViewModel(BaseViewModel):
 
     Attributes:
         id: Task ID
-        formatted_name: Task name with presentation formatting (strikethrough, etc.)
+        name: Task name (plain text, no formatting applied)
         formatted_estimated_duration: Formatted duration string (e.g., "8.0", "-")
         status: Task status (needed for timeline cell formatting)
         planned_start: Planned start date (None if not set)
@@ -33,7 +33,7 @@ class TaskGanttRowViewModel(BaseViewModel):
     """
 
     id: int
-    formatted_name: str
+    name: str
     formatted_estimated_duration: str
     status: TaskStatus
     planned_start: date | None

--- a/packages/taskdog-ui/src/taskdog/view_models/timeline_view_model.py
+++ b/packages/taskdog-ui/src/taskdog/view_models/timeline_view_model.py
@@ -20,7 +20,7 @@ class TimelineTaskRowViewModel(BaseViewModel):
 
     Attributes:
         task_id: Task ID
-        formatted_name: Task name with presentation formatting (strikethrough, etc.)
+        name: Task name (plain text, no formatting applied)
         actual_start: Actual start time on the target date
         actual_end: Actual end time on the target date
         duration_hours: Work duration in hours for this date
@@ -29,7 +29,7 @@ class TimelineTaskRowViewModel(BaseViewModel):
     """
 
     task_id: int
-    formatted_name: str
+    name: str
     actual_start: time
     actual_end: time
     duration_hours: float

--- a/packages/taskdog-ui/tests/presentation/renderers/test_rich_gantt_renderer.py
+++ b/packages/taskdog-ui/tests/presentation/renderers/test_rich_gantt_renderer.py
@@ -22,7 +22,7 @@ class TestRichGanttRendererBuildTable:
         # Sample task view models
         self.task1 = TaskGanttRowViewModel(
             id=1,
-            formatted_name="Task 1",
+            name="Task 1",
             formatted_estimated_duration="8.0",
             status=TaskStatus.PENDING,
             planned_start=date(2025, 1, 1),
@@ -35,7 +35,7 @@ class TestRichGanttRendererBuildTable:
 
         self.task2 = TaskGanttRowViewModel(
             id=2,
-            formatted_name="[strike dim]Task 2[/strike dim]",
+            name="Task 2",
             formatted_estimated_duration="4.0",
             status=TaskStatus.COMPLETED,
             planned_start=date(2025, 1, 2),
@@ -158,7 +158,7 @@ class TestRichGanttRendererBuildTable:
             tasks=[
                 TaskGanttRowViewModel(
                     id=1,
-                    formatted_name="Task without estimate",
+                    name="Task without estimate",
                     formatted_estimated_duration="-",
                     status=TaskStatus.PENDING,
                     planned_start=date(2025, 1, 1),
@@ -216,7 +216,7 @@ class TestRichGanttRendererRender:
             tasks=[
                 TaskGanttRowViewModel(
                     id=1,
-                    formatted_name="Task 1",
+                    name="Task 1",
                     formatted_estimated_duration="4.0",
                     status=TaskStatus.PENDING,
                     planned_start=date(2025, 1, 1),

--- a/packages/taskdog-ui/tests/presenters/test_gantt_presenter.py
+++ b/packages/taskdog-ui/tests/presenters/test_gantt_presenter.py
@@ -67,9 +67,9 @@ class TestGanttPresenter:
         task = self._make_task(name="My task", is_finished=False)
         result = self.presenter.present(self._make_gantt_output([task]))
 
-        assert result.tasks[0].formatted_name == "My task"
+        assert result.tasks[0].name == "My task"
 
-    def test_present_task_name_finished_has_strikethrough(self):
+    def test_present_task_name_finished_is_plain_text(self):
         task = self._make_task(
             name="Done task",
             status=TaskStatus.COMPLETED,
@@ -77,27 +77,14 @@ class TestGanttPresenter:
         )
         result = self.presenter.present(self._make_gantt_output([task]))
 
-        assert result.tasks[0].formatted_name == "[strike dim]Done task[/strike dim]"
+        assert result.tasks[0].name == "Done task"
         assert result.tasks[0].is_finished is True
 
-    def test_present_task_name_with_square_brackets_not_finished(self):
+    def test_present_task_name_with_square_brackets(self):
         task = self._make_task(name="[tracker] My task", is_finished=False)
         result = self.presenter.present(self._make_gantt_output([task]))
 
-        assert result.tasks[0].formatted_name == "\\[tracker] My task"
-
-    def test_present_task_name_with_square_brackets_finished(self):
-        task = self._make_task(
-            name="[tracker] Done task",
-            status=TaskStatus.COMPLETED,
-            is_finished=True,
-        )
-        result = self.presenter.present(self._make_gantt_output([task]))
-
-        assert (
-            result.tasks[0].formatted_name
-            == "[strike dim]\\[tracker] Done task[/strike dim]"
-        )
+        assert result.tasks[0].name == "[tracker] My task"
 
     def test_present_estimated_duration_formatted(self):
         task = self._make_task(estimated_duration=4.5)

--- a/packages/taskdog-ui/tests/presenters/test_timeline_presenter.py
+++ b/packages/taskdog-ui/tests/presenters/test_timeline_presenter.py
@@ -99,13 +99,13 @@ class TestTimelinePresenter:
 
         row = result.rows[0]
         assert row.task_id == 1
-        assert row.formatted_name == "[strike dim]Task A[/strike dim]"
+        assert row.name == "Task A"
         assert row.actual_start == time(9, 0)
         assert row.actual_end == time(12, 0)
         assert row.duration_hours == 3.0
 
     def test_present_task_name_with_square_brackets(self):
-        """Test that square brackets in task names are escaped for Rich markup."""
+        """Test that square brackets in task names are preserved as plain text."""
         actual_start = datetime(2026, 1, 30, 9, 0, 0)
         actual_end = datetime(2026, 1, 30, 12, 0, 0)
         tasks = [
@@ -120,28 +120,7 @@ class TestTimelinePresenter:
         task_list = self._create_task_list_output(tasks)
         result = self.presenter.present(task_list, self.target_date)
 
-        assert result.rows[0].formatted_name == "\\[tracker] My task"
-
-    def test_present_task_name_with_square_brackets_finished(self):
-        """Test that square brackets are escaped even with strikethrough."""
-        actual_start = datetime(2026, 1, 30, 9, 0, 0)
-        actual_end = datetime(2026, 1, 30, 12, 0, 0)
-        tasks = [
-            self._create_task_row_dto(
-                1,
-                "[tracker] Done task",
-                TaskStatus.COMPLETED,
-                actual_start,
-                actual_end,
-            ),
-        ]
-        task_list = self._create_task_list_output(tasks)
-        result = self.presenter.present(task_list, self.target_date)
-
-        assert (
-            result.rows[0].formatted_name
-            == "[strike dim]\\[tracker] Done task[/strike dim]"
-        )
+        assert result.rows[0].name == "[tracker] My task"
 
     def test_present_task_on_different_date(self):
         """Test with a task that has work on a different date."""
@@ -218,8 +197,8 @@ class TestTimelinePresenter:
         assert result.start_hour == 7
         assert result.end_hour == 20
 
-    def test_present_finished_task_strikethrough(self):
-        """Test that finished tasks have strikethrough formatting."""
+    def test_present_finished_task_preserves_plain_name(self):
+        """Test that finished tasks have plain text name (formatting is Renderer's job)."""
         tasks = [
             self._create_task_row_dto(
                 1,
@@ -240,9 +219,9 @@ class TestTimelinePresenter:
         result = self.presenter.present(task_list, self.target_date)
 
         assert result.rows[0].is_finished is True
-        assert "[strike dim]" in result.rows[0].formatted_name
+        assert result.rows[0].name == "Completed Task"
         assert result.rows[1].is_finished is True
-        assert "[strike dim]" in result.rows[1].formatted_name
+        assert result.rows[1].name == "Canceled Task"
 
     def test_present_total_work_hours(self):
         """Test that total work hours is calculated correctly."""

--- a/packages/taskdog-ui/tests/renderers/test_rich_timeline_renderer.py
+++ b/packages/taskdog-ui/tests/renderers/test_rich_timeline_renderer.py
@@ -34,12 +34,9 @@ class TestRichTimelineRenderer:
         is_finished: bool = True,
     ) -> TimelineTaskRowViewModel:
         """Create a TimelineTaskRowViewModel for testing."""
-        formatted_name = name
-        if is_finished:
-            formatted_name = f"[strike dim]{name}[/strike dim]"
         return TimelineTaskRowViewModel(
             task_id=task_id,
-            formatted_name=formatted_name,
+            name=name,
             actual_start=actual_start,
             actual_end=actual_end,
             duration_hours=duration_hours,

--- a/packages/taskdog-ui/tests/services/test_task_data_loader.py
+++ b/packages/taskdog-ui/tests/services/test_task_data_loader.py
@@ -81,7 +81,7 @@ class TestTaskDataLoader:
 
         gantt_task_vm = TaskGanttRowViewModel(
             id=1,
-            formatted_name="Task 1",
+            name="Task 1",
             formatted_estimated_duration="-",
             status=TaskStatus.PENDING,
             planned_start=None,


### PR DESCRIPTION
## Summary
- Move Rich-specific formatting (escape + strikethrough) from Presenters to Renderers
- Rename `formatted_name` to plain `name` in `TaskGanttRowViewModel` and `TimelineTaskRowViewModel`
- Ensures ViewModels are technology-agnostic and Renderers own all display logic

## Motivation
Gantt/Timeline Presenters were applying `rich.markup.escape()` and strikethrough markup, then storing the result as `formatted_name` in ViewModels. This coupled ViewModels to Rich and left Renderers with nothing to do. Meanwhile, `RichTableRenderer` was already handling formatting correctly at render time. This PR unifies all three to the same pattern.

## Changed files
**ViewModels** — `formatted_name: str` → `name: str`
- `gantt_view_model.py`, `timeline_view_model.py`

**Presenters** — removed escape/strikethrough, now data conversion only
- `gantt_presenter.py`, `timeline_presenter.py`

**Renderers/Widgets** — added escape/strikethrough at render time
- `rich_gantt_renderer.py`, `rich_timeline_renderer.py`, `gantt_data_table.py`

**Tests** — updated 5 test files to match new responsibilities

## Test plan
- [x] `make test-ui` — 937 passed, 70.15% coverage
- [x] `make check` — lint, typecheck, codespell all passed

Refs #715