### PR TITLE
perf(ui): offload TUI initial task load to a worker thread

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -338,6 +338,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
             state=self.state,
             task_data_loader=self.task_data_loader,
             main_screen_provider=lambda: self.main_screen,
+            app=self,
             on_error=self._handle_api_error,
         )
 

--- a/packages/taskdog-ui/src/taskdog/tui/services/task_ui_manager.py
+++ b/packages/taskdog-ui/src/taskdog/tui/services/task_ui_manager.py
@@ -1,5 +1,6 @@
 """Task UI Manager for orchestrating data lifecycle in TUI."""
 
+import asyncio
 from collections.abc import Callable
 from datetime import date, timedelta
 from typing import TYPE_CHECKING
@@ -16,6 +17,7 @@ from taskdog_core.domain.exceptions.task_exceptions import (
 )
 
 if TYPE_CHECKING:
+    from taskdog.tui.app import TaskdogTUI
     from taskdog.tui.screens.main_screen import MainScreen
 
 
@@ -35,6 +37,7 @@ class TaskUIManager:
         state: TUIState,
         task_data_loader: TaskDataLoader,
         main_screen_provider: Callable[[], "MainScreen | None"],
+        app: "TaskdogTUI",
         on_error: Callable[
             [ServerConnectionError | AuthenticationError | ServerError], None
         ]
@@ -46,11 +49,13 @@ class TaskUIManager:
             state: Shared TUIState instance
             task_data_loader: Service for loading task data
             main_screen_provider: Callable that returns current MainScreen (lazy access)
+            app: The running app, used to dispatch background workers
             on_error: Optional callback for API errors (connection, auth, server)
         """
         self.state = state
         self.task_data_loader = task_data_loader
         self._get_main_screen = main_screen_provider
+        self._app = app
         self._on_error = on_error
 
     def _handle_api_error(
@@ -65,17 +70,83 @@ class TaskUIManager:
             self._on_error(error)
 
     def load_tasks(self, keep_scroll_position: bool = False) -> None:
-        """Load tasks and update UI.
+        """Load tasks and update the UI without blocking the event loop.
 
-        Performs a complete reload cycle: fetches data from API,
-        updates internal caches, and refreshes all UI components.
+        Samples widget geometry and sort state on the main thread, then runs the
+        blocking fetch + transform in a background thread via a worker so first
+        paint and interaction are not blocked by the synchronous HTTP round-trip.
+        UI mutations happen back on the main thread once the worker resumes.
+
+        Uses an exclusive worker group so that a reload arriving mid-flight
+        (e.g. a websocket task change) supersedes the in-flight load: last
+        result wins.
 
         Args:
             keep_scroll_position: Whether to preserve scroll position during refresh
         """
-        task_data = self._fetch_task_data()
+        # Sample anything that must be read on the main thread (widget geometry,
+        # shared state) BEFORE handing off to the worker thread.
+        date_range = self._calculate_gantt_date_range()
+        sort_by = self.state.sort_by
+        sort_reverse = self.state.sort_reverse
+        self._app.run_worker(
+            self._load_tasks_worker(
+                date_range, sort_by, sort_reverse, keep_scroll_position
+            ),
+            group="load_tasks",
+            exclusive=True,
+        )
+
+    async def _load_tasks_worker(
+        self,
+        date_range: tuple[date, date],
+        sort_by: str,
+        sort_reverse: bool,
+        keep_scroll_position: bool,
+    ) -> None:
+        """Fetch + transform off-thread, then apply the result on the main thread.
+
+        The blocking fetch/transform runs via asyncio.to_thread; error handling
+        and all UI/state mutation happen after the await, back on the event loop.
+        """
+        try:
+            task_data = await asyncio.to_thread(
+                self._load_task_data, date_range, sort_by, sort_reverse
+            )
+        except (ServerConnectionError, AuthenticationError, ServerError) as e:
+            self._handle_api_error(e)
+            task_data = self._create_empty_task_data()
+        except Exception:
+            task_data = self._create_empty_task_data()
+
+        # Back on the event-loop thread: safe to touch state and widgets.
+        if self._get_main_screen() is None:
+            return
         self._update_cache(task_data)
         self._refresh_ui(task_data, keep_scroll_position)
