### PR TITLE
refactor: adopt PEP 695 generics, drop standalone TypeVar boilerplate

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/controllers/task_lifecycle_controller.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/task_lifecycle_controller.py
@@ -29,7 +29,7 @@ from taskdog_core.controllers.base_controller import BaseTaskController
 from taskdog_core.domain.repositories.task_repository import TaskRepository
 
 # Type alias for use case factory function
-StatusChangeUseCaseFactory = Callable[
+type StatusChangeUseCaseFactory = Callable[
     [TaskRepository], StatusChangeUseCase[SingleTaskInput]
 ]
 

--- a/packages/taskdog-server/src/taskdog_server/api/error_handlers.py
+++ b/packages/taskdog-server/src/taskdog_server/api/error_handlers.py
@@ -5,7 +5,7 @@ Provides reusable decorators for common error handling patterns in API endpoints
 
 from collections.abc import Callable
 from functools import wraps
-from typing import Any, TypeVar
+from typing import Any
 
 from fastapi import HTTPException, status
 
@@ -17,11 +17,8 @@ from taskdog_core.domain.exceptions.task_exceptions import (
     TaskValidationError,
 )
 
-# Type variable for generic decorator
-F = TypeVar("F", bound=Callable[..., Any])
 
-
-def handle_task_errors(func: F) -> F:
+def handle_task_errors[F: Callable[..., Any]](func: F) -> F:
     """Decorator for common task operation error handling.
 
     Catches domain exceptions and converts them to appropriate HTTP exceptions:

--- a/packages/taskdog-ui/src/taskdog/cli/error_handler.py
+++ b/packages/taskdog-ui/src/taskdog/cli/error_handler.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import wraps
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import click
 
@@ -17,10 +17,8 @@ from taskdog_core.domain.exceptions.task_exceptions import (
     TaskNotFoundException,
 )
 
-F = TypeVar("F", bound=Callable[..., Any])
 
-
-def handle_task_errors(action_name: str) -> Callable[[F], F]:
+def handle_task_errors[F: Callable[..., Any]](action_name: str) -> Callable[[F], F]:
     """Decorator for task-specific error handling in CLI commands.
 
     Use this for commands that operate on specific task IDs (add, update, remove).
@@ -60,7 +58,7 @@ def handle_task_errors(action_name: str) -> Callable[[F], F]:
     return decorator
 
 
-def handle_command_errors(action_name: str) -> Callable[[F], F]:
+def handle_command_errors[F: Callable[..., Any]](action_name: str) -> Callable[[F], F]:
     """Decorator for general command error handling.
 
     Use this for commands that don't operate on specific task IDs (tree, table, gantt, today).

--- a/packages/taskdog-ui/src/taskdog/tui/commands/base.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/base.py
@@ -2,7 +2,7 @@
 
 from abc import ABC
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from taskdog.tui.context import TUIContext
 from taskdog.tui.events import TasksRefreshed
@@ -10,8 +10,6 @@ from taskdog_core.domain.exceptions.task_exceptions import TaskError
 
 if TYPE_CHECKING:
     from taskdog.tui.app import TaskdogTUI
-
-F = TypeVar("F", bound=Callable[..., Any])
 
 
 class TUICommandBase(ABC):  # noqa: B024
@@ -66,7 +64,7 @@ class TUICommandBase(ABC):  # noqa: B024
         # Default: no-op
         # Subclasses should override this method
 
-    def handle_error(self, callback_fn: F) -> F:
+    def handle_error[F: Callable[..., Any]](self, callback_fn: F) -> F:
         """Wrap a callback function with error handling.
 
         This is useful for dialog callbacks or async operations where

--- a/packages/taskdog-ui/src/taskdog/tui/commands/decorators.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/decorators.py
@@ -2,9 +2,7 @@
 
 from collections.abc import Callable
 from functools import wraps
-from typing import Any, TypeVar, cast
-
-F = TypeVar("F", bound=Callable[..., Any])
+from typing import Any, cast
 
 
 def require_selected_task[F: Callable[..., Any]](func: F) -> F:

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/base_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/base_dialog.py
@@ -1,7 +1,7 @@
 """Base dialog class for TUI modal screens."""
 
 from abc import abstractmethod
-from typing import Any, ClassVar, TypeVar
+from typing import Any, ClassVar
 
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -10,11 +10,8 @@ from textual.screen import ModalScreen
 from textual.validation import Validator
 from textual.widgets import Input, Static
 
-T = TypeVar("T")
-V = TypeVar("V", bound=Validator)
 
-
-class BaseModalDialog(ModalScreen[T]):
+class BaseModalDialog[T](ModalScreen[T]):
     """Base class for modal dialog screens.
 
     Provides common functionality:
@@ -71,7 +68,9 @@ class BaseModalDialog(ModalScreen[T]):
             # If error-message widget doesn't exist, skip error clearing
             pass
 
-    def _get_validator(self, input_widget: Input, validator_type: type[V]) -> V:
+    def _get_validator[V: Validator](
+        self, input_widget: Input, validator_type: type[V]
+    ) -> V:
         """Get a validator of a specific type from an Input widget.
 
         Args:

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/form_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/form_dialog.py
@@ -1,17 +1,15 @@
 """Base class for form dialogs with standard navigation."""
 
 from abc import abstractmethod
-from typing import ClassVar, TypeVar
+from typing import ClassVar
 
 from textual.binding import Binding
 from textual.widgets import Input
 
 from taskdog.tui.dialogs.base_dialog import BaseModalDialog
 
-T = TypeVar("T")
 
-
-class FormDialogBase(BaseModalDialog[T]):
+class FormDialogBase[T](BaseModalDialog[T]):
     """Base class for form dialogs with standard navigation.
 
     Provides:

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/scrollable_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/scrollable_dialog.py
@@ -1,7 +1,7 @@
 """Base class for scrollable dialogs with Vi navigation."""
 
 from abc import abstractmethod
-from typing import ClassVar, TypeVar
+from typing import ClassVar
 
 from textual.binding import Binding
 from textual.containers import VerticalScroll
@@ -10,10 +10,8 @@ from textual.css.query import NoMatches
 from taskdog.tui.dialogs.base_dialog import BaseModalDialog
 from taskdog.tui.widgets.vi_navigation_mixin import ViNavigationMixin
 
-T = TypeVar("T")
 
-
-class ScrollableDialogBase(BaseModalDialog[T], ViNavigationMixin):
+class ScrollableDialogBase[T](BaseModalDialog[T], ViNavigationMixin):
     """Base class for scrollable read-only dialogs with Vi navigation.
 
     Provides:

--- a/packages/taskdog-ui/src/taskdog/utils/note_editor.py
+++ b/packages/taskdog-ui/src/taskdog/utils/note_editor.py
@@ -11,7 +11,7 @@ from taskdog.utils.editor import get_editor
 from taskdog.utils.notes_template import get_note_template
 from taskdog_core.application.dto.task_dto import TaskDetailDto
 
-EditorRunner = Callable[[str, Path], None]
+type EditorRunner = Callable[[str, Path], None]
 
 
 class NotesProvider(Protocol):


### PR DESCRIPTION
## Summary

Now that the project requires Python 3.12+, this replaces module-level `TypeVar` boilerplate with PEP 695 inline type parameters, and the two `Callable` type aliases with the `type` statement. The codebase already used PEP 695 in a few spots (`tui/commands/decorators.py`, `datetime_parser.py`); this makes it consistent.

## Changes

- **Decorators** (`server/api/error_handlers.py`, `cli/error_handler.py`, `tui/commands/base.py`): `F = TypeVar("F", bound=Callable[..., Any])` → inline `[F: Callable[..., Any]]` on each function/method.
- **Generic dialog base classes** (`tui/dialogs/base_dialog.py`, `form_dialog.py`, `scrollable_dialog.py`): `T = TypeVar("T")` → `class X[T](...)`; the `_get_validator` method gets an inline `[V: Validator]`.
- **Dead code** (`tui/commands/decorators.py`): removed a module-level `TypeVar` already superseded by an inline `[F]` parameter.
- **Type aliases** (`controllers/task_lifecycle_controller.py`, `utils/note_editor.py`): `X = Callable[...]` → `type X = Callable[...]`.

`shared/config_loader.py` is intentionally left unchanged: its `TypeVar` is shared across three `@overload` signatures, where a single module-level declaration reads better than repeating the constraint on each.

Net: -14 lines, no behavior change.

## Verification

- `make typecheck`: pass (all 5 packages)
- `make lint`: pass
- `make test`: pass