### PR TITLE
refactor(core,client): Pydantic DTOs, collapse 1:1 converters

### DIFF
--- a/packages/taskdog-client/src/taskdog_client/converters/datetime_utils.py
+++ b/packages/taskdog-client/src/taskdog_client/converters/datetime_utils.py
@@ -62,44 +62,6 @@ def _parse_datetime_fields(
     return {field: _parse_optional_datetime(data, field) for field in fields}
 
 
-def _parse_required_datetime(data: dict[str, Any], field: str) -> datetime:
-    """Parse required datetime field from API response.
-
-    Args:
-        data: Dictionary containing datetime fields
-        field: Field name to extract
-
-    Returns:
-        Parsed datetime value
-
-    Raises:
-        ConversionError: If field is missing or value is malformed
-    """
-    value = data.get(field)
-    if value is None:
-        raise ConversionError(
-            f"Required datetime field '{field}' is missing or None",
-            field=field,
-            value=value,
-        )
-
-    try:
-        result = _core_parse_datetime(value)
-        if result is None:
-            raise ConversionError(
-                f"Required datetime field '{field}' parsed to None",
-                field=field,
-                value=value,
-            )
-        return result
-    except (ValueError, TypeError) as e:
-        raise ConversionError(
-            f"Failed to parse required datetime field '{field}': {value}",
-            field=field,
-            value=value,
-        ) from e
-
-
 def _parse_date_dict(data: dict[str, Any], field: str) -> dict[date_type, float]:
     """Parse dictionary with ISO date string keys to date object keys.
 

--- a/packages/taskdog-client/src/taskdog_client/converters/task_converters.py
+++ b/packages/taskdog-client/src/taskdog_client/converters/task_converters.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from taskdog_core.application.dto.get_task_by_id_output import TaskByIdOutput
 from taskdog_core.application.dto.task_detail_output import TaskDetailOutput
@@ -10,21 +10,40 @@ from taskdog_core.application.dto.task_dto import TaskDetailDto, TaskRowDto
 from taskdog_core.application.dto.task_list_output import TaskListOutput
 from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 from taskdog_core.application.dto.update_task_output import TaskUpdateOutput
-from taskdog_core.domain.entities.task import TaskStatus
 
-from .datetime_utils import (
-    _parse_datetime_fields,
-    _parse_required_datetime,
-)
 from .exceptions import ConversionError
 from .gantt_converters import convert_to_gantt_output
+
+
+def _model_validate[M: BaseModel](model_cls: type[M], data: dict[str, Any]) -> M:
+    """Validate API response data into a DTO, wrapping errors as ConversionError.
+
+    Args:
+        model_cls: Pydantic DTO class to build
+        data: API response data
+
+    Returns:
+        Validated DTO instance
+
+    Raises:
+        ConversionError: If the response data cannot be validated into the DTO
+    """
+    try:
+        return model_cls.model_validate(data)
+    except ValidationError as e:
+        first_error = e.errors()[0]
+        field = str(first_error["loc"][0]) if first_error["loc"] else None
+        raise ConversionError(
+            f"Failed to convert response to {model_cls.__name__}: {e}",
+            field=field,
+            value=data.get(field) if field else None,
+        ) from e
 
 
 def _build_task_detail_dto(data: dict[str, Any]) -> TaskDetailDto:
     """Build TaskDetailDto from API response data.
 
-    This is a shared method to avoid duplication between convert_to_get_task_by_id_output
-    and convert_to_get_task_detail_output.
+    Shared by convert_to_get_task_by_id_output and convert_to_get_task_detail_output.
 
     Args:
         data: API response data containing task fields
@@ -35,16 +54,7 @@ def _build_task_detail_dto(data: dict[str, Any]) -> TaskDetailDto:
     Raises:
         ConversionError: If the response data cannot be validated into the DTO
     """
-    try:
-        return TaskDetailDto.model_validate(data)
-    except ValidationError as e:
-        first_error = e.errors()[0]
-        field = str(first_error["loc"][0]) if first_error["loc"] else None
-        raise ConversionError(
-            f"Failed to convert response to TaskDetailDto: {e}",
-            field=field,
-            value=data.get(field) if field else None,
-        ) from e
+    return _model_validate(TaskDetailDto, data)
 
 
 def convert_to_task_operation_output(data: dict[str, Any]) -> TaskOperationOutput:
@@ -55,31 +65,11 @@ def convert_to_task_operation_output(data: dict[str, Any]) -> TaskOperationOutpu
 
     Returns:
         TaskOperationOutput with task data
-    """
-    # Parse datetime fields using utility
-    dt_fields = _parse_datetime_fields(
-        data, ["deadline", "planned_start", "planned_end", "actual_start", "actual_end"]
-    )
 
-    return TaskOperationOutput(
-        id=data["id"],
-        name=data["name"],
-        status=TaskStatus(data["status"]),
-        priority=data["priority"],
-        deadline=dt_fields["deadline"],
-        estimated_duration=data.get("estimated_duration"),
-        planned_start=dt_fields["planned_start"],
-        planned_end=dt_fields["planned_end"],
-        actual_start=dt_fields["actual_start"],
-        actual_end=dt_fields["actual_end"],
-        actual_duration=data.get("actual_duration"),
-        depends_on=data.get("depends_on", []),
-        tags=data.get("tags", []),
-        is_fixed=data.get("is_fixed", False),
-        is_archived=data.get("is_archived", False),
-        actual_duration_hours=data.get("actual_duration_hours"),
-        daily_allocations=data.get("daily_allocations", {}),
-    )
+    Raises:
+        ConversionError: If the response data cannot be validated into the DTO
+    """
+    return _model_validate(TaskOperationOutput, data)
 
 
 def convert_to_update_task_output(data: dict[str, Any]) -> TaskUpdateOutput:
@@ -110,39 +100,9 @@ def convert_to_task_list_output(data: dict[str, Any]) -> TaskListOutput:
     Returns:
         TaskListOutput with task list and metadata
     """
-    tasks = []
-    for task in data["tasks"]:
-        # Parse datetime fields using utility
-        dt_fields = _parse_datetime_fields(
-            task,
-            ["planned_start", "planned_end", "deadline", "actual_start", "actual_end"],
-        )
+    tasks = [_model_validate(TaskRowDto, task) for task in data["tasks"]]
 
-        tasks.append(
-            TaskRowDto(
-                id=task["id"],
-                name=task["name"],
-                priority=task["priority"],
-                status=TaskStatus(task["status"]),
-                planned_start=dt_fields["planned_start"],
-                planned_end=dt_fields["planned_end"],
-                deadline=dt_fields["deadline"],
-                actual_start=dt_fields["actual_start"],
-                actual_end=dt_fields["actual_end"],
-                estimated_duration=task.get("estimated_duration"),
-                actual_duration_hours=task.get("actual_duration_hours"),
-                is_fixed=task.get("is_fixed", False),
-                depends_on=task.get("depends_on", []),
-                tags=task.get("tags", []),
-                is_archived=task.get("is_archived", False),
-                is_finished=task.get("is_finished", False),
-                created_at=_parse_required_datetime(task, "created_at"),
-                updated_at=_parse_required_datetime(task, "updated_at"),
-                has_notes=task.get("has_notes", False),
-            )
-        )
-
-    # Convert gantt data if present
+    # Convert gantt data if present (separate reshaping converter)
     gantt_data = None
     if data.get("gantt"):
         gantt_data = convert_to_gantt_output(data["gantt"])

--- a/packages/taskdog-client/src/taskdog_client/converters/task_converters.py
+++ b/packages/taskdog-client/src/taskdog_client/converters/task_converters.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from pydantic import ValidationError
+
 from taskdog_core.application.dto.get_task_by_id_output import TaskByIdOutput
 from taskdog_core.application.dto.task_detail_output import TaskDetailOutput
 from taskdog_core.application.dto.task_dto import TaskDetailDto, TaskRowDto
@@ -11,10 +13,10 @@ from taskdog_core.application.dto.update_task_output import TaskUpdateOutput
 from taskdog_core.domain.entities.task import TaskStatus
 
 from .datetime_utils import (
-    _parse_date_dict,
     _parse_datetime_fields,
     _parse_required_datetime,
 )
+from .exceptions import ConversionError
 from .gantt_converters import convert_to_gantt_output
 
 
@@ -29,38 +31,20 @@ def _build_task_detail_dto(data: dict[str, Any]) -> TaskDetailDto:
 
     Returns:
         TaskDetailDto with all task data populated
-    """
-    # Parse datetime fields with error handling
-    dt_fields = _parse_datetime_fields(
-        data, ["planned_start", "planned_end", "deadline", "actual_start", "actual_end"]
-    )
 
-    # Build and return TaskDetailDto with safe parsing
-    return TaskDetailDto(
-        id=data["id"],
-        name=data["name"],
-        priority=data["priority"],
-        status=TaskStatus(data["status"]),
-        planned_start=dt_fields["planned_start"],
-        planned_end=dt_fields["planned_end"],
-        deadline=dt_fields["deadline"],
-        actual_start=dt_fields["actual_start"],
-        actual_end=dt_fields["actual_end"],
-        actual_duration=data.get("actual_duration"),
-        estimated_duration=data.get("estimated_duration"),
-        daily_allocations=_parse_date_dict(data, "daily_allocations"),
-        is_fixed=data.get("is_fixed", False),
-        depends_on=data.get("depends_on", []),
-        tags=data.get("tags", []),
-        is_archived=data.get("is_archived", False),
-        created_at=_parse_required_datetime(data, "created_at"),
-        updated_at=_parse_required_datetime(data, "updated_at"),
-        actual_duration_hours=data.get("actual_duration_hours"),
-        is_active=data.get("is_active", False),
-        is_finished=data.get("is_finished", False),
-        can_be_modified=data.get("can_be_modified", False),
-        is_schedulable=data.get("is_schedulable", False),
-    )
+    Raises:
+        ConversionError: If the response data cannot be validated into the DTO
+    """
+    try:
+        return TaskDetailDto.model_validate(data)
+    except ValidationError as e:
+        first_error = e.errors()[0]
+        field = str(first_error["loc"][0]) if first_error["loc"] else None
+        raise ConversionError(
+            f"Failed to convert response to TaskDetailDto: {e}",
+            field=field,
+            value=data.get(field) if field else None,
+        ) from e
 
 
 def convert_to_task_operation_output(data: dict[str, Any]) -> TaskOperationOutput:

--- a/packages/taskdog-client/tests/converters/test_datetime_utils.py
+++ b/packages/taskdog-client/tests/converters/test_datetime_utils.py
@@ -7,7 +7,6 @@ from taskdog_client.converters.datetime_utils import (
     _parse_date_dict,
     _parse_datetime_fields,
     _parse_optional_datetime,
-    _parse_required_datetime,
 )
 from taskdog_client.converters.exceptions import ConversionError
 
@@ -113,47 +112,6 @@ class TestParseDatetimeFields:
 
         assert result["planned_start"] is None
         assert result["planned_end"] is None
-
-
-class TestParseRequiredDatetime:
-    """Test cases for _parse_required_datetime."""
-
-    def test_valid_datetime(self):
-        """Test parsing valid required datetime."""
-        data = {"created_at": "2025-01-01T00:00:00"}
-        result = _parse_required_datetime(data, "created_at")
-
-        assert result == datetime(2025, 1, 1, 0, 0, 0)
-
-    def test_missing_field_raises_error(self):
-        """Test that missing field raises ConversionError."""
-        data = {}
-
-        with pytest.raises(ConversionError) as exc_info:
-            _parse_required_datetime(data, "created_at")
-
-        assert exc_info.value.field == "created_at"
-        assert "missing" in str(exc_info.value).lower()
-
-    def test_none_value_raises_error(self):
-        """Test that None value raises ConversionError."""
-        data = {"created_at": None}
-
-        with pytest.raises(ConversionError) as exc_info:
-            _parse_required_datetime(data, "created_at")
-
-        assert exc_info.value.field == "created_at"
-        assert exc_info.value.value is None
-
-    def test_invalid_format_raises_error(self):
-        """Test that invalid format raises ConversionError."""
-        data = {"created_at": "invalid-datetime"}
-
-        with pytest.raises(ConversionError) as exc_info:
-            _parse_required_datetime(data, "created_at")
-
-        assert exc_info.value.field == "created_at"
-        assert exc_info.value.value == "invalid-datetime"
 
 
 class TestParseDateDict:

--- a/packages/taskdog-client/tests/test_converters.py
+++ b/packages/taskdog-client/tests/test_converters.py
@@ -420,13 +420,14 @@ class TestConverterErrorHandling:
         assert exc_info.value.value == "invalid-datetime-format"
 
     def test_invalid_date_type_raises_conversion_error(self):
-        """Test that invalid date type (int instead of string) raises ConversionError."""
+        """Test that an uncoercible date type raises ConversionError."""
+        bad_value = ["not", "a", "date"]
         data = {
             "id": 1,
             "name": "Test Task",
             "status": "PENDING",
             "priority": 50,
-            "deadline": 12345,  # Invalid type (should be string)
+            "deadline": bad_value,  # Invalid type (not coercible to datetime)
             "planned_start": None,
             "planned_end": None,
             "actual_start": None,
@@ -437,7 +438,7 @@ class TestConverterErrorHandling:
             convert_to_task_operation_output(data)
 
         assert exc_info.value.field == "deadline"
-        assert exc_info.value.value == 12345
+        assert exc_info.value.value == bad_value
 
     def test_invalid_date_dict_raises_conversion_error(self):
         """Test that invalid date dictionary keys raise ConversionError."""

--- a/packages/taskdog-core/pyproject.toml
+++ b/packages/taskdog-core/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 dependencies = [
     "alembic>=1.13.0",
     "holidays>=0.60.0",
+    "pydantic>=2.10.0",
     "sqlalchemy>=2.0.0",
 ]
 

--- a/packages/taskdog-core/src/taskdog_core/application/dto/gantt_output.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/gantt_output.py
@@ -9,14 +9,14 @@ Design Principle:
 - Presentation layer: Decides how to display (colors, styles, layout)
 """
 
-from dataclasses import dataclass
 from datetime import date
+
+from pydantic import BaseModel
 
 from taskdog_core.application.dto.task_dto import GanttTaskDto
 
 
-@dataclass
-class GanttDateRange:
+class GanttDateRange(BaseModel):
     """Date range for the Gantt chart.
 
     Attributes:
@@ -37,8 +37,7 @@ class GanttDateRange:
         return (self.end_date - self.start_date).days + 1
 
 
-@dataclass
-class GanttOutput:
+class GanttOutput(BaseModel):
     """Complete Gantt chart data result.
 
     This DTO contains only business data needed for Gantt visualization.

--- a/packages/taskdog-core/src/taskdog_core/application/dto/get_task_by_id_output.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/get_task_by_id_output.py
@@ -3,13 +3,12 @@
 This DTO wraps task detail data for single task retrieval queries.
 """
 
-from dataclasses import dataclass
+from pydantic import BaseModel
 
 from taskdog_core.application.dto.task_dto import TaskDetailDto
 
 
-@dataclass
-class TaskByIdOutput:
+class TaskByIdOutput(BaseModel):
     """Output DTO for single task retrieval by ID.
 
     Used by QueryController.get_task_by_id() and consumed by TUI commands.

--- a/packages/taskdog-core/src/taskdog_core/application/dto/optimization_output.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/optimization_output.py
@@ -1,14 +1,14 @@
 """DTOs for optimization results."""
 
-from dataclasses import dataclass
 from datetime import date, datetime
+
+from pydantic import BaseModel
 
 from taskdog_core.application.dto.optimization_summary import OptimizationSummary
 from taskdog_core.application.dto.task_dto import TaskSummaryDto
 
 
-@dataclass
-class SchedulingFailure:
+class SchedulingFailure(BaseModel):
     """Information about a task scheduling failure.
 
     Attributes:
@@ -20,8 +20,7 @@ class SchedulingFailure:
     reason: str
 
 
-@dataclass
-class OptimizationOutput:
+class OptimizationOutput(BaseModel):
     """Complete result of schedule optimization.
 
     This DTO encapsulates all information from the optimization process,

--- a/packages/taskdog-core/src/taskdog_core/application/dto/optimization_summary.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/optimization_summary.py
@@ -1,12 +1,11 @@
 """DTO for optimization summary data."""
 
-from dataclasses import dataclass
+from pydantic import BaseModel
 
 from taskdog_core.application.dto.task_dto import TaskSummaryDto
 
 
-@dataclass
-class OptimizationSummary:
+class OptimizationSummary(BaseModel):
     """Summary data from schedule optimization.
 
     Attributes:

--- a/packages/taskdog-core/src/taskdog_core/application/dto/statistics_output.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/statistics_output.py
@@ -2,11 +2,12 @@
 
 from dataclasses import dataclass
 
+from pydantic import BaseModel
+
 from taskdog_core.application.dto.task_dto import TaskSummaryDto
 
 
-@dataclass
-class TaskStatistics:
+class TaskStatistics(BaseModel):
     """Basic task statistics.
 
     Attributes:
@@ -26,8 +27,7 @@ class TaskStatistics:
     completion_rate: float
 
 
-@dataclass
-class TimeStatistics:
+class TimeStatistics(BaseModel):
     """Time tracking statistics.
 
     Attributes:
@@ -47,8 +47,7 @@ class TimeStatistics:
     tasks_with_time_tracking: int
 
 
-@dataclass
-class EstimationAccuracyStatistics:
+class EstimationAccuracyStatistics(BaseModel):
     """Estimation accuracy statistics.
 
     Attributes:
@@ -70,8 +69,7 @@ class EstimationAccuracyStatistics:
     worst_estimated_tasks: list[TaskSummaryDto]
 
 
-@dataclass
-class DeadlineComplianceStatistics:
+class DeadlineComplianceStatistics(BaseModel):
     """Deadline compliance statistics.
 
     Attributes:
@@ -89,8 +87,7 @@ class DeadlineComplianceStatistics:
     average_delay_days: float
 
 
-@dataclass
-class PriorityDistributionStatistics:
+class PriorityDistributionStatistics(BaseModel):
     """Priority distribution statistics.
 
     Attributes:
@@ -108,8 +105,7 @@ class PriorityDistributionStatistics:
     priority_completion_map: dict[int, int]
 
 
-@dataclass
-class TrendStatistics:
+class TrendStatistics(BaseModel):
     """Trend statistics over time.
 
     Attributes:
@@ -125,8 +121,7 @@ class TrendStatistics:
     monthly_completion_trend: dict[str, int]
 
 
-@dataclass
-class StatisticsOutput:
+class StatisticsOutput(BaseModel):
     """Complete statistics result.
 
     Attributes:

--- a/packages/taskdog-core/src/taskdog_core/application/dto/tag_statistics_output.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/tag_statistics_output.py
@@ -4,11 +4,10 @@ This DTO provides a presentation-agnostic representation of tag usage statistics
 containing tag counts and metadata for display or API responses.
 """
 
-from dataclasses import dataclass
+from pydantic import BaseModel
 
 
-@dataclass
-class TagStatisticsOutput:
+class TagStatisticsOutput(BaseModel):
     """Output DTO for tag statistics.
 
     Contains tag usage statistics across all tasks.

--- a/packages/taskdog-core/src/taskdog_core/application/dto/task_detail_output.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/task_detail_output.py
@@ -1,12 +1,11 @@
 """DTO for task detail information."""
 
-from dataclasses import dataclass
+from pydantic import BaseModel
 
 from taskdog_core.application.dto.task_dto import TaskDetailDto
 
 
-@dataclass
-class TaskDetailOutput:
+class TaskDetailOutput(BaseModel):
     """Result DTO for task detail with notes.
 
     Attributes:

--- a/packages/taskdog-core/src/taskdog_core/application/dto/task_dto.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/task_dto.py
@@ -6,7 +6,6 @@ the Task entity directly to the presentation layer.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import date, datetime
 from typing import TYPE_CHECKING
 
@@ -18,13 +17,14 @@ if TYPE_CHECKING:
     from taskdog_core.domain.entities.task import Task
 
 
-@dataclass(frozen=True)
-class TaskSummaryDto:
+class TaskSummaryDto(BaseModel):
     """Minimal task information for lists and references.
 
     Used when only basic task identification is needed.
     Includes optional duration fields for statistics display.
     """
+
+    model_config = ConfigDict(frozen=True)
 
     id: int
     name: str
@@ -54,12 +54,13 @@ class TaskSummaryDto:
         )
 
 
-@dataclass(frozen=True)
-class GanttTaskDto:
+class GanttTaskDto(BaseModel):
     """Task data for Gantt chart display.
 
     Contains only the fields needed for Gantt visualization.
     """
+
+    model_config = ConfigDict(frozen=True)
 
     id: int
     name: str
@@ -102,12 +103,13 @@ class GanttTaskDto:
         )
 
 