+
+    def _load_task_data(
+        self, date_range: tuple[date, date], sort_by: str, sort_reverse: bool
+    ) -> TaskData:
+        """Fetch and transform task data from the API.
+
+        Pure and blocking, so it is safe to run in a worker thread. Raises on API
+        errors; the caller handles them on the main thread.
+
+        Args:
+            date_range: (start, end) for the Gantt payload
+            sort_by: Sort field name
+            sort_reverse: Sort direction
+
+        Returns:
+            TaskData with all tasks, table view models, and gantt view model
+        """
+        return self.task_data_loader.load_tasks(
+            include_archived=False,  # Non-archived by default
+            sort_by=sort_by,
+            reverse=sort_reverse,
+            date_range=date_range,
+        )
 
     def _calculate_gantt_date_range(self) -> tuple[date, date]:
         """Calculate the date range for Gantt chart display.
@@ -92,27 +163,6 @@ class TaskUIManager:
         start_date = today - timedelta(days=today.weekday())
         end_date = start_date + timedelta(days=MIN_GANTT_DISPLAY_DAYS - 1)
         return (start_date, end_date)
-
-    def _fetch_task_data(self) -> TaskData:
-        """Fetch task data using TaskDataLoader.
-
-        Returns:
-            TaskData object containing all task information
-        """
-        try:
-            date_range = self._calculate_gantt_date_range()
-
-            return self.task_data_loader.load_tasks(
-                include_archived=False,  # Non-archived by default
-                sort_by=self.state.sort_by,
-                reverse=self.state.sort_reverse,
-                date_range=date_range,
-            )
-        except (ServerConnectionError, AuthenticationError, ServerError) as e:
-            self._handle_api_error(e)
-            return self._create_empty_task_data()
-        except Exception:
-            return self._create_empty_task_data()
 
     def _create_empty_task_data(self) -> TaskData:
         """Create empty TaskData to avoid crash on errors.

--- a/packages/taskdog-ui/tests/tui/services/test_task_ui_manager.py
+++ b/packages/taskdog-ui/tests/tui/services/test_task_ui_manager.py
@@ -10,6 +10,7 @@ from taskdog.tui.services.task_ui_manager import TaskUIManager
 from taskdog.tui.state.tui_state import TUIState
 from taskdog.view_models.gantt_view_model import GanttViewModel
 from taskdog.view_models.task_view_model import TaskRowViewModel
+from taskdog_core.application.dto.gantt_output import GanttDateRange, GanttOutput
 from taskdog_core.application.dto.task_dto import TaskRowDto
 from taskdog_core.application.dto.task_list_output import TaskListOutput
 from taskdog_core.domain.entities.task import TaskStatus
@@ -18,6 +19,8 @@ from taskdog_core.domain.exceptions.task_exceptions import (
     ServerConnectionError,
     ServerError,
 )
+
+_DATE_RANGE = (date.today(), date.today() + timedelta(days=7))
 
 
 def create_task_dto(task_id: int, name: str, status: TaskStatus) -> TaskRowDto:
@@ -70,6 +73,19 @@ def create_task_viewmodel(
     )
 
 
