### PR TITLE
Improve native Windows editor and config defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ uvx --from taskdog-ui taskdog tui
 
 **Supported Platforms**: Linux, macOS
 
+**Experimental**: Windows (WSL2 recommended; native support is still being hardened)
+
 ### Recommended (with systemd/launchd service)
 
 ```bash
@@ -79,6 +81,14 @@ taskdog tui
 ```
 
 For complete setup including API key configuration, see **[Quick Start Guide](docs/QUICKSTART.md)**.
+
+### Windows users
+
+- WSL2 is recommended and follows the same setup flow as Linux.
+- Native Windows support is experimental. By default, data is stored under
+  `%LOCALAPPDATA%\taskdog` and configuration under `%APPDATA%\taskdog`.
+- The editor integration checks `%EDITOR%` first, then falls back to `code`,
+  `notepad`, and `vim`.
 
 ## Features
 

--- a/packages/taskdog-core/src/taskdog_core/shared/xdg_utils.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/xdg_utils.py
@@ -1,31 +1,56 @@
-"""XDG Base Directory utilities for taskdog.
+"""Platform directory utilities for taskdog.
 
-Implements the XDG Base Directory Specification:
-https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+Uses XDG Base Directory defaults on Unix-like systems and AppData defaults on
+Windows, while keeping XDG environment variables as explicit overrides.
 """
 
 import os
+import platform
 from pathlib import Path
 
 from taskdog_core.shared.constants.file_management import CONFIG_FILE_NAME
 
 
 class XDGDirectories:
-    """XDG Base Directory helper for taskdog."""
+    """Platform-specific directory helper for taskdog.
+
+    XDG environment variables are honored first for compatibility. Native
+    Windows defaults use AppData locations when XDG variables are not set.
+    """
 
     APP_NAME = "taskdog"
 
     @classmethod
+    def _default_data_base(cls) -> Path:
+        """Get platform default base directory for application data."""
+        if platform.system() == "Windows":
+            local_app_data = os.getenv("LOCALAPPDATA")
+            if local_app_data:
+                return Path(local_app_data)
+            return Path.home() / "AppData" / "Local"
+        return Path.home() / ".local" / "share"
+
+    @classmethod
+    def _default_config_base(cls) -> Path:
+        """Get platform default base directory for configuration files."""
+        if platform.system() == "Windows":
+            app_data = os.getenv("APPDATA")
+            if app_data:
+                return Path(app_data)
+            return Path.home() / "AppData" / "Roaming"
+        return Path.home() / ".config"
+
+    @classmethod
     def get_data_home(cls, create: bool = True) -> Path:
-        """Get XDG_DATA_HOME directory for taskdog.
+        """Get application data directory for taskdog.
 
         Returns:
-            Path to $XDG_DATA_HOME/taskdog (default: ~/.local/share/taskdog)
+            Path to $XDG_DATA_HOME/taskdog, or the platform default.
 
         Args:
             create: Create directory if it doesn't exist (default: True)
         """
-        base_dir = os.getenv("XDG_DATA_HOME", str(Path("~/.local/share").expanduser()))
+        base_dir = Path(os.getenv("XDG_DATA_HOME") or cls._default_data_base())
         data_dir = Path(base_dir) / cls.APP_NAME
 
         if create:
@@ -35,15 +60,15 @@ class XDGDirectories:
 
     @classmethod
     def get_config_home(cls, create: bool = True) -> Path:
-        """Get XDG_CONFIG_HOME directory for taskdog.
+        """Get configuration directory for taskdog.
 
         Returns:
