### PR TITLE
refactor: use individual API for single-task hard delete in TUI

### DIFF
--- a/packages/taskdog-client/src/taskdog_client/task_client.py
+++ b/packages/taskdog-client/src/taskdog_client/task_client.py
@@ -201,15 +201,17 @@ class TaskClient:
         """
         return self._base.lifecycle_operation(task_id, "restore")
 
-    def remove_task(self, task_id: int) -> None:
+    def remove_task(self, task_id: int) -> TaskOperationOutput:
         """Permanently delete a task.
 
         Args:
             task_id: Task ID
 
+        Returns:
+            TaskOperationOutput with deleted task data
+
         Raises:
             TaskNotFoundException: If task not found
         """
-        response = self._base._safe_request("delete", f"/api/v1/tasks/{task_id}")
-        if not response.is_success:
-            self._base._handle_error(response)
+        data = self._base._request_json("delete", f"/api/v1/tasks/{task_id}")
+        return convert_to_task_operation_output(data)

--- a/packages/taskdog-client/src/taskdog_client/taskdog_api_client.py
+++ b/packages/taskdog-client/src/taskdog_client/taskdog_api_client.py
@@ -189,7 +189,7 @@ class TaskdogApiClient:
         """Restore an archived task."""
         return self._tasks.restore_task(task_id)
 
-    def remove_task(self, task_id: int) -> None:
+    def remove_task(self, task_id: int) -> TaskOperationOutput:
         """Permanently delete a task."""
         return self._tasks.remove_task(task_id)
 

--- a/packages/taskdog-client/tests/test_task_client.py
+++ b/packages/taskdog-client/tests/test_task_client.py
@@ -139,23 +139,14 @@ class TestTaskClient:
         assert result == mock_output
 
     def test_remove_task(self):
-        """Test remove_task makes correct API call."""
-        mock_response = Mock()
-        mock_response.is_success = True
-        self.mock_base._safe_request.return_value = mock_response
+        """Test remove_task makes correct API call and returns TaskOperationOutput."""
+        mock_data = {"id": 1, "name": "Task 1", "status": "PENDING", "priority": 50}
+        self.mock_base._request_json.return_value = mock_data
 
-        self.client.remove_task(task_id=1)
+        result = self.client.remove_task(task_id=1)
 
-        self.mock_base._safe_request.assert_called_once_with(
+        self.mock_base._request_json.assert_called_once_with(
             "delete", "/api/v1/tasks/1"
         )
-
-    def test_remove_task_not_found(self):
-        """Test remove_task handles not found error."""
-        mock_response = Mock()
-        mock_response.is_success = False
-        self.mock_base._safe_request.return_value = mock_response
-
-        self.client.remove_task(task_id=999)
-
-        self.mock_base._handle_error.assert_called_once_with(mock_response)
+        assert result.id == 1
+        assert result.name == "Task 1"

--- a/packages/taskdog-core/src/taskdog_core/application/services/optimization/earliest_deadline_optimization_strategy.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/optimization/earliest_deadline_optimization_strategy.py
@@ -24,7 +24,9 @@ class EarliestDeadlineOptimizationStrategy(GreedyBasedOptimizationStrategy):
         """Sort tasks by deadline (earliest first)."""
         return sorted(
             tasks,
-            key=lambda t: t.deadline
-            if t.deadline is not None
-            else datetime(9999, 12, 31, 23, 59, 59),
+            key=lambda t: (
+                t.deadline
+                if t.deadline is not None
+                else datetime(9999, 12, 31, 23, 59, 59)
+            ),
         )

--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/remove_task.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/remove_task.py
@@ -1,12 +1,13 @@
 """Use case for removing a task."""
 
 from taskdog_core.application.dto.base import SingleTaskInput
+from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 from taskdog_core.application.use_cases.base import UseCase
 from taskdog_core.domain.repositories.notes_repository import NotesRepository
 from taskdog_core.domain.repositories.task_repository import TaskRepository
 
 
-class RemoveTaskUseCase(UseCase[SingleTaskInput, None]):
+class RemoveTaskUseCase(UseCase[SingleTaskInput, TaskOperationOutput]):
     """Use case for removing tasks."""
 
     def __init__(self, repository: TaskRepository, notes_repository: NotesRepository):
@@ -19,21 +20,30 @@ class RemoveTaskUseCase(UseCase[SingleTaskInput, None]):
         self.repository = repository
         self.notes_repository = notes_repository
 
-    def execute(self, input_dto: SingleTaskInput) -> None:
+    def execute(self, input_dto: SingleTaskInput) -> TaskOperationOutput:
         """Execute task removal.
 
         Deletes both the task and its associated notes file (if any).