+def create_gantt_output() -> GanttOutput:
+    """Helper to create a minimal valid GanttOutput (API gantt payload)."""
+    return GanttOutput(
+        date_range=GanttDateRange(
+            start_date=date(2024, 1, 1), end_date=date(2024, 1, 31)
+        ),
+        tasks=[],
+        task_daily_hours={},
+        daily_workload={},
+        holidays=set(),
+    )
+
+
 def create_gantt_viewmodel() -> GanttViewModel:
     """Helper to create GanttViewModel with minimal fields."""
     return GanttViewModel(
@@ -114,12 +130,15 @@ class TestTaskUIManager:
         self.main_screen = MagicMock()
         self.main_screen.gantt_widget = MagicMock()
         self.main_screen.task_table = MagicMock()
+        self.main_screen.gantt_widget.calculate_date_range.return_value = _DATE_RANGE
+        self.app = MagicMock()
         self.on_error = MagicMock()
 
         self.manager = TaskUIManager(
             state=self.state,
             task_data_loader=self.task_data_loader,
             main_screen_provider=lambda: self.main_screen,
+            app=self.app,
             on_error=self.on_error,
         )
 
@@ -128,144 +147,128 @@ class TestTaskUIManager:
         assert self.manager.state is self.state
         assert self.manager.task_data_loader is self.task_data_loader
         assert self.manager._get_main_screen is not None
+        assert self.manager._app is self.app
         assert self.manager._on_error is self.on_error
 
-    def test_load_tasks_updates_cache_and_ui(self):
-        """Test load_tasks fetches data, updates cache, and refreshes UI."""
-        # Setup
+    def test_load_tasks_dispatches_worker(self):
+        """Test load_tasks samples geometry on the main thread and dispatches a worker."""
+        self.manager.load_tasks()
+
+        # Date range must be sampled on the (main) thread before handing off.
+        self.main_screen.gantt_widget.calculate_date_range.assert_called_once()
+        # The blocking work is offloaded to a worker, not run inline.
+        self.app.run_worker.assert_called_once()
+        # Close the coroutine handed to the (mocked) worker to avoid warnings.
+        self.app.run_worker.call_args[0][0].close()
+
+    @pytest.mark.asyncio
+    async def test_load_tasks_worker_updates_cache_and_ui(self):
+        """Test the worker fetches data, updates cache, and refreshes UI."""
         task = create_task_dto(1, "Test Task", TaskStatus.PENDING)
         vm = create_task_viewmodel(1, "Test Task", TaskStatus.PENDING)
         gantt = create_gantt_viewmodel()
         task_data = create_task_data([task], [vm], gantt)
-
         self.task_data_loader.load_tasks.return_value = task_data
-        self.main_screen.gantt_widget.calculate_date_range.return_value = (
-            date.today(),
-            date.today() + timedelta(days=7),
-        )
 
-        # Execute
-        self.manager.load_tasks()
+        await self.manager._load_tasks_worker(_DATE_RANGE, "id", False, False)
 
-        # Verify data loader was called
+        # Verify data loader was called off-thread
         self.task_data_loader.load_tasks.assert_called_once()
-
         # Verify state cache was updated
         assert len(self.state.tasks_cache) == 1
         assert len(self.state.viewmodels_cache) == 1
-
         # Verify UI widgets were refreshed
         self.main_screen.gantt_widget.update_gantt.assert_called_once()
         self.main_screen.refresh_tasks.assert_called_once()
 
-    def test_load_tasks_with_keep_scroll_position(self):
-        """Test load_tasks passes keep_scroll_position to refresh_tasks."""
-        # Setup
-        task_data = create_task_data()
-        self.task_data_loader.load_tasks.return_value = task_data
-        self.main_screen.gantt_widget.calculate_date_range.return_value = (
-            date.today(),
-            date.today() + timedelta(days=7),
-        )
+    @pytest.mark.asyncio
+    async def test_load_tasks_worker_keep_scroll_position(self):
+        """Test the worker passes keep_scroll_position through to refresh_tasks."""
+        self.task_data_loader.load_tasks.return_value = create_task_data()
 
-        # Execute with keep_scroll_position=True
-        self.manager.load_tasks(keep_scroll_position=True)
+        await self.manager._load_tasks_worker(_DATE_RANGE, "id", False, True)
 
-        # Verify refresh_tasks was called with keep_scroll_position=True
         self.main_screen.refresh_tasks.assert_called_once()
         call_kwargs = self.main_screen.refresh_tasks.call_args[1]
         assert call_kwargs.get("keep_scroll_position") is True
 
+    @pytest.mark.asyncio
+    async def test_load_tasks_worker_skips_ui_when_unmounted(self):
+        """Test the worker does not touch UI if the screen is gone after fetching."""
+        manager = TaskUIManager(
+            state=self.state,
+            task_data_loader=self.task_data_loader,
+            main_screen_provider=lambda: None,
+            app=self.app,
+        )
+        self.task_data_loader.load_tasks.return_value = create_task_data()
+
+        # Should not raise even though there is no main screen to update.
+        await manager._load_tasks_worker(_DATE_RANGE, "id", False, False)
+
+    def test_load_task_data_uses_given_settings(self):
+        """Test _load_task_data forwards the sampled sort/date settings to the loader."""
+        self.task_data_loader.load_tasks.return_value = create_task_data()
+
+        self.manager._load_task_data(_DATE_RANGE, "priority", True)
+
+        call_kwargs = self.task_data_loader.load_tasks.call_args[1]
+        assert call_kwargs["sort_by"] == "priority"
+        assert call_kwargs["reverse"] is True
+        assert call_kwargs["date_range"] == _DATE_RANGE
+        assert call_kwargs["include_archived"] is False
+
     def test_calculate_gantt_date_range_uses_widget(self):
         """Test _calculate_gantt_date_range delegates to gantt_widget."""
-        # Setup
         expected_range = (date(2024, 1, 1), date(2024, 1, 31))
         self.main_screen.gantt_widget.calculate_date_range.return_value = expected_range
 
-        # Execute
         result = self.manager._calculate_gantt_date_range()
 
-        # Verify
         assert result == expected_range
         self.main_screen.gantt_widget.calculate_date_range.assert_called_once()
 
     def test_calculate_gantt_date_range_fallback(self):
         """Test _calculate_gantt_date_range uses fallback when widget unavailable."""
-        # Setup - no main_screen
         manager = TaskUIManager(
             state=self.state,
             task_data_loader=self.task_data_loader,
             main_screen_provider=lambda: None,
+            app=self.app,
         )
 
-        # Execute
         start_date, end_date = manager._calculate_gantt_date_range()
 
-        # Verify fallback dates (this week's Monday to MIN_GANTT_DISPLAY_DAYS later)
         today = date.today()
         expected_start = today - timedelta(days=today.weekday())
         assert start_date == expected_start
         assert end_date > start_date
 
-    def test_fetch_task_data_handles_connection_error(self):
-        """Test _fetch_task_data calls error callback on ServerConnectionError."""
-        # Setup
-        original_error = ConnectionError("Connection refused")
+    @pytest.mark.asyncio
+    async def test_worker_handles_connection_error(self):
+        """Test the worker reports ServerConnectionError and falls back to empty data."""
         self.task_data_loader.load_tasks.side_effect = ServerConnectionError(
             base_url="http://localhost:8000",
-            original_error=original_error,
-        )
-        self.main_screen.gantt_widget.calculate_date_range.return_value = (
-            date.today(),
-            date.today() + timedelta(days=7),
+            original_error=ConnectionError("Connection refused"),
         )
 
-        # Execute
-        result = self.manager._fetch_task_data()
+        await self.manager._load_tasks_worker(_DATE_RANGE, "id", False, False)
 
-        # Verify error callback was called with the error
         self.on_error.assert_called_once()
-        error_arg = self.on_error.call_args[0][0]
-        assert isinstance(error_arg, ServerConnectionError)
-
-        # Verify empty TaskData is returned
-        assert result.all_tasks == []
-        assert result.table_view_models == []
-        assert result.gantt_view_model is None
-
-    def test_fetch_task_data_uses_state_settings(self):
-        """Test _fetch_task_data uses sort/filter settings from state."""
-        # Setup state
-        self.state.sort_by = "priority"
-        self.state.sort_reverse = True
-
-        task_data = create_task_data()
-        self.task_data_loader.load_tasks.return_value = task_data
-        self.main_screen.gantt_widget.calculate_date_range.return_value = (
-            date.today(),
-            date.today() + timedelta(days=7),
-        )
-
-        # Execute
-        self.manager._fetch_task_data()
-
-        # Verify data loader was called with state settings
-        call_kwargs = self.task_data_loader.load_tasks.call_args[1]
-        assert call_kwargs["sort_by"] == "priority"
-        assert call_kwargs["reverse"] is True
+        assert isinstance(self.on_error.call_args[0][0], ServerConnectionError)
+        # Empty data is applied: no rows cached, table still refreshed.
+        assert self.state.tasks_cache == []
+        self.main_screen.refresh_tasks.assert_called_once()
 
     def test_update_cache_updates_state(self):
         """Test _update_cache updates TUIState correctly."""
-        # Setup
         task = create_task_dto(1, "Test Task", TaskStatus.PENDING)
         vm = create_task_viewmodel(1, "Test Task", TaskStatus.PENDING)
         gantt = create_gantt_viewmodel()
         task_data = create_task_data([task], [vm], gantt)
 
-        # Execute
         self.manager._update_cache(task_data)
 
-        # Verify state was updated
         assert len(self.state.tasks_cache) == 1
         assert self.state.tasks_cache[0].id == 1
         assert len(self.state.viewmodels_cache) == 1
@@ -274,11 +277,11 @@ class TestTaskUIManager:
 
     def test_refresh_ui_without_main_screen(self):
         """Test _refresh_ui does nothing when main_screen is None."""
-        # Setup - no main_screen
         manager = TaskUIManager(
             state=self.state,
             task_data_loader=self.task_data_loader,
             main_screen_provider=lambda: None,
+            app=self.app,
         )
         task_data = create_task_data()
 
@@ -287,31 +290,25 @@ class TestTaskUIManager:
 
     def test_refresh_ui_updates_gantt_widget(self):
         """Test _refresh_ui updates gantt widget (reads from State cache)."""
-        # Setup
         task = create_task_dto(1, "Test Task", TaskStatus.PENDING)
         vm = create_task_viewmodel(1, "Test Task", TaskStatus.PENDING)
         gantt = create_gantt_viewmodel()
         task_data = create_task_data([task], [vm], gantt)
 
-        # Execute
         self.manager._refresh_ui(task_data, keep_scroll_position=False)
 
-        # Verify gantt widget was told to render
         self.main_screen.gantt_widget.update_gantt.assert_called_once()
         call_kwargs = self.main_screen.gantt_widget.update_gantt.call_args[1]
         assert call_kwargs["task_ids"] == [1]
 
     def test_refresh_ui_updates_task_table(self):
         """Test _refresh_ui updates task table with viewmodels."""
-        # Setup
         task = create_task_dto(1, "Test Task", TaskStatus.PENDING)
         vm = create_task_viewmodel(1, "Test Task", TaskStatus.PENDING)
         task_data = create_task_data([task], [vm])
 
-        # Execute
         self.manager._refresh_ui(task_data, keep_scroll_position=True)
 
-        # Verify task table was updated via main_screen
         self.main_screen.refresh_tasks.assert_called_once_with(
             keep_scroll_position=True
         )
@@ -330,6 +327,7 @@ class TestRecalculateGantt:
         # Setup default return values for gantt_widget methods
         self.main_screen.gantt_widget.get_filter_include_archived.return_value = False
         self.main_screen.gantt_widget.get_sort_by.return_value = "deadline"
+        self.app = MagicMock()
         self.on_error = MagicMock()
 
         # Setup mock API client and presenter on task_data_loader
@@ -340,18 +338,18 @@ class TestRecalculateGantt:
             state=self.state,
             task_data_loader=self.task_data_loader,
             main_screen_provider=lambda: self.main_screen,
+            app=self.app,
             on_error=self.on_error,
         )
 
     def test_recalculate_gantt_fetches_and_updates_widget(self):
         """Test recalculate_gantt fetches data and updates widget."""
