### PR TITLE
chore(demo): add vhs demo recording tape and --no-optimize seed flag

### DIFF
--- a/scripts/demo_data.py
+++ b/scripts/demo_data.py
@@ -159,7 +159,7 @@ class DemoDataLoader:
 
     def load(self) -> dict[str, Any]:
         """Load and parse JSON data file."""
-        with open(self.data_file, encoding="utf-8") as f:
+        with self.data_file.open(encoding="utf-8") as f:
             return json.load(f)
 
     def resolve_date(self, days: int) -> str:
@@ -222,10 +222,12 @@ class DemoDataCreator:
         client: TaskdogAPIClient,
         loader: DemoDataLoader,
         max_workers: int = 5,
+        optimize: bool = True,
     ):
         self.client = client
         self.loader = loader
         self.max_workers = max_workers
+        self.optimize = optimize
         self.task_id_map: dict[str, int] = {}  # T1 -> actual_id
 
     def run(self) -> None:
@@ -237,8 +239,7 @@ class DemoDataCreator:
         all_tasks = []
         for project in data["projects"]:
             print(f"{BLUE}[{project['name']}]{NC}")
-            for task in project["tasks"]:
-                all_tasks.append(task)
+            all_tasks.extend(project["tasks"])
 
         self._create_tasks_parallel(all_tasks)
 
@@ -259,10 +260,12 @@ class DemoDataCreator:
         progress = data.get("progress", {})
         self._simulate_progress(progress)
 
-        # Phase 6: Run optimization
-        print(f"\n{BLUE}Running schedule optimization...{NC}")
-        opt_config = data.get("optimization", {})
-        self._run_optimization(opt_config)
+        # Phase 6: Run optimization (skippable so the initial state has no
+        # planned schedule — e.g. for demo recordings that optimize on camera)
+        if self.optimize:
+            print(f"\n{BLUE}Running schedule optimization...{NC}")
+            opt_config = data.get("optimization", {})
+            self._run_optimization(opt_config)
 
         # Summary
         self._print_summary(data)
@@ -517,6 +520,11 @@ def main() -> int:
         default=None,
         help="API key for authentication (X-Api-Key header)",
     )
+    parser.add_argument(
+        "--no-optimize",
+        action="store_true",
+        help="Skip the final schedule optimization (leaves tasks unscheduled)",
+    )
     args = parser.parse_args()
 
     # Check data file exists
@@ -564,7 +572,9 @@ def main() -> int:
 
     # Create demo data
     loader = DemoDataLoader()
-    creator = DemoDataCreator(client, loader, max_workers=args.workers)
+    creator = DemoDataCreator(
+        client, loader, max_workers=args.workers, optimize=not args.no_optimize
+    )
 
     try:
         creator.run()