+        Returns task information captured before deletion.
 
         Args:
             input_dto: Task removal input data
 
+        Returns:
+            TaskOperationOutput containing the deleted task's information
+
         Raises:
             TaskNotFoundException: If task doesn't exist
         """
-        self._get_task_or_raise(self.repository, input_dto.task_id)
+        task = self._get_task_or_raise(self.repository, input_dto.task_id)
+
+        # Capture task info before deletion
+        result = TaskOperationOutput.from_task(task)
 
         # Delete notes first (idempotent - won't fail if notes don't exist)
         self.notes_repository.delete_notes(input_dto.task_id)
 
         # Then delete the task
         self.repository.delete(input_dto.task_id)
+
+        return result

--- a/packages/taskdog-core/src/taskdog_core/controllers/task_crud_controller.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/task_crud_controller.py
@@ -231,13 +231,16 @@ class TaskCrudController(BaseTaskController):
 
         return result
 
-    def remove_task(self, task_id: int) -> None:
+    def remove_task(self, task_id: int) -> TaskOperationOutput:
         """Remove a task (hard delete).
 
         Permanently deletes the task and its associated notes from storage.
 
         Args:
             task_id: ID of the task to remove
+
+        Returns:
+            TaskOperationOutput containing the deleted task's information
 
         Raises:
             TaskNotFoundException: If task not found
@@ -248,8 +251,10 @@ class TaskCrudController(BaseTaskController):
 
         use_case = RemoveTaskUseCase(self.repository, self.notes_repository)
         request = SingleTaskInput(task_id=task_id)
-        use_case.execute(request)
+        result = use_case.execute(request)
 
         self.logger.info(
             f"Task removed successfully: task_id={task_id}", task_id=task_id
         )
+
+        return result

--- a/packages/taskdog-core/tests/application/queries/filters/test_task_filter.py
+++ b/packages/taskdog-core/tests/application/queries/filters/test_task_filter.py
@@ -123,13 +123,15 @@ class TestTaskFilter:
         "composed_factory,expected_filter_count",
         [
             (
-                lambda: (PendingOnlyFilter() >> HighPriorityFilter())
-                >> ConcreteFilter(),
+                lambda: (
+                    (PendingOnlyFilter() >> HighPriorityFilter()) >> ConcreteFilter()
+                ),
                 3,
             ),
             (
-                lambda: PendingOnlyFilter()
-                >> (HighPriorityFilter() >> ConcreteFilter()),
+                lambda: (
+                    PendingOnlyFilter() >> (HighPriorityFilter() >> ConcreteFilter())
+                ),
                 3,
             ),
         ],

--- a/packages/taskdog-server/src/taskdog_server/api/routers/tasks.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/tasks.py
@@ -6,7 +6,6 @@ from typing import Annotated
 from fastapi import APIRouter, Query, status
 
 from taskdog_core.application.dto.query_inputs import ListTasksInput