-        # Setup
         gantt = create_gantt_viewmodel()
         task_list_output = TaskListOutput(
             tasks=[],
             total_count=0,
             filtered_count=0,
-            gantt_data=MagicMock(),
+            gantt_data=create_gantt_output(),
         )
         self.task_data_loader.api_client.list_tasks.return_value = task_list_output
         self.task_data_loader.gantt_presenter.present.return_value = gantt
@@ -359,10 +357,8 @@ class TestRecalculateGantt:
         start_date = date(2024, 1, 1)
         end_date = date(2024, 1, 31)
 
-        # Execute
         self.manager.recalculate_gantt(start_date, end_date)
 
-        # Verify API was called with parameters from gantt_widget
         self.task_data_loader.api_client.list_tasks.assert_called_once_with(
             include_archived=False,  # from gantt_widget.get_filter_include_archived()
             sort_by="deadline",  # from gantt_widget.get_sort_by()
@@ -372,16 +368,13 @@ class TestRecalculateGantt:
             gantt_end_date=end_date,
         )
 
-        # Verify presenter was called
         self.task_data_loader.gantt_presenter.present.assert_called_once()
 
-        # Verify State was updated and widget was told to render
         assert self.state.gantt_cache == gantt
         self.main_screen.gantt_widget.update_view_model_and_render.assert_called_once()
 
     def test_recalculate_gantt_respects_gantt_widget_filter_state(self):
         """Test recalculate_gantt uses filter/sort state from gantt_widget."""
