### PR TITLE
refactor: introduce NotesController for Clean Architecture alignment

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/dto/notes_output.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/notes_output.py
@@ -1,0 +1,20 @@
+"""Output DTO for notes operations."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class NotesOutput:
+    """Output DTO for notes operations.
+
+    Attributes:
+        task_id: Task ID
+        task_name: Task name (used for WebSocket broadcast messages)
+        content: Notes content (markdown)
+        has_notes: Whether the task has non-empty notes
+    """
+
+    task_id: int
+    task_name: str
+    content: str
+    has_notes: bool

--- a/packages/taskdog-core/src/taskdog_core/controllers/__init__.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/__init__.py
@@ -2,6 +2,12 @@
 
 from taskdog_core.controllers.audit_log_controller import AuditLogController
 from taskdog_core.controllers.bulk_task_controller import BulkTaskController
+from taskdog_core.controllers.notes_controller import NotesController
 from taskdog_core.controllers.query_controller import QueryController
 
-__all__ = ["AuditLogController", "BulkTaskController", "QueryController"]
+__all__ = [
+    "AuditLogController",
+    "BulkTaskController",
+    "NotesController",
+    "QueryController",
+]

--- a/packages/taskdog-core/src/taskdog_core/controllers/notes_controller.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/notes_controller.py
@@ -1,0 +1,120 @@
+"""Notes controller for orchestrating task notes operations.
+
+This controller provides a consistent interface for notes CRUD operations,
+with task existence validation. Presentation layers (API server) should use
+this controller rather than accessing the notes repository directly.
+"""
+
+from taskdog_core.application.dto.notes_output import NotesOutput
+from taskdog_core.domain.exceptions.task_exceptions import TaskNotFoundException
+from taskdog_core.domain.repositories.notes_repository import NotesRepository
+from taskdog_core.domain.repositories.task_repository import TaskRepository
+
+
+class NotesController:
+    """Controller for task notes operations.
+
+    Validates task existence before performing notes operations,
+    ensuring consistent error handling across all endpoints.
+
+    Attributes:
+        _repository: Task repository for existence validation
+        _notes_repository: Notes repository for notes persistence
+    """
+
+    def __init__(
+        self,
+        repository: TaskRepository,
+        notes_repository: NotesRepository,
+    ) -> None:
+        """Initialize the notes controller.
+
+        Args:
+            repository: Task repository for existence validation
+            notes_repository: Notes repository for notes persistence
+        """
+        self._repository = repository
+        self._notes_repository = notes_repository
+
+    def _get_task_or_raise(self, task_id: int) -> str:
+        """Verify task exists and return its name.
+
+        Args:
+            task_id: Task ID to verify
+
+        Returns:
+            Task name
+
+        Raises:
+            TaskNotFoundException: If task does not exist
+        """
+        task = self._repository.get_by_id(task_id)
+        if task is None:
+            raise TaskNotFoundException(task_id)
+        return task.name
+
+    def get_notes(self, task_id: int) -> NotesOutput:
+        """Get notes for a task.
+
+        Args:
+            task_id: Task ID
+
+        Returns:
+            NotesOutput with content and metadata
+
+        Raises:
+            TaskNotFoundException: If task does not exist
+        """
+        task_name = self._get_task_or_raise(task_id)
+        has_notes = self._notes_repository.has_notes(task_id)
+        content = self._notes_repository.read_notes(task_id) or ""
+        return NotesOutput(
+            task_id=task_id,
+            task_name=task_name,
+            content=content,
+            has_notes=has_notes,
+        )
+
+    def update_notes(self, task_id: int, content: str) -> NotesOutput:
+        """Update notes for a task.
+
+        Args:
+            task_id: Task ID
+            content: New notes content (markdown)
+
+        Returns:
+            NotesOutput with updated content and metadata
+
+        Raises:
+            TaskNotFoundException: If task does not exist
+        """
+        task_name = self._get_task_or_raise(task_id)
+        self._notes_repository.write_notes(task_id, content)
+        has_notes = self._notes_repository.has_notes(task_id)
+        return NotesOutput(
+            task_id=task_id,
+            task_name=task_name,
+            content=content,
+            has_notes=has_notes,
+        )
+
+    def delete_notes(self, task_id: int) -> NotesOutput:
+        """Delete notes for a task.
+
+        Args:
+            task_id: Task ID
+
+        Returns:
+            NotesOutput with task info (for broadcast/audit)
+
+        Raises:
+            TaskNotFoundException: If task does not exist
+        """
+        task_name = self._get_task_or_raise(task_id)
+        self._notes_repository.write_notes(task_id, "")
+        return NotesOutput(
+            task_id=task_id,
+            task_name=task_name,
+            content="",
+            has_notes=False,
+        )

--- a/packages/taskdog-core/tests/controllers/test_notes_controller.py
+++ b/packages/taskdog-core/tests/controllers/test_notes_controller.py
@@ -1,0 +1,102 @@
+"""Tests for NotesController."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from taskdog_core.controllers.notes_controller import NotesController
+from taskdog_core.domain.entities.task import Task, TaskStatus
+from taskdog_core.domain.exceptions.task_exceptions import TaskNotFoundException
+from taskdog_core.domain.repositories.notes_repository import NotesRepository
+from taskdog_core.infrastructure.persistence.database.sqlite_task_repository import (
+    SqliteTaskRepository,
+)
+
+
+class TestNotesController:
+    """Test cases for NotesController."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Set up test fixtures."""
+        self.repository = Mock(spec=SqliteTaskRepository)
+        self.notes_repository = Mock(spec=NotesRepository)
+        self.controller = NotesController(
+            repository=self.repository,
+            notes_repository=self.notes_repository,
+        )
+        self.task = Task(id=1, name="Test Task", priority=1, status=TaskStatus.PENDING)
+
+    def test_get_notes_returns_output(self):
+        """Test get_notes returns NotesOutput with content."""
+        self.repository.get_by_id.return_value = self.task
+        self.notes_repository.has_notes.return_value = True
+        self.notes_repository.read_notes.return_value = "# Hello"
+
+        result = self.controller.get_notes(1)
+
+        assert result.task_id == 1
+        assert result.task_name == "Test Task"
+        assert result.content == "# Hello"
+        assert result.has_notes is True
+
+    def test_get_notes_returns_empty_when_no_notes(self):
+        """Test get_notes returns empty content when no notes exist."""
+        self.repository.get_by_id.return_value = self.task
+        self.notes_repository.has_notes.return_value = False
+        self.notes_repository.read_notes.return_value = None
+
+        result = self.controller.get_notes(1)
+
+        assert result.content == ""
+        assert result.has_notes is False
+
+    def test_get_notes_raises_when_task_not_found(self):
+        """Test get_notes raises TaskNotFoundException for missing task."""
+        self.repository.get_by_id.return_value = None
+
+        with pytest.raises(TaskNotFoundException):
+            self.controller.get_notes(999)
+
+    def test_update_notes_writes_and_returns_output(self):
+        """Test update_notes writes content and returns NotesOutput."""
+        self.repository.get_by_id.return_value = self.task
+        self.notes_repository.has_notes.return_value = True
+
+        result = self.controller.update_notes(1, "New content")
+
+        self.notes_repository.write_notes.assert_called_once_with(1, "New content")
+        assert result.task_id == 1
+        assert result.task_name == "Test Task"
+        assert result.content == "New content"
+        assert result.has_notes is True
+
+    def test_update_notes_raises_when_task_not_found(self):
+        """Test update_notes raises TaskNotFoundException for missing task."""
+        self.repository.get_by_id.return_value = None
+
+        with pytest.raises(TaskNotFoundException):
+            self.controller.update_notes(999, "content")
+
+        self.notes_repository.write_notes.assert_not_called()
+
+    def test_delete_notes_writes_empty_and_returns_output(self):
+        """Test delete_notes clears content and returns NotesOutput."""
+        self.repository.get_by_id.return_value = self.task
+
+        result = self.controller.delete_notes(1)
+
+        self.notes_repository.write_notes.assert_called_once_with(1, "")
+        assert result.task_id == 1
+        assert result.task_name == "Test Task"
+        assert result.content == ""
+        assert result.has_notes is False
+
+    def test_delete_notes_raises_when_task_not_found(self):
+        """Test delete_notes raises TaskNotFoundException for missing task."""
+        self.repository.get_by_id.return_value = None
+
+        with pytest.raises(TaskNotFoundException):
+            self.controller.delete_notes(999)
+
+        self.notes_repository.write_notes.assert_not_called()