--- a/vhs/demo.tape
+++ b/vhs/demo.tape
@@ -1,0 +1,103 @@
+# taskdog TUI demo —
+#   launch → add a task → search/find it → start → done →
+#   sort toggle → command palette → optimize → Gantt repaints.
+#
+# Recording prep (server + seed must be running BEFORE vhs):
+#   Run against an ISOLATED server/db on port 8765 so the real
+#   tasks.db and the systemd server (:8000) are never touched.
+#     DATA=$(mktemp -d) CONF=$(mktemp -d)
+#     mkdir -p $CONF/taskdog
+#     printf '[ui]\ntheme = "rose-pine"\n' > $CONF/taskdog/cli.toml
+#     XDG_DATA_HOME=$DATA XDG_CONFIG_HOME=$CONF \
+#       taskdog-server --host 127.0.0.1 --port 8765 &
+#     python scripts/demo_data.py --host 127.0.0.1 --port 8765 -y --no-optimize
+#     XDG_CONFIG_HOME=$CONF TASKDOG_API_HOST=127.0.0.1 TASKDOG_API_PORT=8765 \
+#       vhs vhs/demo.tape           # → assets/demo.mp4
+
+Output assets/demo.mp4
+
+Set FontSize 16
+Set Width 2400
+Set Height 1350
+Set Framerate 24
+Set Theme "rose-pine"
+Set TypingSpeed 60ms
+Set PlaybackSpeed 1.0
+
+# Launch the TUI against the seeded demo server (~50 tasks).
+Type "taskdog tui"
+Enter
+Sleep 3s
+
+# --- Add a task ---
+# `a` opens the form. Name is required; one Tab moves to Duration.
+Type "a"
+Sleep 1200ms
+Type "Ship release notes"
+Sleep 400ms
+Tab
+Type "3"
+Sleep 600ms
+# Ctrl+S submits the form.
+Ctrl+S
+Sleep 2s
+
+# --- Find it, then walk it through its lifecycle ---
+# `/` focuses the search box; typing filters the table live.
+Type "/"
+Sleep 500ms
+Type "Ship release"
+Sleep 1s
+# Enter returns focus to the (now single-row) table.
+Enter
+Sleep 800ms
+# `s` starts the task (PENDING -> IN_PROGRESS).
+Type "s"
+Sleep 1800ms
+# `d` completes it (IN_PROGRESS -> COMPLETED, shown struck through).
+Type "d"
+Sleep 1800ms
+# Escape clears the search filter and shows everything again.
+Escape
+Sleep 1500ms
+
+# --- Focus the Gantt chart and maximize it ---
+# Ctrl+K moves focus to the previous widget (the Gantt, above the table);
+# `z` maximizes the focused widget to full screen.
+Ctrl+K
+Sleep 800ms
+Type "z"
+Sleep 2s
+
+# --- Optimize the whole schedule (repaints the fullscreen Gantt) ---
+# Ctrl+P opens the command palette; "optimize" filters to the command.
+Ctrl+P
+Sleep 600ms
+Type "optimize"
+Sleep 800ms
+Enter
+Sleep 1200ms
+# Dialog opens focused on the algorithm select (Greedy by default).
+# Ctrl+J moves to the required "Max Hours per Day" field; fill it.
+Ctrl+J
+Sleep 500ms
+Type "8"
+Sleep 800ms
+# Ctrl+J past Start Date (pre-filled) to the "Override existing
+# schedules" checkbox; Space turns it on so every task is rescheduled
+# (otherwise already-scheduled demo tasks are skipped).
+Ctrl+J
+Sleep 400ms
+Ctrl+J
+Sleep 400ms
+Space
+Sleep 800ms
+# Ctrl+S runs the optimizer.
+Ctrl+S
+Sleep 2s
+
+# Let the Gantt chart settle into its optimized schedule.
+Sleep 5s
+
+Type "q"
+Sleep 400ms


### PR DESCRIPTION
## What

Adds reproducible tooling to record the README TUI demo video with [vhs](https://github.com/charmbracelet/vhs).

- **`vhs/demo.tape`** — the recording script. Story: launch TUI → add a task → search for it → start → done → focus the Gantt and maximize it (`Ctrl+K`, `z`) → run schedule optimization on camera (rose-pine theme, 2400×1350). The header documents the isolated recording prep (separate server/db on port 8765 so the real `tasks.db` and systemd server are never touched).
- **`scripts/demo_data.py`** — new `--no-optimize` flag. With it, the seeded state has no planned schedule, so the demo can run optimization live and show the Gantt fill up. Default behaviour is unchanged, so the Docker `:demo` image still optimizes as before.

Also fixes two pre-existing ruff findings in `demo_data.py` that the pre-commit hook surfaced (`PTH123`, `PERF402`).

## Not included

The recorded `assets/demo.mp4` is intentionally left out — the README embeds the video via a GitHub `user-attachments` URL, so the binary doesn't need to live in the repo. Swapping the README video URL will be a separate change once the new clip is uploaded.

## How to record

```bash
DATA=$(mktemp -d) CONF=$(mktemp -d)
mkdir -p $CONF/taskdog
printf '[ui]\ntheme = "rose-pine"\n' > $CONF/taskdog/cli.toml
XDG_DATA_HOME=$DATA XDG_CONFIG_HOME=$CONF taskdog-server --host 127.0.0.1 --port 8765 &
python scripts/demo_data.py --host 127.0.0.1 --port 8765 -y --no-optimize
XDG_CONFIG_HOME=$CONF TASKDOG_API_HOST=127.0.0.1 TASKDOG_API_PORT=8765 vhs vhs/demo.tape
```