-        # Setup - gantt_widget has "all tasks" filter enabled
         self.main_screen.gantt_widget.get_filter_include_archived.return_value = True
         self.main_screen.gantt_widget.get_sort_by.return_value = "priority"
 
@@ -390,50 +383,39 @@ class TestRecalculateGantt:
             tasks=[],
             total_count=0,
             filtered_count=0,
-            gantt_data=MagicMock(),
+            gantt_data=create_gantt_output(),
         )
         self.task_data_loader.api_client.list_tasks.return_value = task_list_output
         self.task_data_loader.gantt_presenter.present.return_value = gantt
 
-        # Execute
         self.manager.recalculate_gantt(date(2024, 1, 1), date(2024, 1, 31))
 
-        # Verify API was called with filter state from gantt_widget
         call_kwargs = self.task_data_loader.api_client.list_tasks.call_args[1]
-        assert (
-            call_kwargs["include_archived"] is True
-        )  # Respects gantt_widget.get_filter_include_archived()
-        assert (
-            call_kwargs["sort_by"] == "priority"
-        )  # Respects gantt_widget.get_sort_by()
+        assert call_kwargs["include_archived"] is True
+        assert call_kwargs["sort_by"] == "priority"
 
     def test_recalculate_gantt_handles_connection_error(self):
         """Test recalculate_gantt calls error callback on failure."""
-        # Setup
-        original_error = ConnectionError("Connection refused")
         self.task_data_loader.api_client.list_tasks.side_effect = ServerConnectionError(
             base_url="http://localhost:8000",
-            original_error=original_error,
+            original_error=ConnectionError("Connection refused"),
         )
 
-        # Execute
         self.manager.recalculate_gantt(date(2024, 1, 1), date(2024, 1, 31))
 
-        # Verify error callback was called with the error
         self.on_error.assert_called_once()
         error_arg = self.on_error.call_args[0][0]
         assert isinstance(error_arg, ServerConnectionError)
 
-        # Verify widget was NOT updated
         self.main_screen.gantt_widget.update_view_model_and_render.assert_not_called()
 
     def test_recalculate_gantt_without_main_screen(self):
         """Test recalculate_gantt handles missing main_screen gracefully."""