-@dataclass(frozen=True)
-class TaskRowDto:
+class TaskRowDto(BaseModel):
     """Task data for table row display.
 
     Contains all fields needed for table visualization.
     """
+
+    model_config = ConfigDict(frozen=True)
 
     id: int
     name: str

--- a/packages/taskdog-core/src/taskdog_core/application/dto/task_dto.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/task_dto.py
@@ -7,12 +7,15 @@ the Task entity directly to the presentation layer.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import date, datetime
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from datetime import date, datetime
+from pydantic import BaseModel, ConfigDict
 
-    from taskdog_core.domain.entities.task import Task, TaskStatus
+from taskdog_core.domain.entities.task import TaskStatus
+
+if TYPE_CHECKING:
+    from taskdog_core.domain.entities.task import Task
 
 
 @dataclass(frozen=True)
@@ -196,13 +199,14 @@ class TaskRowDto:
         }
 
 
-@dataclass(frozen=True)
-class TaskDetailDto:
+class TaskDetailDto(BaseModel):
     """Complete task information for detail views.
 
     Contains all task data needed for display and editing,
     without exposing the Task entity.
     """
+
+    model_config = ConfigDict(frozen=True)
 
     id: int
     name: str
@@ -213,7 +217,7 @@ class TaskDetailDto:
     deadline: datetime | None
     actual_start: datetime | None
     actual_end: datetime | None