-            Path to $XDG_CONFIG_HOME/taskdog (default: ~/.config/taskdog)
+            Path to $XDG_CONFIG_HOME/taskdog, or the platform default.
 
         Args:
             create: Create directory if it doesn't exist (default: True)
         """
-        base_dir = os.getenv("XDG_CONFIG_HOME", str(Path("~/.config").expanduser()))
+        base_dir = Path(os.getenv("XDG_CONFIG_HOME") or cls._default_config_base())
         config_dir = Path(base_dir) / cls.APP_NAME
 
         if create:

--- a/packages/taskdog-core/tests/shared/test_xdg_utils.py
+++ b/packages/taskdog-core/tests/shared/test_xdg_utils.py
@@ -13,9 +13,18 @@ class TestXDGDirectories:
     def test_get_data_home_default(self):
         """Test get_data_home with default XDG_DATA_HOME."""
         # Use patch.dict with clear=True to ensure complete environment isolation
-        with patch.dict(os.environ, {}, clear=True):
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "taskdog_core.shared.xdg_utils.platform.system", return_value="Linux"
+            ),
+            patch(
+                "taskdog_core.shared.xdg_utils.Path.home",
+                return_value=Path("/home/test"),
+            ),
+        ):
             data_home = XDGDirectories.get_data_home(create=False)
-            expected = Path.home() / ".local" / "share" / "taskdog"
+            expected = Path("/home/test/.local/share/taskdog")
             assert data_home == expected
 
     def test_get_data_home_custom(self):
@@ -28,9 +37,86 @@ class TestXDGDirectories:
     def test_get_config_home_default(self):
         """Test get_config_home with default XDG_CONFIG_HOME."""
         # Use patch.dict with clear=True to ensure complete environment isolation
-        with patch.dict(os.environ, {}, clear=True):
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "taskdog_core.shared.xdg_utils.platform.system", return_value="Linux"
+            ),
+            patch(
+                "taskdog_core.shared.xdg_utils.Path.home",
+                return_value=Path("/home/test"),
+            ),
+        ):
             config_home = XDGDirectories.get_config_home(create=False)
-            expected = Path.home() / ".config" / "taskdog"
+            expected = Path("/home/test/.config/taskdog")
+            assert config_home == expected
+
+    def test_get_data_home_windows_default(self):
+        """Test get_data_home with Windows LOCALAPPDATA."""
+        with (
+            patch.dict(
+                os.environ, {"LOCALAPPDATA": "C:/Users/test/AppData/Local"}, clear=True
+            ),
+            patch(
+                "taskdog_core.shared.xdg_utils.platform.system", return_value="Windows"
+            ),
+        ):
+            data_home = XDGDirectories.get_data_home(create=False)
+            expected = Path("C:/Users/test/AppData/Local/taskdog")
+            assert data_home == expected
+
+    def test_get_config_home_windows_default(self):
+        """Test get_config_home with Windows APPDATA."""
+        with (
+            patch.dict(
+                os.environ,
+                {"APPDATA": "C:/Users/test/AppData/Roaming"},
+                clear=True,
+            ),
+            patch(
+                "taskdog_core.shared.xdg_utils.platform.system", return_value="Windows"
+            ),
+        ):
+            config_home = XDGDirectories.get_config_home(create=False)
+            expected = Path("C:/Users/test/AppData/Roaming/taskdog")
+            assert config_home == expected
+
+    def test_xdg_data_home_overrides_windows_default(self):
+        """Test XDG_DATA_HOME remains higher priority on Windows."""
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "XDG_DATA_HOME": "/tmp/xdg-data",
+                    "LOCALAPPDATA": "C:/Users/test/AppData/Local",
+                },
+                clear=True,
+            ),
+            patch(
+                "taskdog_core.shared.xdg_utils.platform.system", return_value="Windows"
+            ),
+        ):
+            data_home = XDGDirectories.get_data_home(create=False)
+            expected = Path("/tmp/xdg-data/taskdog")
+            assert data_home == expected
+
+    def test_xdg_config_home_overrides_windows_default(self):
+        """Test XDG_CONFIG_HOME remains higher priority on Windows."""
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "XDG_CONFIG_HOME": "/tmp/xdg-config",
+                    "APPDATA": "C:/Users/test/AppData/Roaming",
+                },
+                clear=True,
+            ),
+            patch(
+                "taskdog_core.shared.xdg_utils.platform.system", return_value="Windows"
+            ),
+        ):
+            config_home = XDGDirectories.get_config_home(create=False)
+            expected = Path("/tmp/xdg-config/taskdog")
             assert config_home == expected
 
     def test_get_config_home_custom(self):

--- a/packages/taskdog-ui/src/taskdog/utils/editor.py
+++ b/packages/taskdog-ui/src/taskdog/utils/editor.py
@@ -1,7 +1,15 @@
 """Editor utilities for opening files in user's preferred editor."""
 
 import os
