### PR TITLE
docs(core): fix UseCase docstring example to use output DTO

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/base.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/base.py
@@ -19,12 +19,12 @@ class UseCase[TInput, TOutput](ABC):
         TOutput: The output type (usually a domain entity or DTO)
 
     Example:
-        class CreateTaskUseCase(UseCase[CreateTaskInput, Task]):
-            def execute(self, input_dto: CreateTaskInput) -> Task:
+        class CreateTaskUseCase(UseCase[CreateTaskInput, TaskOperationOutput]):
+            def execute(self, input_dto: CreateTaskInput) -> TaskOperationOutput:
                 # Validation
                 # Business logic
                 # Persistence
-                return task
+                return TaskOperationOutput.from_task(task)
     """
 
     @abstractmethod


### PR DESCRIPTION
## Summary

The docstring example in the `UseCase` base class showed `UseCase[..., Task]` returning a `Task` entity, but every concrete use case returns an output DTO (`TaskOperationOutput`, `TaskUpdateOutput`, `StatusChangeOutput`, etc.). This was a leftover from an earlier refactor (entities → output DTOs) and could mislead new contributors into breaking the controller-layer contract.

Updated the example to match the current DTO-return convention.

## Test plan

- Docstring-only change; pre-commit (ruff, mypy, codespell) and pre-push tests pass.

Closes #877