-    actual_duration: float | None
+    actual_duration: float | None = None
     estimated_duration: float | None
     daily_allocations: dict[date, float]
     is_fixed: bool

--- a/packages/taskdog-core/src/taskdog_core/application/dto/task_list_output.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/task_list_output.py
@@ -4,17 +4,13 @@ This DTO provides a presentation-agnostic representation of task list query resu
 containing the filtered tasks along with metadata for pagination and statistics.
 """
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from pydantic import BaseModel
 
+from taskdog_core.application.dto.gantt_output import GanttOutput
 from taskdog_core.application.dto.task_dto import TaskRowDto
 
-if TYPE_CHECKING:
-    from taskdog_core.application.dto.gantt_output import GanttOutput
 
-
-@dataclass
-class TaskListOutput:
+class TaskListOutput(BaseModel):
     """Output DTO for task list queries.
 
     Contains filtered and sorted tasks along with count metadata.
@@ -30,5 +26,5 @@ class TaskListOutput:
     tasks: list[TaskRowDto]
     total_count: int
     filtered_count: int
-    gantt_data: "GanttOutput | None" = None
+    gantt_data: GanttOutput | None = None
     task_ids_with_notes: set[int] | None = None

--- a/packages/taskdog-core/src/taskdog_core/application/dto/task_operation_output.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/task_operation_output.py
@@ -1,13 +1,13 @@
 """Output DTO for task write operations."""
 
