### PR TITLE
chore(deps): group production dependency updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,19 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      # Group remaining production dependencies (minor/patch) into a single PR
+      production-dependencies:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "pytest*"
+          - "mypy*"
+          - "ruff*"
+          - "coverage*"
+          - "pre-commit*"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "python"


### PR DESCRIPTION
## Summary
- Today we hit 8 separate dependabot PRs that all failed CI on `uv lock --check` and required individual rebase + `uv lock` + push.
- Root cause: only dev dependencies are grouped in `.github/dependabot.yml`. Production dep bumps (minor/patch) each create their own PR, multiplying the toil whenever main moves.
- This PR adds a `production-dependencies` group that bundles minor/patch updates of all non-dev packages into one PR per week. Major bumps still come individually so they get focused review.

## Test plan
- [ ] After merge, wait for the next dependabot weekly run and confirm production dep bumps land as a single PR.
- [ ] Confirm dev-dep grouping is unaffected.
- [ ] Major version bumps still appear as individual PRs.