### PR TITLE
refactor: extract shared finished-name formatter for Gantt/Timeline

### DIFF
--- a/packages/taskdog-ui/src/taskdog/formatters/text_formatter.py
+++ b/packages/taskdog-ui/src/taskdog/formatters/text_formatter.py
@@ -1,0 +1,13 @@
+"""Text formatting utilities for terminal display."""
+
+from rich.markup import escape
+
+from taskdog.constants.common import COLUMN_FINISHED_STYLE
+
+
+def format_finished_name(name: str, is_finished: bool) -> str:
+    """Escape Rich markup in the name and apply strikethrough if finished."""
+    escaped = escape(name)
+    if is_finished:
+        return f"[{COLUMN_FINISHED_STYLE}]{escaped}[/{COLUMN_FINISHED_STYLE}]"
+    return escaped

--- a/packages/taskdog-ui/src/taskdog/renderers/rich_gantt_renderer.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/rich_gantt_renderer.py
@@ -1,7 +1,6 @@
 from datetime import date, timedelta
 from typing import Any
 
-from rich.markup import escape
 from rich.table import Table
 from rich.text import Text
 
@@ -25,6 +24,7 @@ from taskdog.constants.gantt import (
     HEADER_TIMELINE,
 )
 from taskdog.constants.task_table import TASK_NAME_COLUMN_WIDTH
+from taskdog.formatters.text_formatter import format_finished_name
 from taskdog.renderers.gantt_cell_formatter import GanttCellFormatter
 from taskdog.renderers.rich_renderer_base import RichRendererBase
 from taskdog.view_models.gantt_view_model import GanttViewModel, TaskGanttRowViewModel
@@ -263,13 +263,7 @@ class RichGanttRenderer(RichRendererBase):
             end_date: End date of the chart
             holidays: Set of holiday dates for styling
         """
-        # Apply Rich markup escape and strikethrough for finished tasks
-        escaped_name = escape(task_vm.name)
-        task_name = (
-            f"[strike dim]{escaped_name}[/strike dim]"
-            if task_vm.is_finished
-            else escaped_name
-        )
+        task_name = format_finished_name(task_vm.name, task_vm.is_finished)
 
         # Use pre-formatted estimated duration
         estimated_hours = task_vm.formatted_estimated_duration

--- a/packages/taskdog-ui/src/taskdog/renderers/rich_timeline_renderer.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/rich_timeline_renderer.py
@@ -4,7 +4,6 @@ This module renders the Timeline chart as a Rich Table, showing
 actual work times on a horizontal time axis for a specific day.
 """
 
-from rich.markup import escape
 from rich.table import Table
 from rich.text import Text
 
