### PR TITLE
refactor(core): drop unused time/file-size constants

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/domain/constants.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/constants.py
@@ -6,18 +6,8 @@ of infrastructure, presentation, or shared utilities.
 """
 
 # Physical constants - Time conversions
-SECONDS_PER_MINUTE = 60
-"""Number of seconds in one minute (physical constant)."""
-
 SECONDS_PER_HOUR = 3600
 """Number of seconds in one hour (physical constant)."""
-
-SECONDS_PER_DAY = 86400
-"""Number of seconds in one day (24 hours * 3600 seconds)."""
-
-# File size validation
-MIN_FILE_SIZE_FOR_CONTENT = 0
-"""Minimum file size in bytes to consider a file as having content."""
 
 # Validation limits - Business rules
 MIN_PRIORITY_EXCLUSIVE = 0

--- a/packages/taskdog-core/src/taskdog_core/shared/constants/time.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/constants/time.py
@@ -1,7 +1,7 @@
 """Time and duration-related constants.
 
-Note: Physical constants SECONDS_PER_HOUR and MIN_FILE_SIZE_FOR_CONTENT
-have been moved to domain.constants to comply with Clean Architecture principles.
+Note: The physical constant SECONDS_PER_HOUR has been moved to
+domain.constants to comply with Clean Architecture principles.
 """
 
 # Calendar


### PR DESCRIPTION
## Summary

Continuing the small, safe cleanup pass. `domain/constants.py` declared three constants that are never referenced anywhere in the codebase (src or tests):

- `SECONDS_PER_MINUTE`
- `SECONDS_PER_DAY`
- `MIN_FILE_SIZE_FOR_CONTENT`

Remove them. `SECONDS_PER_HOUR` (still used in 3 places) is kept. The stale "moved to domain.constants" note in `shared/constants/time.py` is updated to drop the reference to the now-deleted `MIN_FILE_SIZE_FOR_CONTENT`.

## Verification

- `grep` across `packages/*/src` and `packages/*/tests` confirms zero references to the three deleted constants
- `ruff check` passes
- `taskdog-core` test suite: 1114 passed

## Note

This was the only genuine dead code found in a sweep of taskdog-core / client / mcp. Two larger candidates an automated pass flagged (`parse_date_set`, `parse_time_value`) turned out to be live cross-package (used by taskdog-client and taskdog-ui respectively) and were left untouched.