-from dataclasses import dataclass
 from datetime import datetime
+
+from pydantic import BaseModel
 
 from taskdog_core.domain.entities.task import Task, TaskStatus
 
 
-@dataclass
-class TaskOperationOutput:
+class TaskOperationOutput(BaseModel):
     """Generic output DTO for task write operations.
 
     This DTO is used by TaskController to return task operation results

--- a/packages/taskdog-core/src/taskdog_core/application/dto/task_operation_output.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/task_operation_output.py
@@ -38,19 +38,19 @@ class TaskOperationOutput(BaseModel):
     name: str
     status: TaskStatus
     priority: int | None
-    deadline: datetime | None
-    estimated_duration: float | None
-    planned_start: datetime | None
-    planned_end: datetime | None
-    actual_start: datetime | None
-    actual_end: datetime | None
-    actual_duration: float | None
-    depends_on: list[int]
-    tags: list[str]
-    is_fixed: bool
-    is_archived: bool
-    actual_duration_hours: float | None
-    daily_allocations: dict[str, float]
+    deadline: datetime | None = None
+    estimated_duration: float | None = None
+    planned_start: datetime | None = None
+    planned_end: datetime | None = None
+    actual_start: datetime | None = None
+    actual_end: datetime | None = None
+    actual_duration: float | None = None
+    depends_on: list[int] = []
+    tags: list[str] = []
+    is_fixed: bool = False
+    is_archived: bool = False
+    actual_duration_hours: float | None = None
+    daily_allocations: dict[str, float] = {}
 
     @classmethod
     def from_task(cls, task: Task) -> "TaskOperationOutput":

--- a/packages/taskdog-core/src/taskdog_core/application/dto/update_task_output.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/update_task_output.py
@@ -1,13 +1,12 @@
 """Output DTO for update_task operation."""
 
-from dataclasses import dataclass
+from pydantic import BaseModel
 
 from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 from taskdog_core.domain.entities.task import Task
 
 
-@dataclass
-class TaskUpdateOutput:
+class TaskUpdateOutput(BaseModel):
     """Output DTO for update_task operation.
 
     This DTO wraps TaskOperationOutput and adds metadata about which

