### PR TITLE
chore(deps): bump uvicorn[standard] to >=0.48.0

### DIFF
--- a/packages/taskdog-server/pyproject.toml
+++ b/packages/taskdog-server/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dependencies = [
     "taskdog-core==0.19.0",
     "fastapi>=0.115.0",
-    "uvicorn[standard]>=0.47.0",
+    "uvicorn[standard]>=0.48.0",
     "pydantic>=2.10.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1475,7 +1475,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "taskdog-core", editable = "packages/taskdog-core" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.47.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.48.0" },
 ]
 provides-extras = ["dev"]
 
@@ -1607,15 +1607,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.47.0"
+version = "0.48.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/b1/8e7077a8641086aea449e1b5752a570f1b5906c64e0a33cd6d93b63a066b/uvicorn-0.47.0.tar.gz", hash = "sha256:7c9a0ea1a9414106bbab7324609c162d8fa0cdcdcb703060987269d77c7bb533", size = 90582, upload-time = "2026-05-14T18:16:54.455Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a6077343a576f9844f7f8f06ab819aefd00206e9255f18/uvicorn-0.48.0.tar.gz", hash = "sha256:a5504207195d08c2511bf9125ede5ac4a4b71725d519e758d01dcf0bc2d31c37", size = 91074, upload-time = "2026-05-24T12:08:41.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/41/ac2dfdbc1f60c7af4f994c7a335cfa7040c01642b605d65f611cecc2a1e4/uvicorn-0.47.0-py3-none-any.whl", hash = "sha256:2c5715bc12d1892d84752049f400cd1c3cb018514967fdfeb97640443a6a9432", size = 71301, upload-time = "2026-05-14T18:16:51.762Z" },
+    { url = "https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad", size = 71410, upload-time = "2026-05-24T12:08:40.258Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Supersedes #909 with a consistent change.

The original dependabot PR (#909) only updated `uv.lock` (uvicorn `0.47.0` → `0.48.0` and the recorded `requires-dist` specifier), but left `packages/taskdog-server/pyproject.toml` at `uvicorn[standard]>=0.47.0`. That left the lockfile inconsistent with the project metadata, so `uv lock --check` (the `Lint` job) failed.

This PR bumps the `pyproject.toml` constraint to `>=0.48.0` and regenerates `uv.lock` so the two stay in sync.

## Changes

- `packages/taskdog-server/pyproject.toml`: `uvicorn[standard]>=0.47.0` → `>=0.48.0`
- `uv.lock`: uvicorn `0.47.0` → `0.48.0` (regenerated)

## Verification

- `uv lock --check`: passes
- `taskdog-server` test suite: 309 passed

Closes #909