--- a/packages/taskdog-server/src/taskdog_server/api/context.py
+++ b/packages/taskdog-server/src/taskdog_server/api/context.py
@@ -6,6 +6,7 @@ from sqlalchemy.engine import Engine
 
 from taskdog_core.controllers.audit_log_controller import AuditLogController
 from taskdog_core.controllers.bulk_task_controller import BulkTaskController
+from taskdog_core.controllers.notes_controller import NotesController
 from taskdog_core.controllers.query_controller import QueryController
 from taskdog_core.controllers.task_analytics_controller import TaskAnalyticsController
 from taskdog_core.controllers.task_crud_controller import TaskCrudController
@@ -50,6 +51,7 @@ class ApiContext:
     holiday_checker: IHolidayChecker | None
     time_provider: ITimeProvider
     audit_log_controller: AuditLogController
+    notes_controller: NotesController
     bulk_controller: BulkTaskController
     engine: Engine | None = field(default=None, repr=False)
 

--- a/packages/taskdog-server/src/taskdog_server/api/dependencies.py
+++ b/packages/taskdog-server/src/taskdog_server/api/dependencies.py
@@ -9,6 +9,7 @@ from fastapi.security import APIKeyHeader
 
 from taskdog_core.controllers.audit_log_controller import AuditLogController
 from taskdog_core.controllers.bulk_task_controller import BulkTaskController