+import platform
 import shutil
+
+
+def _fallback_editors() -> list[str]:
+    """Return platform-appropriate editor fallbacks."""
+    if platform.system() == "Windows":
+        return ["code", "notepad", "vim"]
+    return ["vim", "nano", "vi"]
 
 
 def get_editor() -> str:
@@ -19,11 +27,13 @@ def get_editor() -> str:
         return editor
 
     # Fallback to common editors
-    for fallback in ["vim", "nano", "vi"]:
+    fallbacks = _fallback_editors()
+    for fallback in fallbacks:
         if shutil.which(fallback):
             return fallback
 
     # No editor found
     raise RuntimeError(
-        "No editor found. Please set $EDITOR environment variable or install vim, nano, or vi."
+        "No editor found. Please set $EDITOR environment variable "
+        f"or install one of: {', '.join(fallbacks)}."
     )

--- a/packages/taskdog-ui/tests/utils/test_editor.py
+++ b/packages/taskdog-ui/tests/utils/test_editor.py
@@ -1,6 +1,6 @@
 """Tests for editor utilities."""
 
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 
@@ -33,7 +33,10 @@ class TestGetEditor:
         """Test fallback to vim when $EDITOR is not set."""
         mock_which.return_value = "/usr/bin/vim"
 
-        with patch("os.getenv", return_value=None):
+        with (
+            patch("os.getenv", return_value=None),
+            patch("taskdog.utils.editor.platform.system", return_value="Linux"),
+        ):
             result = get_editor()
             assert result == "vim"
 
@@ -42,7 +45,10 @@ class TestGetEditor:
         """Test fallback to nano when vim is not found."""
         mock_which.side_effect = lambda cmd: "/usr/bin/nano" if cmd == "nano" else None
 
-        with patch("os.getenv", return_value=None):
+        with (
+            patch("os.getenv", return_value=None),
+            patch("taskdog.utils.editor.platform.system", return_value="Linux"),
+        ):
             result = get_editor()
             assert result == "nano"
 
@@ -51,24 +57,96 @@ class TestGetEditor:
         """Test fallback to vi when vim and nano are not found."""
         mock_which.side_effect = lambda cmd: "/usr/bin/vi" if cmd == "vi" else None
 
-        with patch("os.getenv", return_value=None):
+        with (
+            patch("os.getenv", return_value=None),
+            patch("taskdog.utils.editor.platform.system", return_value="Linux"),
+        ):
             result = get_editor()
             assert result == "vi"
