### PR TITLE
feat(mcp): add optimize_schedule and list_algorithms tools

### DIFF
--- a/packages/taskdog-mcp/src/taskdog_mcp/server.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/server.py
@@ -44,6 +44,7 @@ def create_mcp_server(config: McpConfig | None = None) -> FastMCP:
         task_crud,
         task_decomposition,
         task_lifecycle,
+        task_optimization,
         task_query,
         task_tags,
     )
@@ -54,6 +55,7 @@ def create_mcp_server(config: McpConfig | None = None) -> FastMCP:
     task_decomposition.register_tools(mcp, client)
     task_tags.register_tools(mcp, client)
     task_audit.register_tools(mcp, client)
+    task_optimization.register_tools(mcp, client)
 
     logger.info(
         f"MCP server '{config.server.name}' initialized, connecting to {base_url}"

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_optimization.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_optimization.py
@@ -1,0 +1,143 @@
+"""Task optimization MCP tools.
+
+Tools for auto-generating optimal task schedules and listing available
+optimization algorithms.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
+    from taskdog_client import TaskdogApiClient
+
+
+def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
+    """Register task optimization tools with the MCP server.
+
+    Args:
+        mcp: FastMCP server instance
+        client: Taskdog API client
+    """
+
+    @mcp.tool()
+    def optimize_schedule(
+        algorithm: str,
+        max_hours_per_day: float,
+        start_date: str | None = None,
+        task_ids: list[int] | None = None,
+        force_override: bool = False,
+        include_all_days: bool = False,
+    ) -> dict[str, Any]:
+        """Auto-generate optimal task schedules.
+
+        Schedules tasks with estimated_duration based on priority, deadlines,
+        and dependencies. By default schedules on weekdays only and skips tasks
+        that already have a planned_start (use force_override to override).
+
+        Args:
+            algorithm: Algorithm name. One of: greedy (front-load),
+                balanced (even distribution), backward (JIT from deadline),
+                priority_first (priority only), earliest_deadline (EDF),
+                round_robin (parallel progress), dependency_aware (CPM),
+                genetic (evolutionary), monte_carlo (random sampling).
+                Use list_algorithms() to discover available algorithms.
+            max_hours_per_day: Maximum work hours per day (e.g., 6.0 or 8.0)
+            start_date: Optimization start date in ISO format
+                (e.g., '2025-12-15' or '2025-12-15T09:00:00').
+                Defaults to server current time when omitted.
+            task_ids: Specific task IDs to optimize. If omitted, all
+                schedulable tasks are considered.
+            force_override: If True, override existing schedules
+            include_all_days: If True, schedule on weekends and holidays too
+
+        Returns:
+            Optimization result with successful_tasks, failed_tasks,
+            daily_allocations, and summary metrics.
+        """
+        try:
+            start_dt = datetime.fromisoformat(start_date) if start_date else None
+        except ValueError as e:
+            raise ValueError(f"Invalid datetime format: {e}") from e
+
+        if max_hours_per_day <= 0:
+            raise ValueError("max_hours_per_day must be greater than 0")
+
+        result = client.optimize_schedule(
+            algorithm=algorithm,
+            start_date=start_dt,
+            max_hours_per_day=max_hours_per_day,
+            force_override=force_override,
+            task_ids=task_ids,
+            include_all_days=include_all_days,
+        )
+
+        successful = [{"id": t.id, "name": t.name} for t in result.successful_tasks]
+        failed = [
+            {"id": f.task.id, "name": f.task.name, "reason": f.reason}
+            for f in result.failed_tasks
+        ]
+
+        if result.all_failed():
+            message = (
+                f"All {len(failed)} task(s) failed to be scheduled with '{algorithm}'"
+            )
+        elif result.has_failures():
+            message = (
+                f"Optimized {len(successful)} task(s) using '{algorithm}' "
+                f"({len(failed)} could not be scheduled)"
+            )
+        elif len(successful) == 0:
+            message = (
+                "No tasks were optimized "
+                "(all tasks already scheduled, no estimated_duration, "
+                "or all completed)"
+            )
+        else:
+            message = (
+                f"Optimized {len(successful)} task(s) using '{algorithm}' "
+                "(all tasks scheduled)"
+            )
+
+        return {
+            "algorithm": algorithm,
+            "successful_tasks": successful,
+            "failed_tasks": failed,
+            "daily_allocations": {
+                d.isoformat(): hours for d, hours in result.daily_allocations.items()
+            },
+            "summary": {
+                "new_count": result.summary.new_count,
+                "rescheduled_count": result.summary.rescheduled_count,
+                "total_hours": result.summary.total_hours,
+                "deadline_conflicts": result.summary.deadline_conflicts,
+                "days_span": result.summary.days_span,
+                "overloaded_days": [
+                    {"date": d, "hours": h} for d, h in result.summary.overloaded_days
+                ],
+            },
+            "message": message,
+        }
+
+    @mcp.tool()
+    def list_algorithms() -> dict[str, Any]:
+        """List available schedule optimization algorithms.
+
+        Returns metadata for each algorithm so callers can choose one
+        appropriate for their workload.
+
+        Returns:
+            Dict with `algorithms` (list of {name, display_name, description})
+            and `total` count.
+        """
+        metadata = client.get_algorithm_metadata()
+        algorithms = [
+            {"name": name, "display_name": display_name, "description": description}
+            for name, display_name, description in metadata
+        ]
+        return {
+            "algorithms": algorithms,
+            "total": len(algorithms),
+        }

--- a/packages/taskdog-mcp/tests/test_tools.py
+++ b/packages/taskdog-mcp/tests/test_tools.py
@@ -146,6 +146,9 @@ def create_mock_client() -> MagicMock:
     # Query methods
     client.get_tag_statistics = MagicMock()
     client.calculate_statistics = MagicMock()
+    # Optimization methods
+    client.optimize_schedule = MagicMock()
+    client.get_algorithm_metadata = MagicMock()
     # Relationship methods
     client.add_dependency = MagicMock()
     client.remove_dependency = MagicMock()
@@ -1607,3 +1610,254 @@ class TestTaskTagTools:
         delete_tag_fn(tag_name="bug")
 
         client.delete_tag.assert_called_once_with("bug")
+
+
+def _make_optimization_output(
+    successful: list[tuple[int, str]] | None = None,
+    failed: list[tuple[int, str, str]] | None = None,
+) -> Any:
+    """Build an OptimizationOutput with simple test data."""
+    from datetime import date
+
+    from taskdog_core.application.dto.optimization_output import (
+        OptimizationOutput,
+        SchedulingFailure,
+    )
+    from taskdog_core.application.dto.optimization_summary import OptimizationSummary
+    from taskdog_core.application.dto.task_dto import TaskSummaryDto
+
+    successful_tasks = [
+        TaskSummaryDto(id=tid, name=name) for tid, name in successful or []
+    ]
+    failed_tasks = [
+        SchedulingFailure(
+            task=TaskSummaryDto(id=tid, name=name),
+            reason=reason,
+        )
+        for tid, name, reason in failed or []
+    ]
+    return OptimizationOutput(
+        successful_tasks=successful_tasks,
+        failed_tasks=failed_tasks,
+        daily_allocations={date(2025, 12, 15): 6.0, date(2025, 12, 16): 4.0},
+        summary=OptimizationSummary(
+            new_count=len(successful_tasks),
+            rescheduled_count=0,
+            total_hours=10.0,
+            deadline_conflicts=0,
+            days_span=2,
+            unscheduled_tasks=[f.task for f in failed_tasks],
+            overloaded_days=[],
+        ),
+        task_states_before={},
+    )
+
+
+class TestTaskOptimizationTools:
+    """Test task optimization MCP tools."""
+
+    def test_optimize_schedule_returns_formatted_response(self) -> None:
+        """Test optimize_schedule returns successful_tasks, daily_allocations, summary."""
+        from mcp.server.fastmcp import FastMCP
+        from taskdog_mcp.tools import task_optimization
+
+        client = create_mock_client()
+        client.optimize_schedule.return_value = _make_optimization_output(
+            successful=[(1, "Task A"), (2, "Task B")],
+        )
+
+        mcp = FastMCP("test")
+        task_optimization.register_tools(mcp, client)
+
+        optimize_fn = mcp._tool_manager._tools["optimize_schedule"].fn
+        result = optimize_fn(algorithm="greedy", max_hours_per_day=8.0)
+
+        client.optimize_schedule.assert_called_once_with(
+            algorithm="greedy",
+            start_date=None,
+            max_hours_per_day=8.0,
+            force_override=False,
+            task_ids=None,
+            include_all_days=False,
+        )
+        assert result["algorithm"] == "greedy"
+        assert len(result["successful_tasks"]) == 2
+        assert result["successful_tasks"][0] == {"id": 1, "name": "Task A"}
+        assert result["failed_tasks"] == []
+        assert result["daily_allocations"] == {"2025-12-15": 6.0, "2025-12-16": 4.0}
+        assert result["summary"]["new_count"] == 2
+        assert result["summary"]["total_hours"] == 10.0
+        assert result["summary"]["days_span"] == 2
+        assert "Optimized 2 task(s)" in result["message"]
+
+    def test_optimize_schedule_with_failures(self) -> None:
+        """Test optimize_schedule reports partial failures."""
+        from mcp.server.fastmcp import FastMCP
+        from taskdog_mcp.tools import task_optimization
+
+        client = create_mock_client()
+        client.optimize_schedule.return_value = _make_optimization_output(
+            successful=[(1, "Task A")],
+            failed=[(2, "Task B", "deadline too tight")],
+        )
+
+        mcp = FastMCP("test")
+        task_optimization.register_tools(mcp, client)
+
+        optimize_fn = mcp._tool_manager._tools["optimize_schedule"].fn
+        result = optimize_fn(algorithm="balanced", max_hours_per_day=6.0)
+
+        assert len(result["successful_tasks"]) == 1
+        assert result["failed_tasks"] == [
+            {"id": 2, "name": "Task B", "reason": "deadline too tight"}
+        ]
+        assert "1 task(s)" in result["message"]
+        assert "1 could not be scheduled" in result["message"]
+
+    def test_optimize_schedule_all_failed(self) -> None:
+        """Test optimize_schedule when no tasks could be scheduled."""
+        from mcp.server.fastmcp import FastMCP
+        from taskdog_mcp.tools import task_optimization
+
+        client = create_mock_client()
+        client.optimize_schedule.return_value = _make_optimization_output(
+            successful=[],
+            failed=[
+                (1, "Task A", "missing estimated_duration"),
+                (2, "Task B", "circular dependency"),
+            ],
+        )
+
+        mcp = FastMCP("test")
+        task_optimization.register_tools(mcp, client)
+
+        optimize_fn = mcp._tool_manager._tools["optimize_schedule"].fn
+        result = optimize_fn(algorithm="greedy", max_hours_per_day=8.0)
+
+        assert result["successful_tasks"] == []
+        assert len(result["failed_tasks"]) == 2
+        assert "All 2 task(s) failed" in result["message"]
+
+    def test_optimize_schedule_no_tasks(self) -> None:
+        """Test optimize_schedule when there's nothing to optimize."""
+        from mcp.server.fastmcp import FastMCP
+        from taskdog_mcp.tools import task_optimization
+
+        client = create_mock_client()
+        client.optimize_schedule.return_value = _make_optimization_output()
+
+        mcp = FastMCP("test")
+        task_optimization.register_tools(mcp, client)
+
+        optimize_fn = mcp._tool_manager._tools["optimize_schedule"].fn
+        result = optimize_fn(algorithm="greedy", max_hours_per_day=8.0)
+
+        assert result["successful_tasks"] == []
+        assert result["failed_tasks"] == []
+        assert "No tasks were optimized" in result["message"]
+
+    def test_optimize_schedule_passes_all_arguments(self) -> None:
+        """Test optimize_schedule forwards all arguments to the client."""
+        from mcp.server.fastmcp import FastMCP
+        from taskdog_mcp.tools import task_optimization
+
+        client = create_mock_client()
+        client.optimize_schedule.return_value = _make_optimization_output(
+            successful=[(1, "Task A")],
+        )
+
+        mcp = FastMCP("test")
+        task_optimization.register_tools(mcp, client)
+
+        optimize_fn = mcp._tool_manager._tools["optimize_schedule"].fn
+        optimize_fn(
+            algorithm="dependency_aware",
+            max_hours_per_day=4.0,
+            start_date="2025-12-15T09:00:00",
+            task_ids=[1, 2, 3],
+            force_override=True,
+            include_all_days=True,
+        )
+
+        client.optimize_schedule.assert_called_once_with(
+            algorithm="dependency_aware",
+            start_date=datetime(2025, 12, 15, 9, 0, 0),
+            max_hours_per_day=4.0,
+            force_override=True,
+            task_ids=[1, 2, 3],
+            include_all_days=True,
+        )
+
+    @pytest.mark.parametrize(
+        "invalid_date",
+        [
+            pytest.param("not-a-date", id="garbage"),
+            pytest.param("2025-13-01", id="invalid_month"),
+        ],
+    )
+    def test_optimize_schedule_invalid_datetime(self, invalid_date: str) -> None:
+        """Test optimize_schedule raises ValueError for invalid datetime."""
+        from mcp.server.fastmcp import FastMCP
+        from taskdog_mcp.tools import task_optimization
+
+        client = create_mock_client()
+        mcp = FastMCP("test")
+        task_optimization.register_tools(mcp, client)
+
+        optimize_fn = mcp._tool_manager._tools["optimize_schedule"].fn
+
+        with pytest.raises(ValueError, match="Invalid datetime format"):
+            optimize_fn(
+                algorithm="greedy",
+                max_hours_per_day=8.0,
+                start_date=invalid_date,
+            )
+
+    @pytest.mark.parametrize(
+        "invalid_hours",
+        [
+            pytest.param(0, id="zero"),
+            pytest.param(-1.0, id="negative"),
+        ],
+    )
+    def test_optimize_schedule_invalid_max_hours(self, invalid_hours: float) -> None:
+        """Test optimize_schedule rejects non-positive max_hours_per_day."""
+        from mcp.server.fastmcp import FastMCP
+        from taskdog_mcp.tools import task_optimization
+
+        client = create_mock_client()
+        mcp = FastMCP("test")
+        task_optimization.register_tools(mcp, client)
+
+        optimize_fn = mcp._tool_manager._tools["optimize_schedule"].fn
+
+        with pytest.raises(
+            ValueError, match="max_hours_per_day must be greater than 0"
+        ):
+            optimize_fn(algorithm="greedy", max_hours_per_day=invalid_hours)
+
+    def test_list_algorithms_returns_metadata(self) -> None:
+        """Test list_algorithms returns formatted algorithm list."""
+        from mcp.server.fastmcp import FastMCP
+        from taskdog_mcp.tools import task_optimization
+
+        client = create_mock_client()
+        client.get_algorithm_metadata.return_value = [
+            ("greedy", "Greedy", "Front-load tasks by priority"),
+            ("balanced", "Balanced", "Distribute hours evenly across days"),
+        ]
+
+        mcp = FastMCP("test")
+        task_optimization.register_tools(mcp, client)
+
+        list_fn = mcp._tool_manager._tools["list_algorithms"].fn
+        result = list_fn()
+
+        client.get_algorithm_metadata.assert_called_once()
+        assert result["total"] == 2
+        assert len(result["algorithms"]) == 2
+        assert result["algorithms"][0] == {
+            "name": "greedy",
+            "display_name": "Greedy",
+            "description": "Front-load tasks by priority",
+        }


### PR DESCRIPTION
## Summary
- Add `tools/task_optimization.py` exposing two MCP tools that wrap `OptimizeClient`
  - `optimize_schedule(algorithm, max_hours_per_day, start_date?, task_ids?, force_override?, include_all_days?)` — forwards to the existing `/api/v1/optimize` endpoint
  - `list_algorithms()` — returns the 9 strategies from `/api/v1/algorithms` so callers can pick one
- Register the new module in `server.py`
- 9 new unit tests covering success / partial failure / all-failed / no-tasks / full argument forwarding / invalid datetime / invalid max_hours / list_algorithms

Closes #865.

## Why
The schedule optimizer was already exposed via CLI (`taskdog optimize`), TUI, and HTTP API, but Claude Desktop had no way to call it. With this MCP tool, natural-language requests like "明日からのスケジュール最適化して" map directly to `optimize_schedule`.

## Test plan
- [x] `uv run python -m pytest tests/` (84 passed, 9 new)
- [x] `uv run ruff check .` clean
- [x] `uv run mypy src` clean (13 source files)