### PR TITLE
refactor(mcp): centralize task response serialization helpers

### DIFF
--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/serializers.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/serializers.py
@@ -1,0 +1,29 @@
+"""Shared serialization helpers for MCP tool responses."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+
+def iso(dt: datetime | None) -> str | None:
+    """ISO-format a datetime, or None."""
+    return dt.isoformat() if dt else None
+
+
+def str_list(values: Any) -> list[Any]:
+    """Coerce an optional iterable to a list (empty when falsy)."""
+    return list(values) if values else []
+
+
+def task_result(task: Any, message: str, **extra: Any) -> dict[str, Any]:
+    """Standard mutation result: id, name, status, then extras and message."""
+    return {
+        "id": task.id,
+        "name": task.name,
+        "status": task.status.value,
+        **extra,
+        "message": message,
+    }

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_crud.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_crud.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from taskdog_mcp.tools.serializers import iso, str_list, task_result
+
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
     from taskdog_client import TaskdogApiClient
@@ -55,8 +57,8 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
                     "name": t.name,
                     "status": t.status.value,
                     "priority": t.priority,
-                    "deadline": t.deadline.isoformat() if t.deadline else None,
-                    "tags": list(t.tags) if t.tags else [],
+                    "deadline": iso(t.deadline),
+                    "tags": str_list(t.tags),
                     "estimated_duration": t.estimated_duration,
                     "is_archived": t.is_archived,
                 }
@@ -82,15 +84,13 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
             "name": task.name,
             "status": task.status.value,
             "priority": task.priority,
-            "deadline": task.deadline.isoformat() if task.deadline else None,
-            "planned_start": task.planned_start.isoformat()
-            if task.planned_start
-            else None,
-            "planned_end": task.planned_end.isoformat() if task.planned_end else None,
+            "deadline": iso(task.deadline),
+            "planned_start": iso(task.planned_start),
+            "planned_end": iso(task.planned_end),
             "estimated_duration": task.estimated_duration,
             "actual_duration_hours": task.actual_duration_hours,
-            "tags": list(task.tags) if task.tags else [],
-            "depends_on": list(task.depends_on) if task.depends_on else [],
+            "tags": str_list(task.tags),
+            "depends_on": str_list(task.depends_on),
             "is_fixed": task.is_fixed,
             "is_archived": task.is_archived,
             "notes": result.notes_content,
@@ -146,13 +146,11 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
             planned_start=planned_start_dt,
             planned_end=planned_end_dt,
         )
-        return {
-            "id": result.id,
-            "name": result.name,
-            "status": result.status.value,
-            "priority": result.priority,
-            "message": f"Task '{result.name}' created successfully",
-        }
+        return task_result(
+            result,
+            f"Task '{result.name}' created successfully",
+            priority=result.priority,
+        )
 
     @mcp.tool()
     def update_task(
@@ -209,13 +207,11 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
         )
         # TaskUpdateOutput has .task (TaskOperationOutput) and .updated_fields
         task = result.task
-        return {
-            "id": task.id,
-            "name": task.name,
-            "status": task.status.value,
-            "priority": task.priority,
-            "message": f"Task '{task.name}' updated successfully",
-        }
+        return task_result(
+            task,
+            f"Task '{task.name}' updated successfully",
+            priority=task.priority,
+        )
 
     @mcp.tool()
     def delete_task(task_id: int, hard: bool = False) -> dict[str, Any]:
@@ -248,9 +244,4 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
             Restored task data
         """
         result = client.restore_task(task_id)
-        return {
-            "id": result.id,
-            "name": result.name,
-            "status": result.status.value,
-            "message": f"Task '{result.name}' restored",
-        }
+        return task_result(result, f"Task '{result.name}' restored")

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_decomposition.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_decomposition.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from taskdog_mcp.tools.serializers import str_list
+
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
     from taskdog_client import TaskdogApiClient
@@ -108,7 +110,7 @@ def register_decomposition_tools(mcp: FastMCP, client: TaskdogApiClient) -> None
         original = client.get_task_detail(task_id)
         # TaskDetailOutput has .task (TaskDetailDto)
         original_task = original.task
-        original_tags = list(original_task.tags) if original_task.tags else []
+        original_tags = str_list(original_task.tags)
 
         created_subtasks: list[dict[str, Any]] = []
         errors: list[dict[str, Any]] = []
@@ -202,7 +204,7 @@ def register_relationship_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
         return {
             "id": result.id,
             "name": result.name,
-            "depends_on": list(result.depends_on) if result.depends_on else [],
+            "depends_on": str_list(result.depends_on),
             "message": f"Task {task_id} now depends on task {depends_on_id}",
         }
 
@@ -221,7 +223,7 @@ def register_relationship_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
         return {
             "id": result.id,
             "name": result.name,
-            "depends_on": list(result.depends_on) if result.depends_on else [],
+            "depends_on": str_list(result.depends_on),
             "message": f"Removed dependency: task {task_id} no longer depends on task {depends_on_id}",
         }
 
@@ -240,7 +242,7 @@ def register_relationship_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
         return {
             "id": result.id,
             "name": result.name,
-            "tags": list(result.tags) if result.tags else [],
+            "tags": str_list(result.tags),
             "message": f"Tags updated for task '{result.name}'",
         }
 

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_lifecycle.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_lifecycle.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from taskdog_mcp.tools.serializers import iso, task_result
+
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
     from taskdog_client import TaskdogApiClient
