### PR TITLE
refactor: make ApiContext.bulk_controller a required field

### DIFF
--- a/packages/taskdog-server/src/taskdog_server/api/context.py
+++ b/packages/taskdog-server/src/taskdog_server/api/context.py
@@ -50,7 +50,7 @@ class ApiContext:
     holiday_checker: IHolidayChecker | None
     time_provider: ITimeProvider
     audit_log_controller: AuditLogController
-    bulk_controller: BulkTaskController | None = None
+    bulk_controller: BulkTaskController
     engine: Engine | None = field(default=None, repr=False)
 
     def close(self) -> None:

--- a/packages/taskdog-server/src/taskdog_server/api/dependencies.py
+++ b/packages/taskdog-server/src/taskdog_server/api/dependencies.py
@@ -238,8 +238,6 @@ def get_audit_log_controller(context: ApiContextDep) -> AuditLogController:
 
 def get_bulk_controller(context: ApiContextDep) -> BulkTaskController:
     """Get bulk task controller from context."""
-    if context.bulk_controller is None:
-        raise RuntimeError("BulkTaskController not initialized in ApiContext.")
     return context.bulk_controller
 
 

--- a/packages/taskdog-server/tests/api/test_app.py
+++ b/packages/taskdog-server/tests/api/test_app.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from taskdog_core.controllers.audit_log_controller import AuditLogController
+from taskdog_core.controllers.bulk_task_controller import BulkTaskController
 from taskdog_core.controllers.query_controller import QueryController
 from taskdog_core.controllers.task_analytics_controller import TaskAnalyticsController
 from taskdog_core.controllers.task_crud_controller import TaskCrudController
@@ -70,6 +71,11 @@ class TestApp:
             holiday_checker=None,
             time_provider=SystemTimeProvider(),
             audit_log_controller=self.mock_audit_log_controller,
+            bulk_controller=BulkTaskController(
+                lifecycle_controller=lifecycle_controller,
+                crud_controller=crud_controller,
+                query_controller=query_controller,
+            ),
         )
 
         # Create app using create_app (lifespan will set its own context)

--- a/packages/taskdog-server/tests/api/test_context.py
+++ b/packages/taskdog-server/tests/api/test_context.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock
 
 from taskdog_core.controllers.audit_log_controller import AuditLogController
+from taskdog_core.controllers.bulk_task_controller import BulkTaskController
 from taskdog_core.controllers.query_controller import QueryController
 from taskdog_core.controllers.task_analytics_controller import TaskAnalyticsController
 from taskdog_core.controllers.task_crud_controller import TaskCrudController
@@ -35,6 +36,7 @@ class TestApiContext:
         self.mock_holiday_checker = Mock(spec=IHolidayChecker)
         self.mock_time_provider = Mock(spec=ITimeProvider)
         self.mock_audit_log_controller = Mock(spec=AuditLogController)
+        self.mock_bulk_controller = Mock(spec=BulkTaskController)
 
     def test_create_context_with_all_dependencies(self):
         """Test creating ApiContext with all dependencies."""
@@ -51,6 +53,7 @@ class TestApiContext:
             holiday_checker=self.mock_holiday_checker,
             time_provider=self.mock_time_provider,
             audit_log_controller=self.mock_audit_log_controller,
+            bulk_controller=self.mock_bulk_controller,
         )
 
         # Assert
@@ -81,6 +84,7 @@ class TestApiContext:
             holiday_checker=None,
             time_provider=self.mock_time_provider,
             audit_log_controller=self.mock_audit_log_controller,
+            bulk_controller=self.mock_bulk_controller,
         )
 
         # Assert
@@ -101,6 +105,7 @@ class TestApiContext:
             holiday_checker=self.mock_holiday_checker,
             time_provider=self.mock_time_provider,
             audit_log_controller=self.mock_audit_log_controller,
+            bulk_controller=self.mock_bulk_controller,
         )
 
         # Assert - verify all attributes are accessible
@@ -133,6 +138,7 @@ class TestApiContext:
             holiday_checker=None,
             time_provider=self.mock_time_provider,
             audit_log_controller=self.mock_audit_log_controller,
+            bulk_controller=self.mock_bulk_controller,
         )
 
         context2 = ApiContext(
@@ -147,6 +153,7 @@ class TestApiContext:
             holiday_checker=None,
             time_provider=self.mock_time_provider,
             audit_log_controller=self.mock_audit_log_controller,
+            bulk_controller=self.mock_bulk_controller,
         )
 
         # Assert
@@ -170,6 +177,7 @@ class TestApiContext:
             holiday_checker=None,
             time_provider=self.mock_time_provider,
             audit_log_controller=self.mock_audit_log_controller,
+            bulk_controller=self.mock_bulk_controller,
         )
 
         context2 = ApiContext(
@@ -184,6 +192,7 @@ class TestApiContext:
             holiday_checker=None,
             time_provider=self.mock_time_provider,
             audit_log_controller=self.mock_audit_log_controller,
+            bulk_controller=self.mock_bulk_controller,
         )
 
         # Assert
@@ -204,6 +213,7 @@ class TestApiContext:
             holiday_checker=None,
             time_provider=self.mock_time_provider,
             audit_log_controller=self.mock_audit_log_controller,
+            bulk_controller=self.mock_bulk_controller,
         )
 
         # Assert - verify all five controllers are present
@@ -238,6 +248,7 @@ class TestApiContext:
             holiday_checker=None,
             time_provider=time_provider,
             audit_log_controller=self.mock_audit_log_controller,
+            bulk_controller=self.mock_bulk_controller,
         )
 
         assert context.time_provider is time_provider


### PR DESCRIPTION
## Summary

- Make `ApiContext.bulk_controller` a required (non-optional) field instead of `BulkTaskController | None = None`
- Remove unreachable `None` guard in `get_bulk_controller()` dependency provider
- Update test fixtures to pass `bulk_controller` explicitly

The field was always initialized in both production (`dependencies.py`) and test (`conftest.py`) code paths, so the `Optional` type and runtime check were dead code.

## Test plan

- [x] `make typecheck` passes
- [x] `make test-server` passes (309 tests)