-from taskdog_core.domain.exceptions.task_exceptions import TaskNotFoundException
 from taskdog_server.api.converters import (
     convert_to_task_detail_response,
     convert_to_task_list_response,
@@ -371,47 +370,43 @@ async def restore_task(
     return TaskOperationResponse.from_dto(result)
 
 
-@router.delete("/{task_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/{task_id}")
 @handle_task_errors
 async def delete_task(
     task_id: int,
     controller: CrudControllerDep,
-    query_controller: QueryControllerDep,
     broadcaster: EventBroadcasterDep,
     audit_controller: AuditLogControllerDep,
     client_name: AuthenticatedClientDep,
-) -> None:
+) -> TaskOperationResponse:
     """Permanently delete a task.
 
     Args:
         task_id: Task ID
         controller: CRUD controller dependency
-        query_controller: Query controller dependency (for fetching task name before deletion)
         broadcaster: Event broadcaster dependency
         audit_controller: Audit log controller dependency
         client_name: Authenticated client name (for broadcast payload)
 
+    Returns:
+        Deleted task data
+
     Raises:
         HTTPException: 404 if task not found
     """
-    # Get task name before deletion for notification
-    task_output = query_controller.get_task_by_id(task_id)
-    if task_output is None or task_output.task is None:
-        raise TaskNotFoundException(f"Task {task_id} not found")
-    task_name = task_output.task.name
-
-    # Delete task
-    controller.remove_task(task_id)
+    result = controller.remove_task(task_id)
 
     # Broadcast WebSocket event in background
-    broadcaster.task_deleted(task_id, task_name, client_name)
+    broadcaster.task_deleted(task_id, result.name, client_name)
 
     # Audit log
     audit_controller.log_operation(
         operation="delete_task",
         resource_type="task",
         resource_id=task_id,
-        resource_name=task_name,
+        resource_name=result.name,
         client_name=client_name,
         success=True,
     )
+
+    return TaskOperationResponse.from_dto(result)

--- a/packages/taskdog-server/tests/api/routers/test_tasks.py
+++ b/packages/taskdog-server/tests/api/routers/test_tasks.py
@@ -311,7 +311,10 @@ class TestTasksRouter:
         response = client.delete(f"/api/v1/tasks/{task.id}")
 
         # Assert
-        assert response.status_code == 204
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == task.id
+        assert data["name"] == "Test Task"
 
         # Verify task is deleted
         deleted_task = repository.get_by_id(task.id)

--- a/packages/taskdog-ui/src/taskdog/tui/commands/hard_delete.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/hard_delete.py
@@ -2,6 +2,7 @@
 
 from taskdog.tui.commands.batch_command_base import BatchCommandBase
 from taskdog_core.application.dto.bulk_operation_output import BulkOperationOutput
+from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 
 
 class HardDeleteCommand(BatchCommandBase):
@@ -18,6 +19,9 @@ class HardDeleteCommand(BatchCommandBase):
             "[!] This action CANNOT be undone!\n"
             "[!] All tasks will be completely removed from the database.",
         )
+
+    def execute_single(self, task_id: int) -> TaskOperationOutput:
+        return self.context.api_client.remove_task(task_id)
 
     def execute_bulk(self, task_ids: list[int]) -> BulkOperationOutput:
         """Permanently delete tasks (hard delete) via Bulk API."""


### PR DESCRIPTION
## Summary
- `HardDeleteCommand` was missing `execute_single()`, causing single-task hard deletes to fall back to the bulk API
- Made `RemoveTaskUseCase` and the full chain (controller → server → client) return `TaskOperationOutput`, consistent with all other single-task operations (archive, start, complete, etc.)

## Changes
**Core** — `RemoveTaskUseCase` captures task info before deletion and returns `TaskOperationOutput`; `TaskCrudController.remove_task` updated accordingly

**Server** — `DELETE /api/v1/tasks/{id}` now returns `TaskOperationResponse` (200) instead of empty 204; removed redundant pre-fetch via `QueryController`

**Client** — `remove_task` returns `TaskOperationOutput` instead of `None`

**TUI** — `HardDeleteCommand` adds `execute_single()` using individual API, matching `RmCommand` pattern

## Test plan
- [x] `make test-core` — 1118 passed
- [x] `make test-client` — 236 passed
- [x] `make test-server` — 309 passed
- [x] `make test-ui` — 937 passed
- [x] `make check` — lint, typecheck, codespell all passed
- [x] Manual: TUI hard delete works with new server (200 + JSON response)