--- a/packages/taskdog-core/tests/application/dto/test_task_list_output.py
+++ b/packages/taskdog-core/tests/application/dto/test_task_list_output.py
@@ -122,12 +122,12 @@ class TestTaskListOutput:
 
         assert dto1 != dto2
 
-    def test_tasks_list_is_immutable_reference(self, task1, task2) -> None:
-        """Test that tasks list reference is preserved."""
+    def test_tasks_list_contents_preserved(self, task1, task2) -> None:
+        """Test that the tasks list contents are preserved."""
         tasks = [task1, task2]
         dto = TaskListOutput(tasks=tasks, total_count=2, filtered_count=2)
 
-        assert dto.tasks is tasks
+        assert dto.tasks == tasks
 
     def test_repr_includes_counts(self) -> None:
         """Test that repr includes count information."""

--- a/packages/taskdog-mcp/tests/test_tools.py
+++ b/packages/taskdog-mcp/tests/test_tools.py
@@ -851,7 +851,13 @@ class TestTaskQueryTools:
             ),
             estimation_stats=None,
             deadline_stats=None,
-            priority_stats=None,
+            priority_stats=PriorityDistributionStatistics(
+                high_priority_count=0,
+                medium_priority_count=0,
+                low_priority_count=0,
+                high_priority_completion_rate=0.0,
+                priority_completion_map={},
+            ),
             trend_stats=None,
         )
 