@@ -34,15 +36,11 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
             Updated task data with status change confirmation
         """
         result = client.start_task(task_id)
-        return {
-            "id": result.id,
-            "name": result.name,
-            "status": result.status.value,
-            "actual_start": result.actual_start.isoformat()
-            if result.actual_start
-            else None,
-            "message": f"Task '{result.name}' started",
-        }
+        return task_result(
+            result,
+            f"Task '{result.name}' started",
+            actual_start=iso(result.actual_start),
+        )
 
     @mcp.tool()
     def complete_task(task_id: int) -> dict[str, Any]:
@@ -57,14 +55,12 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
             Updated task data with completion confirmation
         """
         result = client.complete_task(task_id)
-        return {
-            "id": result.id,
-            "name": result.name,
-            "status": result.status.value,
-            "actual_end": result.actual_end.isoformat() if result.actual_end else None,
-            "actual_duration_hours": result.actual_duration_hours,
-            "message": f"Task '{result.name}' completed",
-        }
+        return task_result(
+            result,
+            f"Task '{result.name}' completed",
+            actual_end=iso(result.actual_end),
+            actual_duration_hours=result.actual_duration_hours,
+        )
 
     @mcp.tool()
     def pause_task(task_id: int) -> dict[str, Any]:
@@ -79,12 +75,7 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
             Updated task data
         """
         result = client.pause_task(task_id)
-        return {
-            "id": result.id,
-            "name": result.name,
-            "status": result.status.value,
-            "message": f"Task '{result.name}' paused",
-        }
+        return task_result(result, f"Task '{result.name}' paused")
 
     @mcp.tool()
     def cancel_task(task_id: int) -> dict[str, Any]:
@@ -99,12 +90,7 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
             Updated task data
         """
         result = client.cancel_task(task_id)
-        return {
-            "id": result.id,
-            "name": result.name,
-            "status": result.status.value,
-            "message": f"Task '{result.name}' canceled",
-        }
+        return task_result(result, f"Task '{result.name}' canceled")
 
     @mcp.tool()
     def reopen_task(task_id: int) -> dict[str, Any]:
@@ -119,12 +105,7 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
             Updated task data
         """
         result = client.reopen_task(task_id)
-        return {
-            "id": result.id,
-            "name": result.name,
-            "status": result.status.value,
-            "message": f"Task '{result.name}' reopened",
-        }
+        return task_result(result, f"Task '{result.name}' reopened")
 
     @mcp.tool()
     def fix_actual_times(
@@ -171,14 +152,10 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
             clear_duration=clear_duration,
         )
 
-        return {
-            "id": result.id,
-            "name": result.name,
-            "status": result.status.value,
-            "actual_start": result.actual_start.isoformat()
-            if result.actual_start
-            else None,
-            "actual_end": result.actual_end.isoformat() if result.actual_end else None,
-            "actual_duration_hours": result.actual_duration_hours,
-            "message": f"Fixed actual times for task '{result.name}'",
-        }
+        return task_result(
+            result,
+            f"Fixed actual times for task '{result.name}'",
+            actual_start=iso(result.actual_start),
+            actual_end=iso(result.actual_end),
+            actual_duration_hours=result.actual_duration_hours,
+        )

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_query.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_query.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from taskdog_mcp.tools.serializers import iso, str_list
+
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
     from taskdog_client import TaskdogApiClient
@@ -107,10 +109,10 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
                     "name": t.name,
                     "status": t.status.value,
                     "priority": t.priority,
-                    "deadline": t.deadline.isoformat() if t.deadline else None,
+                    "deadline": iso(t.deadline),
                     "estimated_duration": t.estimated_duration,
-                    "tags": list(t.tags) if t.tags else [],
-                    "depends_on": list(t.depends_on) if t.depends_on else [],
+                    "tags": str_list(t.tags),
+                    "depends_on": str_list(t.depends_on),
                 }
                 for t in limited_tasks
             ],


### PR DESCRIPTION
## Summary

Extracts the repeated serialization logic in MCP tools into a shared `tools/serializers.py`:

- `iso(dt)` — ISO-format a datetime, or `None`
- `str_list(values)` — coerce an optional iterable to a list (empty when falsy)
- `task_result(task, message, **extra)` — standard mutation response shape (`id`, `name`, `status`, extras, `message`)

Applied across `task_crud`, `task_lifecycle`, `task_query`, and `task_decomposition`, replacing scattered inline `{... .isoformat() if ... else None ...}` / `list(x) if x else []` / `{id, name, status, message}` construction with a single source of truth for the response shape.

## Scope note

This is a **deduplication / maintainability** refactor, not a raw line-count reduction. The duplication is removed from 4 tool files (−27 lines) but the shared module adds ~28 lines, so net LOC is roughly neutral (+1). The value is a single place to change when a task field is added or a datetime/iterable rule changes.

`task_result` is deliberately **not** applied to `add_dependency` / `remove_dependency` / `set_task_tags`, whose responses intentionally omit `status` — using the helper there would change the output contract.

## Verification

- `make test-mcp` equivalent: 84 passed (unchanged).
- `ruff`, `mypy`, `pre-commit`: all pass.

Behavior-preserving; no tool output shape changes.