+from taskdog_core.controllers.notes_controller import NotesController
 from taskdog_core.controllers.query_controller import QueryController
 from taskdog_core.controllers.task_analytics_controller import TaskAnalyticsController
 from taskdog_core.controllers.task_crud_controller import TaskCrudController
@@ -116,6 +117,7 @@ def initialize_api_context(
         repository, notes_repository, config, holiday_checker
     )
     audit_log_controller = AuditLogController(audit_log_repository, time_provider)
+    notes_controller = NotesController(repository, notes_repository)
 
     bulk_controller = BulkTaskController(
         lifecycle_controller, crud_controller, query_controller
@@ -133,6 +135,7 @@ def initialize_api_context(
         holiday_checker=holiday_checker,
         time_provider=time_provider,
         audit_log_controller=audit_log_controller,
+        notes_controller=notes_controller,
         bulk_controller=bulk_controller,
         engine=engine,
     )
@@ -215,6 +218,11 @@ def get_audit_log_controller(context: ApiContextDep) -> AuditLogController:
     return context.audit_log_controller
 
 
+def get_notes_controller(context: ApiContextDep) -> NotesController:
+    """Get notes controller from context."""
+    return context.notes_controller
+
+
 def get_bulk_controller(context: ApiContextDep) -> BulkTaskController:
     """Get bulk task controller from context."""
     return context.bulk_controller
@@ -281,6 +289,7 @@ NotesRepositoryDep = Annotated[NotesRepository, Depends(get_notes_repository)]
 HolidayCheckerDep = Annotated[IHolidayChecker | None, Depends(get_holiday_checker)]
 TimeProviderDep = Annotated[ITimeProvider, Depends(get_time_provider)]
 AuditLogControllerDep = Annotated[AuditLogController, Depends(get_audit_log_controller)]
+NotesControllerDep = Annotated[NotesController, Depends(get_notes_controller)]
 BulkTaskControllerDep = Annotated[BulkTaskController, Depends(get_bulk_controller)]
 ConnectionManagerDep = Annotated[ConnectionManager, Depends(get_connection_manager)]
 ConnectionManagerWsDep = Annotated[

--- a/packages/taskdog-server/src/taskdog_server/api/routers/notes.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/notes.py
@@ -2,13 +2,11 @@
 
 from fastapi import APIRouter, status
 
-from taskdog_core.domain.exceptions.task_exceptions import TaskNotFoundException
 from taskdog_server.api.dependencies import (
     AuditLogControllerDep,
     AuthenticatedClientDep,
     EventBroadcasterDep,
-    NotesRepositoryDep,
-    RepositoryDep,
+    NotesControllerDep,
 )
 from taskdog_server.api.error_handlers import handle_task_errors
 from taskdog_server.api.models.requests import UpdateNotesRequest
@@ -21,16 +19,14 @@ router = APIRouter()
 @handle_task_errors
 async def get_task_notes(
     task_id: int,
-    repository: RepositoryDep,
-    notes_repo: NotesRepositoryDep,
+    controller: NotesControllerDep,
     _client_name: AuthenticatedClientDep,
 ) -> NotesResponse:
     """Get task notes.
 
     Args:
         task_id: Task ID
-        repository: Task repository dependency
-        notes_repo: Notes repository dependency
+        controller: Notes controller dependency
 
     Returns:
         Notes content and metadata
@@ -38,16 +34,10 @@ async def get_task_notes(
     Raises:
         HTTPException: 404 if task not found
     """
-    # Verify task exists
-    task = repository.get_by_id(task_id)
-    if task is None:
-        raise TaskNotFoundException(task_id)
-
-    # Get notes
-    has_notes = notes_repo.has_notes(task_id)
-    content = notes_repo.read_notes(task_id) or ""
-
-    return NotesResponse(task_id=task_id, content=content, has_notes=has_notes)
+    result = controller.get_notes(task_id)
+    return NotesResponse(
+        task_id=result.task_id, content=result.content, has_notes=result.has_notes
+    )
 
 
 @router.put("/{task_id}/notes", response_model=NotesResponse)
@@ -55,8 +45,7 @@ async def get_task_notes(
 async def update_task_notes(
     task_id: int,
     request: UpdateNotesRequest,
-    repository: RepositoryDep,
-    notes_repo: NotesRepositoryDep,
+    controller: NotesControllerDep,
     broadcaster: EventBroadcasterDep,
     audit_controller: AuditLogControllerDep,
     client_name: AuthenticatedClientDep,
@@ -66,8 +55,7 @@ async def update_task_notes(
     Args:
         task_id: Task ID
         request: Notes content
-        repository: Task repository dependency
-        notes_repo: Notes repository dependency
+        controller: Notes controller dependency
         broadcaster: Event broadcaster dependency
         client_name: Authenticated client name (used for broadcast exclusion)
 
@@ -77,38 +65,32 @@ async def update_task_notes(
     Raises:
         HTTPException: 404 if task not found
     """
-    # Verify task exists
-    task = repository.get_by_id(task_id)
-    if task is None:
-        raise TaskNotFoundException(task_id)
-
-    # Update notes
-    notes_repo.write_notes(task_id, request.content)
-    has_notes = notes_repo.has_notes(task_id)
+    result = controller.update_notes(task_id, request.content)
 
     # Broadcast WebSocket event in background (exclude the requester by client name)
-    broadcaster.task_notes_updated(task_id, task.name, client_name)
+    broadcaster.task_notes_updated(task_id, result.task_name, client_name)
 
     # Audit log
     audit_controller.log_operation(
         operation="update_notes",
         resource_type="task",
         resource_id=task_id,
-        resource_name=task.name,
+        resource_name=result.task_name,
         client_name=client_name,
-        new_values={"has_notes": has_notes},
+        new_values={"has_notes": result.has_notes},
         success=True,
     )
 
-    return NotesResponse(task_id=task_id, content=request.content, has_notes=has_notes)
+    return NotesResponse(
+        task_id=result.task_id, content=result.content, has_notes=result.has_notes
+    )
 
 
 @router.delete("/{task_id}/notes", status_code=status.HTTP_204_NO_CONTENT)
 @handle_task_errors
 async def delete_task_notes(
     task_id: int,
-    repository: RepositoryDep,
-    notes_repo: NotesRepositoryDep,
+    controller: NotesControllerDep,
     broadcaster: EventBroadcasterDep,
     audit_controller: AuditLogControllerDep,
     client_name: AuthenticatedClientDep,
@@ -117,31 +99,24 @@ async def delete_task_notes(
 
     Args:
         task_id: Task ID
-        repository: Task repository dependency
-        notes_repo: Notes repository dependency
+        controller: Notes controller dependency
         broadcaster: Event broadcaster dependency
         client_name: Authenticated client name (used for broadcast exclusion)
 
     Raises:
         HTTPException: 404 if task not found
     """
-    # Verify task exists
-    task = repository.get_by_id(task_id)
-    if task is None:
-        raise TaskNotFoundException(task_id)
-
-    # Delete notes by writing empty content
-    notes_repo.write_notes(task_id, "")
+    result = controller.delete_notes(task_id)
 
     # Broadcast WebSocket event in background (exclude the requester by client name)
-    broadcaster.task_notes_updated(task_id, task.name, client_name)
+    broadcaster.task_notes_updated(task_id, result.task_name, client_name)
 
     # Audit log
     audit_controller.log_operation(
         operation="delete_notes",
         resource_type="task",
         resource_id=task_id,
-        resource_name=task.name,
+        resource_name=result.task_name,
         client_name=client_name,
         success=True,
     )

--- a/packages/taskdog-server/tests/api/test_app.py
+++ b/packages/taskdog-server/tests/api/test_app.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 
 from taskdog_core.controllers.audit_log_controller import AuditLogController
 from taskdog_core.controllers.bulk_task_controller import BulkTaskController
+from taskdog_core.controllers.notes_controller import NotesController
 from taskdog_core.controllers.query_controller import QueryController
 from taskdog_core.controllers.task_analytics_controller import TaskAnalyticsController
 from taskdog_core.controllers.task_crud_controller import TaskCrudController
@@ -66,6 +67,9 @@ class TestApp:
             holiday_checker=None,
             time_provider=SystemTimeProvider(),
             audit_log_controller=self.mock_audit_log_controller,
+            notes_controller=NotesController(
+                self.mock_repository, self.mock_notes_repository
+            ),
             bulk_controller=BulkTaskController(
                 lifecycle_controller=lifecycle_controller,
                 crud_controller=crud_controller,

--- a/packages/taskdog-server/tests/api/test_context.py
+++ b/packages/taskdog-server/tests/api/test_context.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 
 from taskdog_core.controllers.audit_log_controller import AuditLogController
 from taskdog_core.controllers.bulk_task_controller import BulkTaskController
+from taskdog_core.controllers.notes_controller import NotesController
 from taskdog_core.controllers.query_controller import QueryController
 from taskdog_core.controllers.task_analytics_controller import TaskAnalyticsController
 from taskdog_core.controllers.task_crud_controller import TaskCrudController
@@ -36,6 +37,7 @@ class TestApiContext:
         self.mock_holiday_checker = Mock(spec=IHolidayChecker)
         self.mock_time_provider = Mock(spec=ITimeProvider)
         self.mock_audit_log_controller = Mock(spec=AuditLogController)
+        self.mock_notes_controller = Mock(spec=NotesController)
         self.mock_bulk_controller = Mock(spec=BulkTaskController)
 
     def test_create_context_with_all_dependencies(self):
@@ -53,6 +55,7 @@ class TestApiContext:
             holiday_checker=self.mock_holiday_checker,
             time_provider=self.mock_time_provider,
             audit_log_controller=self.mock_audit_log_controller,
+            notes_controller=self.mock_notes_controller,
             bulk_controller=self.mock_bulk_controller,
         )
 
@@ -84,6 +87,7 @@ class TestApiContext:
             holiday_checker=None,
             time_provider=self.mock_time_provider,
             audit_log_controller=self.mock_audit_log_controller,
+            notes_controller=self.mock_notes_controller,
             bulk_controller=self.mock_bulk_controller,
         )
 
@@ -105,6 +109,7 @@ class TestApiContext:
             holiday_checker=self.mock_holiday_checker,
             time_provider=self.mock_time_provider,
             audit_log_controller=self.mock_audit_log_controller,
+            notes_controller=self.mock_notes_controller,
             bulk_controller=self.mock_bulk_controller,
         )
 
@@ -138,6 +143,7 @@ class TestApiContext:
             holiday_checker=None,
             time_provider=self.mock_time_provider,
             audit_log_controller=self.mock_audit_log_controller,
+            notes_controller=self.mock_notes_controller,
             bulk_controller=self.mock_bulk_controller,
         )
 
@@ -153,6 +159,7 @@ class TestApiContext:
             holiday_checker=None,
             time_provider=self.mock_time_provider,
             audit_log_controller=self.mock_audit_log_controller,
+            notes_controller=self.mock_notes_controller,
             bulk_controller=self.mock_bulk_controller,
         )
 
@@ -177,6 +184,7 @@ class TestApiContext:
             holiday_checker=None,
             time_provider=self.mock_time_provider,
             audit_log_controller=self.mock_audit_log_controller,
+            notes_controller=self.mock_notes_controller,
             bulk_controller=self.mock_bulk_controller,
         )
 
@@ -192,6 +200,7 @@ class TestApiContext:
             holiday_checker=None,
             time_provider=self.mock_time_provider,
             audit_log_controller=self.mock_audit_log_controller,
+            notes_controller=self.mock_notes_controller,
             bulk_controller=self.mock_bulk_controller,
         )
 