-        # Setup - no main_screen
         manager = TaskUIManager(
             state=self.state,
             task_data_loader=self.task_data_loader,
             main_screen_provider=lambda: None,
+            app=self.app,
             on_error=self.on_error,
         )
 
@@ -442,20 +424,17 @@ class TestRecalculateGantt:
             tasks=[],
             total_count=0,
             filtered_count=0,
-            gantt_data=MagicMock(),
+            gantt_data=create_gantt_output(),
         )
         self.task_data_loader.api_client.list_tasks.return_value = task_list_output
         self.task_data_loader.gantt_presenter.present.return_value = gantt
 
-        # Execute - should not raise
         manager.recalculate_gantt(date(2024, 1, 1), date(2024, 1, 31))
 
-        # Verify no error was raised and API was still called
         self.task_data_loader.api_client.list_tasks.assert_called_once()
 
     def test_recalculate_gantt_without_gantt_data(self):
         """Test recalculate_gantt handles None gantt_data gracefully."""
-        # Setup - no gantt_data in response
         task_list_output = TaskListOutput(
             tasks=[],
             total_count=0,
@@ -464,13 +443,9 @@ class TestRecalculateGantt:
         )
         self.task_data_loader.api_client.list_tasks.return_value = task_list_output
 
-        # Execute - should not raise
         self.manager.recalculate_gantt(date(2024, 1, 1), date(2024, 1, 31))
 
-        # Verify presenter was NOT called
         self.task_data_loader.gantt_presenter.present.assert_not_called()
-
-        # Verify widget was NOT updated
         self.main_screen.gantt_widget.update_view_model_and_render.assert_not_called()
 
 
@@ -484,12 +459,10 @@ class TestErrorHandling:
         self.task_data_loader = MagicMock(spec=TaskDataLoader)
         self.main_screen = MagicMock()
         self.main_screen.gantt_widget = MagicMock()
-        self.main_screen.gantt_widget.calculate_date_range.return_value = (
-            date.today(),
-            date.today() + timedelta(days=7),
-        )
+        self.main_screen.gantt_widget.calculate_date_range.return_value = _DATE_RANGE
         self.main_screen.gantt_widget.get_filter_include_archived.return_value = False
         self.main_screen.gantt_widget.get_sort_by.return_value = "deadline"
+        self.app = MagicMock()
         self.on_error = MagicMock()
 
         # Setup mock API client and presenter on task_data_loader
@@ -500,33 +473,36 @@ class TestErrorHandling:
             state=self.state,
             task_data_loader=self.task_data_loader,
             main_screen_provider=lambda: self.main_screen,
+            app=self.app,
             on_error=self.on_error,
         )
 
-    def test_fetch_task_data_handles_authentication_error(self):
-        """Test _fetch_task_data calls error callback with AuthenticationError."""
+    @pytest.mark.asyncio
+    async def test_worker_handles_authentication_error(self):
+        """Test the worker reports AuthenticationError and falls back to empty data."""
         self.task_data_loader.load_tasks.side_effect = AuthenticationError(
             message="Unauthorized",
         )
 
-        result = self.manager._fetch_task_data()
+        await self.manager._load_tasks_worker(_DATE_RANGE, "id", False, False)
 
         self.on_error.assert_called_once()
         assert isinstance(self.on_error.call_args[0][0], AuthenticationError)
-        assert result.all_tasks == []
+        assert self.state.tasks_cache == []
 
-    def test_fetch_task_data_handles_server_error(self):
-        """Test _fetch_task_data calls error callback with ServerError."""
+    @pytest.mark.asyncio
+    async def test_worker_handles_server_error(self):
+        """Test the worker reports ServerError and falls back to empty data."""
         self.task_data_loader.load_tasks.side_effect = ServerError(
             status_code=500,
             message="Internal Server Error",
         )
 
-        result = self.manager._fetch_task_data()
+        await self.manager._load_tasks_worker(_DATE_RANGE, "id", False, False)
 
         self.on_error.assert_called_once()
         assert isinstance(self.on_error.call_args[0][0], ServerError)
-        assert result.all_tasks == []
+        assert self.state.tasks_cache == []
 
     def test_recalculate_gantt_handles_authentication_error(self):
         """Test recalculate_gantt calls error callback with AuthenticationError."""
@@ -565,6 +541,7 @@ class TestCreateEmptyTaskData:
             state=state,
             task_data_loader=task_data_loader,
             main_screen_provider=lambda: None,
+            app=MagicMock(),
         )
 
         result = manager._create_empty_task_data()
@@ -585,6 +562,7 @@ class TestRefreshUIEdgeCases:
         self.state = TUIState()
         self.task_data_loader = MagicMock(spec=TaskDataLoader)
         self.main_screen = MagicMock()
