### PR TITLE
chore: sync uv.lock requires-dist with pyproject specifiers

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1375,7 +1375,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.14" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "taskdog-core", editable = "packages/taskdog-core" },
     { name = "websockets", specifier = ">=14.0" },
 ]
@@ -1406,7 +1406,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.14" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
 ]
 provides-extras = ["dev"]
@@ -1437,7 +1437,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.14" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "taskdog-client", editable = "packages/taskdog-client" },
     { name = "taskdog-core", editable = "packages/taskdog-core" },
 ]
@@ -1473,7 +1473,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.14" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "taskdog-core", editable = "packages/taskdog-core" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.47.0" },
 ]
@@ -1514,11 +1514,11 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "python-dateutil", specifier = ">=2.8.0" },
     { name = "rich", specifier = ">=14.2.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.14" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "taskdog-client", editable = "packages/taskdog-client" },
     { name = "taskdog-core", editable = "packages/taskdog-core" },
     { name = "taskdog-server", marker = "extra == 'server'", editable = "packages/taskdog-server" },
-    { name = "textual", specifier = ">=8.2.7" },
+    { name = "textual", specifier = ">=8.0.0" },
     { name = "websockets", specifier = ">=14.0" },
 ]
 provides-extras = ["dev", "server"]


### PR DESCRIPTION
## Summary

Fixes the `uv lock --check` failure in CI (the `Lint` job).

The committed `uv.lock` recorded stale `requires-dist` specifiers that no longer matched the package `pyproject.toml` files:

- `ruff`: lock had `>=0.15.14`, pyproject has `>=0.7.0`
- `textual`: lock had `>=8.2.7`, pyproject has `>=8.0.0`

`uv lock --check` therefore reported the lockfile as out of date on every new PR. Running `uv lock` realigns the recorded metadata with the actual `pyproject.toml` specifiers.

## Notes

- **No resolved package versions change** — this is a metadata-only sync (6 changed lines).
- Verified locally: `uv lock --check` passes after the change.