@@ -213,6 +222,7 @@ class TestApiContext:
             holiday_checker=None,
             time_provider=self.mock_time_provider,
             audit_log_controller=self.mock_audit_log_controller,
+            notes_controller=self.mock_notes_controller,
             bulk_controller=self.mock_bulk_controller,
         )
 
@@ -248,6 +258,7 @@ class TestApiContext:
             holiday_checker=None,
             time_provider=time_provider,
             audit_log_controller=self.mock_audit_log_controller,
+            notes_controller=self.mock_notes_controller,
             bulk_controller=self.mock_bulk_controller,
         )
 

--- a/packages/taskdog-server/tests/conftest.py
+++ b/packages/taskdog-server/tests/conftest.py
@@ -39,6 +39,7 @@ from taskdog_core.controllers.audit_log_controller import (  # noqa: E402
 from taskdog_core.controllers.bulk_task_controller import (  # noqa: E402
     BulkTaskController,
 )
+from taskdog_core.controllers.notes_controller import NotesController  # noqa: E402
 from taskdog_core.controllers.query_controller import QueryController  # noqa: E402
 from taskdog_core.controllers.task_analytics_controller import (  # noqa: E402
     TaskAnalyticsController,
@@ -216,6 +217,7 @@ def app(
     audit_log_controller = AuditLogController(
         session_audit_log_repository, SystemTimeProvider()
     )
+    notes_controller = NotesController(session_repository, session_notes_repository)
     bulk_controller = BulkTaskController(
         lifecycle_controller, crud_controller, query_controller
     )
@@ -233,6 +235,7 @@ def app(
         holiday_checker=None,
         time_provider=SystemTimeProvider(),
         audit_log_controller=audit_log_controller,
+        notes_controller=notes_controller,
         bulk_controller=bulk_controller,
     )
 


### PR DESCRIPTION
## Summary

- Add `NotesController` in taskdog-core with `get_notes`/`update_notes`/`delete_notes` methods that include task existence validation
- Add `NotesOutput` DTO for controller return values (includes `task_name` needed by WebSocket broadcasts)
- Refactor notes router to use `NotesControllerDep` instead of directly accessing `RepositoryDep` + `NotesRepositoryDep`
- Wire `NotesController` into `ApiContext` and `dependencies.py`

## Why

The notes router was the **only router** that bypassed the controller layer and accessed repositories directly. This caused:
1. Task existence checks duplicated across all 3 endpoints (DRY violation)
2. Architectural inconsistency with all other routers (tasks, lifecycle, relationships, analytics)

## Test plan

- [x] `make check` passes (lint + typecheck)
- [x] `make test` — all tests pass (core, server, client, ui, mcp)
- [x] New `test_notes_controller.py` with 7 tests covering all methods + TaskNotFoundException cases
- [x] Existing notes API tests pass unchanged (behavior preserved)