@@ -890,7 +896,13 @@ class TestTaskQueryTools:
             time_stats=None,
             estimation_stats=None,
             deadline_stats=None,
-            priority_stats=None,
+            priority_stats=PriorityDistributionStatistics(
+                high_priority_count=0,
+                medium_priority_count=0,
+                low_priority_count=0,
+                high_priority_completion_rate=0.0,
+                priority_completion_map={},
+            ),
             trend_stats=None,
         )
 

--- a/packages/taskdog-server/tests/api/test_converters.py
+++ b/packages/taskdog-server/tests/api/test_converters.py
@@ -12,6 +12,7 @@ from taskdog_core.application.dto.task_detail_output import TaskDetailOutput
 from taskdog_core.application.dto.task_dto import (
     GanttTaskDto,
     TaskDetailDto,
+    TaskRowDto,
 )
 from taskdog_core.application.dto.task_list_output import TaskListOutput
 from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
@@ -124,7 +125,7 @@ class TestConvertToTaskListResponse:
             updated_at=now,
         )
         dto = TaskListOutput(
-            tasks=[task],
+            tasks=[TaskRowDto.from_entity(task)],
             total_count=10,
             filtered_count=1,
             gantt_data=None,
@@ -156,7 +157,7 @@ class TestConvertToTaskListResponse:
             updated_at=now,
         )
         dto = TaskListOutput(
-            tasks=[task],
+            tasks=[TaskRowDto.from_entity(task)],
             total_count=1,
             filtered_count=1,
             gantt_data=None,
@@ -203,7 +204,7 @@ class TestConvertToTaskListResponse:
             holidays={date(2025, 1, 4)},
         )
         dto = TaskListOutput(
-            tasks=[task],
+            tasks=[TaskRowDto.from_entity(task)],
             total_count=1,
             filtered_count=1,
             gantt_data=gantt_output,
@@ -249,7 +250,7 @@ class TestConvertToTaskListResponse:
             updated_at=now,
         )
         dto = TaskListOutput(
-            tasks=[task1, task2],
+            tasks=[TaskRowDto.from_entity(task1), TaskRowDto.from_entity(task2)],
             total_count=2,
             filtered_count=2,
             gantt_data=None,

--- a/packages/taskdog-ui/tests/services/test_task_data_loader.py
+++ b/packages/taskdog-ui/tests/services/test_task_data_loader.py
@@ -9,6 +9,7 @@ from taskdog.services.task_data_loader import TaskData, TaskDataLoader
 from taskdog.view_models.gantt_view_model import GanttViewModel, TaskGanttRowViewModel
 from taskdog.view_models.task_view_model import TaskRowViewModel
 from taskdog_core.application.dto.gantt_output import GanttOutput
+from taskdog_core.application.dto.task_dto import TaskRowDto
 from taskdog_core.application.dto.task_list_output import TaskListOutput
 from taskdog_core.domain.entities.task import Task, TaskStatus
 
@@ -36,7 +37,9 @@ class TestTaskDataLoader:
         task2 = Task(id=2, name="Task 2", priority=2, status=TaskStatus.COMPLETED)
 
         task_list_output = TaskListOutput(
-            tasks=[task1, task2], total_count=2, filtered_count=2
+            tasks=[TaskRowDto.from_entity(task1), TaskRowDto.from_entity(task2)],
+            total_count=2,
+            filtered_count=2,
         )
         self.api_client.list_tasks.return_value = task_list_output
 
@@ -72,7 +75,7 @@ class TestTaskDataLoader:
         gantt_output = Mock(spec=GanttOutput)
 
         task_list_output = TaskListOutput(
-            tasks=[task1],
+            tasks=[TaskRowDto.from_entity(task1)],
             total_count=1,
             filtered_count=1,
             gantt_data=gantt_output,  # Include gantt data in response

--- a/packages/taskdog-ui/tests/tui/dialogs/test_task_detail_dialog.py
+++ b/packages/taskdog-ui/tests/tui/dialogs/test_task_detail_dialog.py
@@ -71,7 +71,10 @@ class TestTaskDetailDialogInit:
 
     def test_raises_value_error_when_task_is_none(self) -> None:
         """Test that ValueError is raised when task is None."""
-        detail = TaskDetailOutput(task=None, notes_content="", has_notes=False)
+        # model_construct bypasses validation to build the invalid task=None case
+        detail = TaskDetailOutput.model_construct(
+            task=None, notes_content="", has_notes=False
+        )
 
         with pytest.raises(ValueError) as exc_info:
             TaskDetailDialog(detail)

--- a/packages/taskdog-ui/tests/tui/dialogs/test_task_detail_dialog.py
+++ b/packages/taskdog-ui/tests/tui/dialogs/test_task_detail_dialog.py
@@ -244,8 +244,9 @@ class TestTaskDetailDialogActionNote:
     def test_action_note_does_nothing_when_id_is_none(self) -> None:
         """Test that action_note does nothing when task ID is None."""
         task = create_mock_task_dto()
-        task_with_no_id = TaskDetailDto(
-            id=None,  # type: ignore[arg-type]  # Testing edge case
+        # model_construct bypasses validation to build the invalid id=None edge case
+        task_with_no_id = TaskDetailDto.model_construct(
+            id=None,
             name=task.name,
             priority=task.priority,
             status=task.status,

--- a/uv.lock
+++ b/uv.lock
@@ -1388,6 +1388,7 @@ source = { editable = "packages/taskdog-core" }
 dependencies = [
     { name = "alembic" },
     { name = "holidays" },
+    { name = "pydantic" },
     { name = "sqlalchemy" },
 ]
 
@@ -1404,6 +1405,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.13.0" },
     { name = "holidays", specifier = ">=0.60.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7.0" },


### PR DESCRIPTION
## Summary

Implements #922. Converts the closure of output DTOs that `taskdog-client` deserializes from `@dataclass` to Pydantic `BaseModel`, then collapses the 1:1 hand-written converters to `model_validate`. Done in three reviewable commits (spike → DTO conversion → converter collapse).

The domain layer stays framework-free: only `application/dto/` becomes Pydantic. `Task`/`TaskStatus` entities and `domain/services` remain `@dataclass` with their Always-Valid `__post_init__` invariants. This is Clean-Architecture-safe because core already depends on frameworks (sqlalchemy/alembic/holidays) in its infrastructure layer — the real rule is "no frameworks in the domain layer", which this respects. DTOs are boundary data carriers, the defensible place for Pydantic.

## What changed

- **Phase 1** (`5ea296d8`): spike — `TaskDetailDto` → Pydantic, prove `model_validate` end-to-end.
- **Phase 2** (`3b6b1a61`): convert the client-facing output DTO closure (`task_dto`, task/update/list/detail/by_id outputs, gantt, tag/statistics, optimization + summary) to Pydantic. Input DTOs and non-client outputs stay `@dataclass`.
- **Phase 3** (`0f238819`): collapse the 1:1 task converters via a shared `_model_validate` helper (wraps `ValidationError` → `ConversionError`); drop the now-unused `_parse_required_datetime`.

## Honest scope note

The original estimate (~400–650 LOC removed) assumed the gantt/statistics/optimization/tag converters were collapsible. Measuring them showed they are **genuine reshapers** and stay as hand-written code:

| Converter | Collapsed? | Why |
|-----------|-----------|-----|
| task (operation / list / detail) | ✅ | pure 1:1 mapping |
| gantt | ❌ | derives `is_finished` from status, `status.upper()` name lookup, task_id/date key reshaping |
| statistics | ❌ | wire keys differ from DTO fields (`total` → `total_tasks`, …) |
| optimization | ❌ | fabricates `successful_tasks`, computes `days_span`, fills API-absent fields |
| tag | ❌ | `{tag, count}` list → dict, fabricates `total_tagged_tasks` |

`datetime_utils.py` is retained because the gantt converter still uses it.

**Actual reduction: net −151 (src −22, the rest is converter collapse offset by Pydantic field/default declarations and test updates).** The bigger win is structural: server and client are now symmetric (`model_validate` / `model_dump`), and the task CRUD/list/detail converters are effectively one line each.

## Behavior changes surfaced by Pydantic's runtime validation

All were pre-existing dataclass type-lies, none affect production:

- `TaskListOutput.tasks` is rebuilt on validation (no longer identity-preserving) — a list-identity test became a contents test.
- Tests that stuffed `Task` entities into `list[TaskRowDto]` fields now wrap with `TaskRowDto.from_entity` (production always passed proper DTOs).
- Tests passing `None`/partial data to non-optional fields use `model_construct` or real values.
- `TaskOperationOutput` gained field defaults mirroring the old converter's `.get(..., default)` leniency (`id`/`name`/`status`/`priority` stay required).
- Pydantic accepts `int` as a datetime timestamp where the old converter rejected non-strings; the wire only sends ISO strings, so the affected test now uses an uncoercible value.

## Verification

- `make test`: core 1097 / server 307 / client 232 / ui 914 / mcp 84 — all green
- `make typecheck`: pass
- `make lint`: pass

Closes #922. Supersedes #867 (its `statistics_converters.py` concern is the reshape case documented above — left as hand-written).
