### PR TITLE
refactor(core): remove vestigial TimeRange enum and unused time_range field

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/dto/__init__.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/__init__.py
@@ -5,7 +5,6 @@ from taskdog_core.application.dto.gantt_output import GanttDateRange, GanttOutpu
 from taskdog_core.application.dto.query_inputs import (
     GetGanttDataInput,
     ListTasksInput,
-    TimeRange,
 )
 from taskdog_core.application.dto.statistics_output import (
     CalculateStatisticsInput,
@@ -34,7 +33,6 @@ __all__ = [
     "StatusChangeOutput",
     "TaskDetailOutput",
     "TaskStatistics",
-    "TimeRange",
     "TimeStatistics",
     "TrendStatistics",
 ]

--- a/packages/taskdog-core/src/taskdog_core/application/dto/query_inputs.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/query_inputs.py
@@ -6,17 +6,6 @@ providing a presentation-agnostic interface for the Application layer.
 
 from dataclasses import dataclass, field
 from datetime import date
-from enum import Enum
-
-
-class TimeRange(Enum):
-    """Time range presets for task queries.
-
-    Attributes:
-        CUSTOM: Custom date range (uses start_date/end_date)
-    """
-
-    CUSTOM = "custom"
 
 
 @dataclass
@@ -33,7 +22,6 @@ class ListTasksInput:
         match_all_tags: If True, task must have all tags; if False, any tag matches
         start_date: Filter tasks with planned_start/end >= this date
         end_date: Filter tasks with planned_start/end <= this date
-        time_range: Preset time range (CUSTOM)
         sort_by: Field to sort by (default: "id")
         reverse: Reverse sort order (default: False)
     """
@@ -44,7 +32,6 @@ class ListTasksInput:
     match_all_tags: bool = False
     start_date: date | None = None
     end_date: date | None = None
-    time_range: TimeRange = TimeRange.CUSTOM
     sort_by: str = "id"
     reverse: bool = False
 

--- a/packages/taskdog-core/src/taskdog_core/application/queries/task_filter_builder.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/task_filter_builder.py
@@ -41,7 +41,7 @@ class TaskFilterBuilder:
         1. Archive filter (if not include_archived)
         2. Status filter (if status specified)
         3. Tag filter (if tags specified)
-        4. Time range / date filter (based on time_range)
+        4. Date range filter (if start_date/end_date specified)
 
         Args:
             input_dto: The query input parameters
@@ -74,8 +74,8 @@ class TaskFilterBuilder:
             )
             filter_obj = TaskFilterBuilder._compose(filter_obj, tag_filter)
 
-        # Time range filter
-        filter_obj = TaskFilterBuilder._apply_time_range(filter_obj, input_dto)
+        # Date range filter
+        filter_obj = TaskFilterBuilder._apply_date_range(filter_obj, input_dto)
 
         return filter_obj
 
@@ -98,22 +98,21 @@ class TaskFilterBuilder:
         return existing >> new_filter
 
     @staticmethod
-    def _apply_time_range(
+    def _apply_date_range(
         filter_obj: TaskFilter | None,
         input_dto: ListTasksInput,
     ) -> TaskFilter | None:
-        """Apply time range filter based on input DTO.
+        """Apply date range filter based on input DTO.
 
-        Applies DateRangeFilter when custom date range is specified.
+        Applies DateRangeFilter when start_date and/or end_date are specified.
 
         Args:
             filter_obj: Current filter chain
-            input_dto: Query input with time range parameters
+            input_dto: Query input with date range parameters
 
         Returns:
-            Updated filter chain with time filter applied
+            Updated filter chain with date filter applied
         """
-        # Custom time range with explicit dates
         if input_dto.start_date is not None or input_dto.end_date is not None:
             date_filter = DateRangeFilter(
                 start_date=input_dto.start_date,

--- a/packages/taskdog-core/src/taskdog_core/controllers/query_controller.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/query_controller.py
@@ -104,7 +104,6 @@ class QueryController:
                 match_all_tags=input_dto.match_all_tags,
                 start_date=input_dto.start_date,
                 end_date=input_dto.end_date,
-                time_range=input_dto.time_range,
                 sort_by=input_dto.sort_by,
                 reverse=input_dto.reverse,
                 chart_start_date=gantt_start_date,


### PR DESCRIPTION
## Summary

Removes dead code in the query DTO layer:

- `TimeRange` was a **single-member enum** (`CUSTOM = "custom"`) — semantically inert.
- `ListTasksInput.time_range` was set to the default and **passed through** `QueryController` into `TaskFilterBuilder`, but the filter (`_apply_time_range`) branches **only on `start_date`/`end_date`** and never reads `time_range`. Its docstring ("based on time_range") was misleading.

Both are leftovers from time-range presets that were removed earlier.

## Changes

- Delete the `TimeRange` enum and the `time_range` field (`query_inputs.py`).
- Drop the `time_range=` pass-through in `QueryController`.
- Remove `TimeRange` from the dto package `__all__` / import.
- Rename `_apply_time_range` → `_apply_date_range` and correct the docstrings to describe what the filter actually does.

## Verification

- core: 1114 passed · server: 309 passed · ui: 920 passed
- `ruff`, `mypy`, `pre-commit`: all pass

Pure deletion — net **−17 LOC**, no new abstraction. No external (server/CLI/MCP) surface touched; `time_range` was never exposed.