### PR TITLE
chore(client): enable pytest asyncio_mode = "auto"

### DIFF
--- a/packages/taskdog-client/pyproject.toml
+++ b/packages/taskdog-client/pyproject.toml
@@ -62,3 +62,4 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+asyncio_mode = "auto"

--- a/packages/taskdog-client/tests/websocket/test_websocket_client.py
+++ b/packages/taskdog-client/tests/websocket/test_websocket_client.py
@@ -52,7 +52,6 @@ class TestWebSocketClientInit:
 class TestWebSocketClientConnect:
     """Tests for WebSocketClient.connect()."""
 
-    @pytest.mark.asyncio
     @patch("taskdog_client.websocket.websocket_client.WEBSOCKETS_AVAILABLE", True)
     async def test_connect_changes_state_to_connecting(self) -> None:
         """Test that connect() changes state to CONNECTING."""
@@ -73,7 +72,6 @@ class TestWebSocketClientConnect:
             # Clean up
             await client.disconnect()
 
-    @pytest.mark.asyncio
     @patch("taskdog_client.websocket.websocket_client.WEBSOCKETS_AVAILABLE", True)
     async def test_duplicate_connect_is_no_op(self) -> None:
         """Test that calling connect() twice doesn't create duplicate tasks."""
@@ -98,7 +96,6 @@ class TestWebSocketClientConnect:
             assert first_task is second_task
             await client.disconnect()
 
-    @pytest.mark.asyncio
     @patch("taskdog_client.websocket.websocket_client.WEBSOCKETS_AVAILABLE", False)
     async def test_connect_without_websockets_library(self) -> None:
         """Test that connect() does nothing when websockets is not available."""
@@ -113,7 +110,6 @@ class TestWebSocketClientConnect:
 class TestWebSocketClientDisconnect:
     """Tests for WebSocketClient.disconnect()."""
 
-    @pytest.mark.asyncio
     @patch("taskdog_client.websocket.websocket_client.WEBSOCKETS_AVAILABLE", True)
     async def test_disconnect_changes_state_to_disconnected(self) -> None:
         """Test that disconnect() changes state to DISCONNECTED."""
@@ -129,7 +125,6 @@ class TestWebSocketClientDisconnect:
             await client.disconnect()
             assert client._state == ConnectionState.DISCONNECTED
 
-    @pytest.mark.asyncio
     @patch("taskdog_client.websocket.websocket_client.WEBSOCKETS_AVAILABLE", True)
     async def test_disconnect_when_already_disconnected_is_no_op(self) -> None:
         """Test that disconnect() on disconnected client is a no-op."""
@@ -140,7 +135,6 @@ class TestWebSocketClientDisconnect:
         await client.disconnect()
         assert client._state == ConnectionState.DISCONNECTED
 
-    @pytest.mark.asyncio
     @patch("taskdog_client.websocket.websocket_client.WEBSOCKETS_AVAILABLE", True)
     async def test_disconnect_cancels_task(self) -> None:
         """Test that disconnect() cancels the background task."""
@@ -183,7 +177,6 @@ class TestWebSocketClientIsConnected:
 class TestWebSocketClientConcurrency:
     """Tests for WebSocketClient concurrent access."""
 
-    @pytest.mark.asyncio
     @patch("taskdog_client.websocket.websocket_client.WEBSOCKETS_AVAILABLE", True)
     async def test_concurrent_connect_disconnect(self) -> None:
         """Test that concurrent connect/disconnect calls are properly serialized."""


### PR DESCRIPTION
## Summary
- Add `asyncio_mode = "auto"` to `taskdog-client/pyproject.toml`, matching `taskdog-server` and `taskdog-mcp`
- Drop 7 redundant `@pytest.mark.asyncio` decorators from `test_websocket_client.py`

Net diff: +1 / -7.

## Test plan
- [x] `uv run python -m pytest tests/` (236 passed)
- [x] `uv run ruff check .`
- [x] `uv run mypy src`

Closes #873