### PR TITLE
refactor(server): centralize domain exception handling via app-level handlers

### DIFF
--- a/packages/taskdog-server/src/taskdog_server/api/app.py
+++ b/packages/taskdog-server/src/taskdog_server/api/app.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from taskdog_core.shared.config_manager import ConfigManager
 from taskdog_server import __version__
 from taskdog_server.api.dependencies import initialize_api_context
+from taskdog_server.api.error_handlers import register_exception_handlers
 from taskdog_server.api.middleware import LoggingMiddleware
 from taskdog_server.api.routers import (
     analytics_router,
@@ -69,6 +70,9 @@ def create_app() -> FastAPI:
 
     # Add logging middleware (should be first to log all requests)
     app.add_middleware(LoggingMiddleware)
+
+    # Translate domain exceptions to HTTP responses app-wide
+    register_exception_handlers(app)
 
     # Register routers
     app.include_router(bulk_router, prefix="/api/v1/tasks", tags=["bulk"])

--- a/packages/taskdog-server/src/taskdog_server/api/error_handlers.py
+++ b/packages/taskdog-server/src/taskdog_server/api/error_handlers.py
@@ -1,59 +1,47 @@
-"""FastAPI error handling decorators.
+"""FastAPI exception handlers.
 
-Provides reusable decorators for common error handling patterns in API endpoints.
+Registers application-wide handlers that translate domain exceptions into
+appropriate HTTP responses, so individual endpoints don't need to repeat
+try/except blocks.
 """
 
-from collections.abc import Callable
-from functools import wraps
-from typing import Any
-
-from fastapi import HTTPException, status
+from fastapi import FastAPI, Request, status
+from fastapi.responses import JSONResponse
 
 from taskdog_core.domain.exceptions.tag_exceptions import TagNotFoundException
 from taskdog_core.domain.exceptions.task_exceptions import (
-    TaskAlreadyFinishedError,
     TaskNotFoundException,
-    TaskNotStartedError,
     TaskValidationError,
 )
 
 
-def handle_task_errors[F: Callable[..., Any]](func: F) -> F:
-    """Decorator for common task operation error handling.
+async def _not_found_handler(_request: Request, exc: Exception) -> JSONResponse:
+    """Map not-found domain exceptions to 404 NOT_FOUND."""
+    return JSONResponse(
+        status_code=status.HTTP_404_NOT_FOUND, content={"detail": str(exc)}
+    )
 
-    Catches domain exceptions and converts them to appropriate HTTP exceptions:
-    - TaskNotFoundException → 404 NOT_FOUND
-    - TaskValidationError, TaskAlreadyFinishedError, TaskNotStartedError → 400 BAD_REQUEST
 
-    Usage:
-        @router.post("/{task_id}/start")
-        @handle_task_errors
-        async def start_task(task_id: int, ...):
-            result = controller.start_task(task_id)
-            return convert_to_response(result)
+async def _bad_request_handler(_request: Request, exc: Exception) -> JSONResponse:
+    """Map validation domain exceptions to 400 BAD_REQUEST."""
+    return JSONResponse(
+        status_code=status.HTTP_400_BAD_REQUEST, content={"detail": str(exc)}
+    )
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    """Register domain exception handlers on the FastAPI app.
+
+    - TaskNotFoundException, TagNotFoundException -> 404 NOT_FOUND
+    - TaskValidationError (and subclasses) -> 400 BAD_REQUEST
+
+    Starlette resolves handlers by walking the exception's MRO, so registering
+    TaskValidationError also covers TaskAlreadyFinishedError, TaskNotStartedError,
+    and the other validation subclasses.
 
     Args:
-        func: Async function to wrap with error handling
-
-    Returns:
-        Wrapped function with automatic error handling
+        app: FastAPI application instance
     """
-
-    @wraps(func)
-    async def wrapper(*args: Any, **kwargs: Any) -> Any:
-        try:
-            return await func(*args, **kwargs)
-        except (TaskNotFoundException, TagNotFoundException) as e:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail=str(e)
-            ) from e
-        except (
-            TaskValidationError,
-            TaskAlreadyFinishedError,
-            TaskNotStartedError,
-        ) as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
-            ) from e
-
-    return wrapper  # type: ignore[return-value]
+    app.add_exception_handler(TaskNotFoundException, _not_found_handler)
+    app.add_exception_handler(TagNotFoundException, _not_found_handler)
+    app.add_exception_handler(TaskValidationError, _bad_request_handler)