@@ -19,6 +18,7 @@ from taskdog.constants.common import (
 from taskdog.constants.formatting import format_table_title
 from taskdog.constants.gantt import GANTT_TABLE_ID_WIDTH, GANTT_TABLE_TASK_MIN_WIDTH
 from taskdog.constants.timeline import CHARS_PER_HOUR, TIMELINE_TABLE_DURATION_WIDTH
+from taskdog.formatters.text_formatter import format_finished_name
 from taskdog.renderers.rich_renderer_base import RichRendererBase
 from taskdog.renderers.timeline_cell_formatter import TimelineCellFormatter
 from taskdog.view_models.timeline_view_model import (
@@ -163,13 +163,7 @@ class RichTimelineRenderer(RichRendererBase):
         # Format duration
         duration_str = TimelineCellFormatter.format_duration(row_vm.duration_hours)
 
-        # Apply Rich markup escape and strikethrough for finished tasks
-        escaped_name = escape(row_vm.name)
-        task_name = (
-            f"[strike dim]{escaped_name}[/strike dim]"
-            if row_vm.is_finished
-            else escaped_name
-        )
+        task_name = format_finished_name(row_vm.name, row_vm.is_finished)
 
         table.add_row(
             str(row_vm.task_id),

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_data_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_data_table.py
@@ -8,7 +8,6 @@ like task selection, date range adjustment, and filtering.
 from datetime import date, timedelta
 from typing import Any, ClassVar
 
-from rich.markup import escape
 from rich.text import Text
 from textual.binding import Binding
 from textual.coordinate import Coordinate
@@ -17,6 +16,7 @@ from textual.widgets import DataTable
 from taskdog.constants.common import HEADER_ESTIMATED, HEADER_ID, HEADER_NAME
 from taskdog.constants.gantt import CHARS_PER_DAY, GANTT_WORKLOAD_LABEL
 from taskdog.constants.task_table import ESTIMATED_COLUMN_WIDTH, TASK_NAME_COLUMN_WIDTH
+from taskdog.formatters.text_formatter import format_finished_name
 from taskdog.renderers.gantt_cell_formatter import DateMetadata, GanttCellFormatter
 from taskdog.view_models.gantt_view_model import GanttViewModel, TaskGanttRowViewModel
 from taskdog_core.shared.constants import (
@@ -495,14 +495,8 @@ class GanttDataTable(DataTable):  # type: ignore[type-arg]
         Returns:
             Tuple of (task_id, task_name, estimated_hours)
         """
-        # Apply Rich markup escape and strikethrough for finished tasks
         task_id = str(task_vm.id)
-        escaped_name = escape(task_vm.name)
-        task_name = (
-            f"[strike dim]{escaped_name}[/strike dim]"
-            if task_vm.is_finished
-            else escaped_name
-        )
+        task_name = format_finished_name(task_vm.name, task_vm.is_finished)
         est_hours = task_vm.formatted_estimated_duration
 
         return task_id, task_name, est_hours

--- a/packages/taskdog-ui/tests/formatters/test_text_formatter.py
+++ b/packages/taskdog-ui/tests/formatters/test_text_formatter.py
@@ -1,0 +1,29 @@
+"""Tests for text_formatter."""
+
+import pytest
+
+from taskdog.formatters.text_formatter import format_finished_name
+
+
+class TestFormatFinishedName:
+    """Test cases for format_finished_name."""
+
+    @pytest.mark.parametrize(
+        "name,is_finished,expected",
+        [
+            ("Task A", False, "Task A"),
+            ("Task A", True, "[strike dim]Task A[/strike dim]"),
+        ],
+        ids=["unfinished", "finished"],
+    )
+    def test_format_finished_name(self, name, is_finished, expected):
+        result = format_finished_name(name, is_finished)
+        assert result == expected
+
+    def test_escapes_rich_markup_when_unfinished(self):
+        result = format_finished_name("[tracker] Task", False)
+        assert result == r"\[tracker] Task"
+
+    def test_escapes_rich_markup_when_finished(self):
+        result = format_finished_name("[tracker] Task", True)
+        assert result == r"[strike dim]\[tracker] Task[/strike dim]"

--- a/packages/taskdog-ui/tests/presentation/renderers/test_rich_gantt_renderer.py
+++ b/packages/taskdog-ui/tests/presentation/renderers/test_rich_gantt_renderer.py
@@ -129,6 +129,20 @@ class TestRichGanttRendererBuildTable:
         # Note: add_section() doesn't add a row, just a visual separator
         assert len(table.rows) == 4
 
+    def test_build_table_applies_strikethrough_to_finished_tasks(self) -> None:
+        """Finished tasks have strikethrough markup, others do not."""
+        model = self._create_gantt_view_model()
+
+        table = self.renderer.build_table(model)
+
+        assert table is not None
+        # Name column is index 1; cells include date header + task rows + summary
+        name_cells = [str(c) for c in table.columns[1]._cells]
+        finished_cell = next(c for c in name_cells if "Task 2" in c)
+        unfinished_cell = next(c for c in name_cells if "Task 1" in c)
+        assert finished_cell == "[strike dim]Task 2[/strike dim]"
+        assert unfinished_cell == "Task 1"
+
     def test_build_table_includes_workload_summary(self) -> None:
         """Table includes workload summary row with total estimated hours."""
         model = self._create_gantt_view_model()

--- a/packages/taskdog-ui/tests/renderers/test_rich_timeline_renderer.py
+++ b/packages/taskdog-ui/tests/renderers/test_rich_timeline_renderer.py
@@ -107,6 +107,30 @@ class TestRichTimelineRenderer:
         # Check that the table has the expected columns
         assert len(result.columns) == 4  # ID, Task, Timeline, Time
 
+    def test_build_table_applies_strikethrough_to_finished_tasks(self):
+        """Finished tasks have strikethrough markup, others do not."""
+        rows = [
+            self._create_row_vm(
+                task_id=1,
+                name="Done Task",
+                status=TaskStatus.COMPLETED,
+                is_finished=True,
+            ),
+            self._create_row_vm(
+                task_id=2,
+                name="Active Task",
+                status=TaskStatus.IN_PROGRESS,
+                is_finished=False,
+            ),
+        ]
+        timeline_vm = self._create_timeline_vm(rows=rows, total_work_hours=6.0)
+        result = self.renderer.build_table(timeline_vm)
+
+        assert result is not None
+        name_cells = [str(c) for c in result.columns[1]._cells]
+        assert "[strike dim]Done Task[/strike dim]" in name_cells
+        assert "Active Task" in name_cells
+
 
 class TestTimelineCellFormatter:
     """Test cases for TimelineCellFormatter."""


### PR DESCRIPTION
## Summary

Extract the duplicated `escape() + [strike dim]…[/strike dim]` logic from three places into a single helper, addressing #715.

- New `taskdog.formatters.text_formatter.format_finished_name(name, is_finished)` — escapes Rich markup and applies strikethrough using the existing `COLUMN_FINISHED_STYLE` constant.
- Replaced the inline blocks in:
  - `renderers/rich_gantt_renderer.py`
  - `renderers/rich_timeline_renderer.py`
  - `tui/widgets/gantt_data_table.py`
- Removed the now-unused `from rich.markup import escape` imports from those three files.

## Tests

- New `tests/formatters/test_text_formatter.py` covers finished/unfinished cases and Rich markup escaping.
- Added `test_build_table_applies_strikethrough_to_finished_tasks` to both `test_rich_gantt_renderer.py` and `test_rich_timeline_renderer.py` to verify the strikethrough is applied through the renderer path.

## Test plan

- [x] `make lint`
- [x] `make typecheck`
- [x] `make test-ui` — 942 passed (was 936)

Closes #715