+        self.app = MagicMock()
 
     def test_refresh_ui_without_gantt_widget(self):
         """Test _refresh_ui handles missing gantt_widget gracefully."""
@@ -594,6 +572,7 @@ class TestRefreshUIEdgeCases:
             state=self.state,
             task_data_loader=self.task_data_loader,
             main_screen_provider=lambda: self.main_screen,
+            app=self.app,
         )
 
         task = create_task_dto(1, "Test Task", TaskStatus.PENDING)
@@ -601,10 +580,8 @@ class TestRefreshUIEdgeCases:
         gantt = create_gantt_viewmodel()
         task_data = create_task_data([task], [vm], gantt)
 
-        # Execute - should not raise
         manager._refresh_ui(task_data, keep_scroll_position=False)
 
-        # Verify task table was still updated
         self.main_screen.refresh_tasks.assert_called_once()
 
     def test_refresh_ui_without_gantt_view_model(self):
@@ -615,9 +592,9 @@ class TestRefreshUIEdgeCases:
             state=self.state,
             task_data_loader=self.task_data_loader,
             main_screen_provider=lambda: self.main_screen,
+            app=self.app,
         )
 
-        # Create task_data with None gantt_view_model
         task = create_task_dto(1, "Test Task", TaskStatus.PENDING)
         vm = create_task_viewmodel(1, "Test Task", TaskStatus.PENDING)
         task_data = TaskData(
@@ -632,45 +609,36 @@ class TestRefreshUIEdgeCases:
             gantt_view_model=None,
         )
 
-        # Execute - should not raise
         manager._refresh_ui(task_data, keep_scroll_position=False)
 
-        # Verify gantt_widget.update_gantt was NOT called (no gantt data)
         self.main_screen.gantt_widget.update_gantt.assert_not_called()
-
-        # Verify task table was still updated
         self.main_screen.refresh_tasks.assert_called_once()
 
 
 class TestTaskUIManagerWithoutErrorCallback:
     """Test TaskUIManager behavior without error callback."""
 
-    def test_connection_error_without_callback(self):
-        """Test _fetch_task_data handles error gracefully without callback."""
+    @pytest.mark.asyncio
+    async def test_connection_error_without_callback(self):
+        """Test the worker handles an API error gracefully without a callback."""
         state = TUIState()
         task_data_loader = MagicMock(spec=TaskDataLoader)
         main_screen = MagicMock()
         main_screen.gantt_widget = MagicMock()
-        main_screen.gantt_widget.calculate_date_range.return_value = (
-            date.today(),
-            date.today() + timedelta(days=7),
-        )
 
-        # Setup - no error callback
         manager = TaskUIManager(
             state=state,
             task_data_loader=task_data_loader,
             main_screen_provider=lambda: main_screen,
+            app=MagicMock(),
         )
 
-        original_error = ConnectionError("Connection refused")
         task_data_loader.load_tasks.side_effect = ServerConnectionError(
             base_url="http://localhost:8000",
-            original_error=original_error,
+            original_error=ConnectionError("Connection refused"),
         )
 
-        # Execute - should not raise
-        result = manager._fetch_task_data()
+        # Execute - should not raise even without an error callback
+        await manager._load_tasks_worker(_DATE_RANGE, "id", False, False)
 
-        # Verify empty TaskData is returned
-        assert result.all_tasks == []
+        assert state.tasks_cache == []