+
+    @patch("shutil.which")
+    def test_windows_fallback_to_code_when_no_editor_env(self, mock_which) -> None:
+        """Test Windows fallback to VS Code when $EDITOR is not set."""
+        mock_which.side_effect = lambda cmd: (
+            "C:/Tools/code.exe" if cmd == "code" else None
+        )
+
+        with (
+            patch("os.getenv", return_value=None),
+            patch("taskdog.utils.editor.platform.system", return_value="Windows"),
+        ):
+            result = get_editor()
+            assert result == "code"
+
+        mock_which.assert_called_once_with("code")
+
+    @patch("shutil.which")
+    def test_windows_fallback_to_notepad_when_code_not_found(self, mock_which) -> None:
+        """Test Windows fallback to notepad when code is not found."""
+        mock_which.side_effect = lambda cmd: (
+            "C:/Windows/System32/notepad.exe" if cmd == "notepad" else None
+        )
+
+        with (
+            patch("os.getenv", return_value=None),
+            patch("taskdog.utils.editor.platform.system", return_value="Windows"),
+        ):
+            result = get_editor()
+            assert result == "notepad"
+
+        assert mock_which.call_args_list == [call("code"), call("notepad")]
+
+    @patch("shutil.which")
+    def test_windows_fallback_to_vim_when_code_and_notepad_not_found(
+        self, mock_which
+    ) -> None:
+        """Test Windows fallback to vim when code and notepad are not found."""
+        mock_which.side_effect = lambda cmd: (
+            "C:/Tools/vim.exe" if cmd == "vim" else None
+        )
+
+        with (
+            patch("os.getenv", return_value=None),
+            patch("taskdog.utils.editor.platform.system", return_value="Windows"),
+        ):
+            result = get_editor()
+            assert result == "vim"
+
+        assert mock_which.call_args_list == [call("code"), call("notepad"), call("vim")]
 
     @patch("shutil.which", return_value=None)
     def test_raises_runtime_error_when_no_editor_found(self, mock_which) -> None:
         """Test that RuntimeError is raised when no editor is found."""
-        with patch("os.getenv", return_value=None):
+        with (
+            patch("os.getenv", return_value=None),
+            patch("taskdog.utils.editor.platform.system", return_value="Linux"),
+        ):
             with pytest.raises(RuntimeError) as exc_info:
                 get_editor()
 
             assert "No editor found" in str(exc_info.value)
             assert "$EDITOR" in str(exc_info.value)
+            assert "vim, nano, vi" in str(exc_info.value)
+
+    @patch("shutil.which", return_value=None)
+    def test_windows_runtime_error_mentions_windows_fallbacks(self, mock_which) -> None:
+        """Test that Windows errors mention Windows-specific fallback editors."""
+        with (
+            patch("os.getenv", return_value=None),
+            patch("taskdog.utils.editor.platform.system", return_value="Windows"),
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                get_editor()
+
+            assert "code, notepad, vim" in str(exc_info.value)
 
     @patch("shutil.which", return_value="/usr/bin/vim")
     def test_empty_editor_env_uses_fallback(self, mock_which) -> None:
         """Test that empty $EDITOR uses fallback."""
-        with patch("os.getenv", return_value=""):
+        with (
+            patch("os.getenv", return_value=""),
+            patch("taskdog.utils.editor.platform.system", return_value="Linux"),
+        ):
             result = get_editor()
             assert result == "vim"
 
@@ -77,7 +155,10 @@ class TestGetEditor:
         """Test that shutil.which is called with correct arguments."""
         mock_which.return_value = "/usr/bin/vim"
 
-        with patch("os.getenv", return_value=None):
+        with (
+            patch("os.getenv", return_value=None),
+            patch("taskdog.utils.editor.platform.system", return_value="Linux"),
+        ):
             get_editor()
 
         mock_which.assert_called()


### PR DESCRIPTION
Refs #825.

## Summary
- keep `$EDITOR` as the first choice, then use Windows-specific fallbacks: `code`, `notepad`, `vim`
- use `%LOCALAPPDATA%\taskdog` for data and `%APPDATA%\taskdog` for config on native Windows when XDG variables are not set
- document Windows as experimental, with WSL2 recommended for the full supported path

## Verification
- `uv run --with ruff ruff format --config pyproject.toml ...`
- `uv run --with ruff ruff check --fix --config pyproject.toml ...`
- `uv run --package taskdog-core --extra dev python -m pytest packages/taskdog-core/tests/shared/test_xdg_utils.py -q` (10 passed)
- `uv run --package taskdog-ui --extra dev python -m pytest packages/taskdog-ui/tests/utils/test_editor.py -q` (13 passed)
- `uv run --package taskdog-core --extra dev mypy --config-file pyproject.toml packages/taskdog-core/src/taskdog_core/shared/xdg_utils.py`
- `uv run --package taskdog-ui --extra dev mypy --config-file pyproject.toml packages/taskdog-ui/src/taskdog/utils/editor.py`