--- a/packages/taskdog-server/src/taskdog_server/api/routers/lifecycle.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/lifecycle.py
@@ -11,7 +11,6 @@ from taskdog_server.api.dependencies import (
     LifecycleControllerDep,
     QueryControllerDep,
 )
-from taskdog_server.api.error_handlers import handle_task_errors
 from taskdog_server.api.models.requests import FixActualTimesRequest
 from taskdog_server.api.models.responses import TaskOperationResponse
 
@@ -44,7 +43,6 @@ def _create_lifecycle_endpoint(op: LifecycleOperation) -> None:
     """
 
     @router.post(f"/{{task_id}}/{op.name}", response_model=TaskOperationResponse)
-    @handle_task_errors
     async def endpoint(
         task_id: int,
         controller: LifecycleControllerDep,
@@ -79,7 +77,6 @@ for _op in OPERATIONS:
 
 
 @router.post("/{task_id}/fix-actual", response_model=TaskOperationResponse)
-@handle_task_errors
 async def fix_actual_times(
     task_id: int,
     request: FixActualTimesRequest,

--- a/packages/taskdog-server/src/taskdog_server/api/routers/notes.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/notes.py
@@ -8,7 +8,6 @@ from taskdog_server.api.dependencies import (
     EventBroadcasterDep,
     NotesControllerDep,
 )
-from taskdog_server.api.error_handlers import handle_task_errors
 from taskdog_server.api.models.requests import UpdateNotesRequest
 from taskdog_server.api.models.responses import NotesResponse
 
@@ -16,7 +15,6 @@ router = APIRouter()
 
 
 @router.get("/{task_id}/notes", response_model=NotesResponse)
-@handle_task_errors
 async def get_task_notes(
     task_id: int,
     controller: NotesControllerDep,
@@ -41,7 +39,6 @@ async def get_task_notes(
 
 
 @router.put("/{task_id}/notes", response_model=NotesResponse)
-@handle_task_errors
 async def update_task_notes(
     task_id: int,
     request: UpdateNotesRequest,
@@ -87,7 +84,6 @@ async def update_task_notes(
 
 
 @router.delete("/{task_id}/notes", status_code=status.HTTP_204_NO_CONTENT)
-@handle_task_errors
 async def delete_task_notes(
     task_id: int,
     controller: NotesControllerDep,

--- a/packages/taskdog-server/src/taskdog_server/api/routers/relationships.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/relationships.py
@@ -8,7 +8,6 @@ from taskdog_server.api.dependencies import (
     EventBroadcasterDep,
     RelationshipControllerDep,
 )
-from taskdog_server.api.error_handlers import handle_task_errors
 from taskdog_server.api.models.requests import (
     AddDependencyRequest,
     SetTaskTagsRequest,
@@ -19,7 +18,6 @@ router = APIRouter()
 
 
 @router.post("/{task_id}/dependencies", response_model=TaskOperationResponse)
-@handle_task_errors
 async def add_dependency(
     task_id: int,
     request: AddDependencyRequest,
@@ -66,7 +64,6 @@ async def add_dependency(
 @router.delete(
     "/{task_id}/dependencies/{depends_on_id}", response_model=TaskOperationResponse
 )
-@handle_task_errors
 async def remove_dependency(
     task_id: int,
     depends_on_id: int,
@@ -111,7 +108,6 @@ async def remove_dependency(
 
 
 @router.put("/{task_id}/tags", response_model=TaskOperationResponse)
-@handle_task_errors
 async def set_task_tags(
     task_id: int,
     request: SetTaskTagsRequest,

--- a/packages/taskdog-server/src/taskdog_server/api/routers/tags.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/tags.py
@@ -7,14 +7,12 @@ from taskdog_server.api.dependencies import (
     AuthenticatedClientDep,
     RelationshipControllerDep,
 )
-from taskdog_server.api.error_handlers import handle_task_errors
 from taskdog_server.api.models.responses import DeleteTagResponse
 
 router = APIRouter()
 
 
 @router.delete("/{tag_name}", response_model=DeleteTagResponse)
-@handle_task_errors
 async def delete_tag(
     tag_name: str,
     controller: RelationshipControllerDep,

--- a/packages/taskdog-server/src/taskdog_server/api/routers/tasks.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/tasks.py
@@ -19,7 +19,6 @@ from taskdog_server.api.dependencies import (
     HolidayCheckerDep,
     QueryControllerDep,
 )
-from taskdog_server.api.error_handlers import handle_task_errors
 from taskdog_server.api.models.requests import CreateTaskRequest, UpdateTaskRequest
 from taskdog_server.api.models.responses import (
     TaskDetailResponse,
@@ -51,7 +50,6 @@ def _serialize_audit_value(val: object) -> object:
 @router.post(
     "", response_model=TaskOperationResponse, status_code=status.HTTP_201_CREATED
 )
-@handle_task_errors
 async def create_task(
     request: CreateTaskRequest,
     controller: CrudControllerDep,
@@ -182,7 +180,6 @@ async def list_tasks(
 
 
 @router.get("/{task_id}", response_model=TaskDetailResponse)
-@handle_task_errors
 async def get_task(
     task_id: int,
     controller: QueryControllerDep,
@@ -205,7 +202,6 @@ async def get_task(
 
 
 @router.patch("/{task_id}", response_model=UpdateTaskResponse)
-@handle_task_errors
 async def update_task(
     task_id: int,
     request: UpdateTaskRequest,
@@ -281,7 +277,6 @@ async def update_task(
 
 
 @router.post("/{task_id}/archive", response_model=TaskOperationResponse)
-@handle_task_errors
 async def archive_task(
     task_id: int,
     controller: CrudControllerDep,
@@ -325,7 +320,6 @@ async def archive_task(
 
 
 @router.post("/{task_id}/restore", response_model=TaskOperationResponse)
-@handle_task_errors
 async def restore_task(
     task_id: int,
     controller: CrudControllerDep,
@@ -369,7 +363,6 @@ async def restore_task(
 
 
 @router.delete("/{task_id}")
-@handle_task_errors
 async def delete_task(
     task_id: int,
     controller: CrudControllerDep,

--- a/packages/taskdog-server/tests/conftest.py
+++ b/packages/taskdog-server/tests/conftest.py
@@ -251,6 +251,11 @@ def app(
     test_app.state.server_config = server_config
     test_app.state.connection_manager = ConnectionManager()
 
+    # Mirror production app: translate domain exceptions to HTTP responses
+    from taskdog_server.api.error_handlers import register_exception_handlers
+
+    register_exception_handlers(test_app)
+
     # Import and register all routers
     from taskdog_server.api.routers import (
         analytics_router,


### PR DESCRIPTION
## Summary

Replaces the per-endpoint `@handle_task_errors` decorator (16 usages across 5 routers) with FastAPI exception handlers registered once on the app, using a standard FastAPI feature instead of hand-rolled per-endpoint try/except wrapping.

Domain exceptions are now translated app-wide in `error_handlers.register_exception_handlers`:

- `TaskNotFoundException`, `TagNotFoundException` → 404
- `TaskValidationError` (and subclasses) → 400

Registering the `TaskValidationError` base covers all validation subclasses (`TaskAlreadyFinishedError`, `TaskNotStartedError`, `DependencyNotMetError`, etc.) via Starlette's MRO-based handler lookup, so the existing status mapping is preserved exactly.

## Why

- Removes 16 decorator applications and the `@wraps`/`# type: ignore[return-value]` machinery.
- The decorator previously sat on top of endpoint signatures; app-level handlers are the idiomatic FastAPI approach and keep endpoint signatures clean for DI/OpenAPI introspection.

## Changes

- `error_handlers.py`: decorator → `register_exception_handlers(app)`.
- `app.py`: register handlers in `create_app`.
- Routers (`tasks`, `lifecycle`, `relationships`, `notes`, `tags`): drop decorator + import.
- `tests/conftest.py`: test app fixture registers the same handlers to mirror production.

## Verification

- `make test-server`: 309 passed (unchanged).
- `ruff check`, `mypy`, `pre-commit`: all pass.

Behavior-preserving refactor; no API contract change.