--- a/packages/taskdog-ui/tests/tui/test_startup_smoke.py
+++ b/packages/taskdog-ui/tests/tui/test_startup_smoke.py
@@ -1,0 +1,114 @@
+"""Startup smoke test for the TUI.
+
+Verifies that the initial task load is offloaded to a background worker so it
+does not block first paint: even when the (synchronous) API client is slow,
+mounting the app must complete promptly, and the task list fills in afterwards.
+"""
+
+import asyncio
+from datetime import datetime
+from threading import Event
+
+import pytest
+
+from taskdog.tui.app import TaskdogTUI
+from taskdog_core.application.dto.task_dto import TaskRowDto
+from taskdog_core.application.dto.task_list_output import TaskListOutput
+from taskdog_core.domain.entities.task import TaskStatus
+
+
+def _make_task(task_id: int) -> TaskRowDto:
+    return TaskRowDto(
+        id=task_id,
+        name=f"Task {task_id}",
+        status=TaskStatus.PENDING,
+        priority=1,
+        planned_start=None,
+        planned_end=None,
+        deadline=None,
+        actual_start=None,
+        actual_end=None,
+        estimated_duration=None,
+        actual_duration_hours=None,
+        is_fixed=False,
+        depends_on=[],
+        tags=[],
+        is_archived=False,
+        is_finished=False,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+
+class _BlockingApiClient:
+    """Synchronous API client whose list_tasks blocks until released.
+
+    Simulates a slow/unreachable server. If the initial load ran on the event
+    loop, mounting would block here; with the worker offload it does not.
+    """
+
+    def __init__(self) -> None:
+        self.base_url = "http://test"
+        self.api_key = None
+        self.release = Event()
+        self.list_calls = 0
+
+    def list_tasks(self, **kwargs: object) -> TaskListOutput:
+        self.list_calls += 1
+        # Block the worker thread until the test releases it.
+        self.release.wait(timeout=5)
+        return TaskListOutput(
+            tasks=[_make_task(1), _make_task(2)],
+            total_count=2,
+            filtered_count=2,
+            gantt_data=None,
+        )
+
+    def check_health(self) -> bool:
+        return True
+
+
+class _FakeWebSocketClient:
+    """Minimal stand-in for WebSocketClient (no real network)."""
+
+    def __init__(self) -> None:
+        self._callback = None
+
+    def set_callback(self, on_message: object) -> None:
+        self._callback = on_message
+
+    async def connect(self) -> None:
+        return None
+
+    async def disconnect(self) -> None:
+        return None
+
+    def is_connected(self) -> bool:
+        return True
+
+
+@pytest.mark.asyncio
+async def test_initial_load_does_not_block_first_paint() -> None:
+    """Mount completes while the slow fetch is still in flight; data fills in after."""
+    api = _BlockingApiClient()
+    app = TaskdogTUI(api_client=api, websocket_client=_FakeWebSocketClient())
+
+    async with app.run_test() as pilot:
+        # Reaching here at all proves on_mount did not block on list_tasks.
+        # Wait until the worker thread has entered the (blocked) fetch.
+        for _ in range(200):
+            if api.list_calls >= 1:
+                break
+            await asyncio.sleep(0.01)
+        assert api.list_calls >= 1, "initial load was never dispatched to a worker"
+
+        # The fetch is still blocked, so no rows are cached yet — the UI is not
+        # frozen waiting for it.
+        assert app.state.viewmodels_cache == []
+
+        # Release the fetch and let the worker apply the result on the main thread.
+        api.release.set()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert len(app.state.viewmodels_cache) == 2


### PR DESCRIPTION
## Summary

TUI startup blocked first paint. `on_mount` scheduled the initial load via `call_after_refresh(_load_tasks_if_ready)` — a **synchronous** callback that ran the blocking `httpx.Client.list_tasks` plus the table/gantt presenter transforms directly on the Textual event loop. Nothing could paint until the round-trip and all view-model builds finished, and on a slow/unreachable server the UI froze for up to the client's 30s timeout.

The rest of the app already offloads sync HTTP (`ConnectionMonitor`, `show`/`stats`/`audit` dialogs) via `run_worker` + `asyncio.to_thread`; only the initial/reload path was left on the loop. This change brings it in line.

## Change

`TaskUIManager.load_tasks` now:
1. Samples widget geometry (`gantt_widget.calculate_date_range()`) and sort state **on the main thread** (these must not be read off-thread), then
2. dispatches a worker that runs the blocking fetch + transform via `asyncio.to_thread`, then
3. applies state/UI mutations **back on the loop** (after the `await`), so no `call_from_thread` marshalling is needed.

- Exclusive `"load_tasks"` worker group → a reload arriving mid-flight (sort toggle, websocket task change) supersedes the in-flight one (last result wins).
- Error handling moved after the await so `on_error`/`notify` runs on the main thread.
- `TaskUIManager` now takes the `app` to dispatch the worker (mirrors `ConnectionMonitor`).
- Call sites are unchanged — every reload funnels through `load_tasks`, so the shared reload path is unblocked too.

## Effect

First interactive paint no longer waits for the `list_tasks` round-trip + deserialization + 2×N view-model builds; a slow/unreachable server keeps the UI responsive instead of freezing.

## Verification

- **Startup smoke test** (`tests/tui/test_startup_smoke.py`, runs in the default suite): a deliberately blocking API client no longer blocks mount — the app reaches an interactive state with an empty list while the fetch is in flight, then fills in once released. Confirmed it **fails against the old synchronous code** (mount blocks ~5s and the cache is already populated at first paint), so it genuinely guards the regression.
- `make test-ui` (full suite): **905 passed**, no regressions.
- `TaskUIManager` unit tests reworked around the worker decomposition: **26 passed** when run directly. Note: `tests/tui/services/` is excluded from the default suite (pre-existing, see `tests/conftest.py` — "fix in a separate PR"), which is why the startup proof lives under `tests/tui/`.
- `ruff` ✓, `mypy --strict` (172 files) ✓, `vulture` (no dead code) ✓, `codespell` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
