### PR TITLE
fix: make click.ParamType subclasses compatible with click 8.4

### DIFF
--- a/packages/taskdog-ui/src/taskdog/cli/commands/fix_actual.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/fix_actual.py
@@ -2,22 +2,21 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
 
 import click
 
 from taskdog.cli.error_handler import handle_task_errors
 
 if TYPE_CHECKING:
-    from datetime import datetime
-
     from taskdog.cli.context import CliContext
 
 # Sentinel value for "clear" - distinct from None (not provided)
 CLEAR_SENTINEL = "CLEAR"
 
 
-class ClearableDateTimeType(click.ParamType):
+class ClearableDateTimeType(click.ParamType[datetime | str | None]):
     """DateTime type that treats empty string as 'clear' command.
 
     Requires full datetime input (YYYY-MM-DD HH:MM:SS) for accurate timestamps.
@@ -37,10 +36,10 @@ class ClearableDateTimeType(click.ParamType):
             return None
         if value == "" or value == CLEAR_SENTINEL:
             return CLEAR_SENTINEL
-        return cast("datetime", self._inner.convert(value, param, ctx))
+        return self._inner.convert(value, param, ctx)
 
 
-class ClearableFloatType(click.ParamType):
+class ClearableFloatType(click.ParamType[float | str | None]):
     """Float type that treats empty string as 'clear' command."""
 
     name = "FLOAT"

--- a/packages/taskdog-ui/src/taskdog/shared/click_types/field_list.py
+++ b/packages/taskdog-ui/src/taskdog/shared/click_types/field_list.py
@@ -5,7 +5,7 @@ from typing import Any
 import click
 
 
-class FieldList(click.ParamType):
+class FieldList(click.ParamType[list[str] | None]):
     """Parse comma-separated field list with optional validation.
 
     Accepts a comma-separated string of field names and returns a list of

--- a/packages/taskdog-ui/src/taskdog/shared/click_types/positive_number.py
+++ b/packages/taskdog-ui/src/taskdog/shared/click_types/positive_number.py
@@ -5,7 +5,7 @@ from typing import Any
 import click
 
 
-class PositiveFloat(click.ParamType):
+class PositiveFloat(click.ParamType[float]):
     """A Click parameter type that only accepts positive float values.
 
     This type ensures that the value is:
@@ -50,7 +50,7 @@ class PositiveFloat(click.ParamType):
         return float_value
 
 
-class PositiveInt(click.ParamType):
+class PositiveInt(click.ParamType[int]):
     """A Click parameter type that only accepts positive integer values.
 
     This type ensures that the value is:

--- a/uv.lock
+++ b/uv.lock
@@ -185,14 +185,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.3"
+version = "8.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/e4/796662cd90cf80e3a363c99db2b88e0e394b988a575f60a17e16440cd011/click-8.4.0.tar.gz", hash = "sha256:638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973", size = 350843, upload-time = "2026-05-17T00:47:58.425Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl", hash = "sha256:40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81", size = 116147, upload-time = "2026-05-17T00:47:56.842Z" },
 ]
 
 [[package]]
@@ -1523,7 +1523,7 @@ requires-dist = [
     { name = "taskdog-client", editable = "packages/taskdog-client" },
     { name = "taskdog-core", editable = "packages/taskdog-core" },
     { name = "taskdog-server", marker = "extra == 'server'", editable = "packages/taskdog-server" },
-    { name = "textual", specifier = ">=8.2.6" },
+    { name = "textual", specifier = ">=8.0.0" },
     { name = "websockets", specifier = ">=14.0" },
 ]
 provides-extras = ["dev", "server"]


### PR DESCRIPTION
## Summary

CI on `main` is broken because click 8.4.0 (released 2026-05-17) made `click.ParamType` a generic class. The typecheck job pulls click 8.4.0 fresh (the `uv pip install -e packages/*` step is not `--locked`), while the lockfile still pinned 8.3.3 — causing `Missing type arguments for generic type "ParamType"` errors in 3 files / 6 places.

This PR:

- Adds generic type arguments to all `click.ParamType` subclasses
  - `PositiveFloat` → `ParamType[float]`, `PositiveInt` → `ParamType[int]` (`positive_number.py`)
  - `FieldList` → `ParamType[list[str] | None]` (`field_list.py`)
  - `ClearableDateTimeType` / `ClearableFloatType` → `ParamType[datetime | str | None]` / `ParamType[float | str | None]` (`fix_actual.py`)
- Removes the now-redundant `cast("datetime", ...)` since `click.DateTime.convert` is typed as `-> datetime` in 8.4
- Moves `datetime` from `TYPE_CHECKING` to a runtime import in `fix_actual.py` (class-base generic args are evaluated at class-definition time; `from __future__ import annotations` does not defer them)
- Bumps `click` 8.3.3 → 8.4.0 in `uv.lock` so runtime and typecheck use the same version (also fixes a pre-existing `requires-dist` drift in `uv.lock` for `textual` that was failing `uv lock --check`)

Follow-up worth doing in a separate PR: the typecheck CI job runs `uv pip install -e packages/*` without `--locked` after `uv sync --all-extras --dev`, which is what allowed an unreleased-at-lock-time click 8.4.0 to leak in. Those editable installs look redundant under a UV workspace.

## Test plan

- [x] `make check` (lint + typecheck) passes locally with click 8.4.0 installed
- [x] `make test` passes locally (942 tests in taskdog-ui, all packages green)
- [x] `uv lock --check` passes
- [x] CLI smoke test: `fix-actual --help`, `add --help` render correctly
- [ ] CI on this PR passes (Type Check + Lint + all Test/Build matrix)