### PR TITLE
chore: ignore assets/ and .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,7 +220,11 @@ __marimo__/
 
 # Git worktrees
 .worktrees/
+.claude/worktrees/
 
 # Claude Code
 # Local settings are developer-specific (auto-approved commands, etc.)
 .claude/*.local.json
+
+# Generated demo media (uploaded to GitHub, not committed)
+assets/


### PR DESCRIPTION
## Summary

- Ignore `assets/` — holds generated demo media (mp4) that is uploaded to GitHub releases/attachments, not committed to the tree.
- Ignore `.claude/worktrees/` — a git worktree checkout living under `.claude/`, which was causing the whole `.claude/` dir to show as untracked.

`.claude/` itself is intentionally left tracked-eligible (only `*.local.json` and `worktrees/` are ignored), so shared `settings.json` / skill definitions can be committed later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)