### PR TITLE
fix: disable animated half-page scroll in audit log

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/widgets/audit_log_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/audit_log_table.py
@@ -78,6 +78,14 @@ class AuditLogTable(DataTable, TUIWidget, ViNavigationMixin):  # type: ignore[ty
         """Scroll to the bottom of the table."""
         self.scroll_end(animate=False)
 
+    def action_page_down(self) -> None:
+        """Scroll down by half a page without animation."""
+        self.scroll_page_down(animate=False)
+
+    def action_page_up(self) -> None:
+        """Scroll up by half a page without animation."""
+        self.scroll_page_up(animate=False)
+
     def on_mount(self) -> None:
         """Set up table columns."""
         self.add_column(

--- a/packages/taskdog-ui/tests/tui/widgets/test_audit_log_table.py
+++ b/packages/taskdog-ui/tests/tui/widgets/test_audit_log_table.py
@@ -1,0 +1,31 @@
+"""Tests for AuditLogTable keyboard navigation behavior."""
+
+from taskdog.tui.widgets.audit_log_table import AuditLogTable
+
+
+class TestAuditLogTablePageScrollActions:
+    """Ctrl+d/Ctrl+u should use discrete page scrolling like other audit log moves."""
+
+    def test_page_down_disables_animation(self, monkeypatch) -> None:
+        calls: list[bool] = []
+        table = AuditLogTable()
+
+        monkeypatch.setattr(
+            table, "scroll_page_down", lambda *, animate: calls.append(animate)
+        )
+
+        table.action_page_down()
+
+        assert calls == [False]
+
+    def test_page_up_disables_animation(self, monkeypatch) -> None:
+        calls: list[bool] = []
+        table = AuditLogTable()
+
+        monkeypatch.setattr(
+            table, "scroll_page_up", lambda *, animate: calls.append(animate)
+        )
+
+        table.action_page_up()
+
+        assert calls == [False]


### PR DESCRIPTION
## Summary
- disable animation for `Ctrl+d` and `Ctrl+u` in `AuditLogTable` so half-page scrolling matches the widget's other navigation actions
- add a focused regression test covering the non-animated page scroll handlers

## Testing
- `python -m pytest packages/taskdog-ui/tests/tui/widgets/test_audit_log_table.py`
- `python -m ruff check --config pyproject.toml packages/taskdog-ui/src/taskdog/tui/widgets/audit_log_table.py packages/taskdog-ui/tests/tui/widgets/test_audit_log_table.py`

Closes #939.