### PR TITLE
perf(ui): keep Textual off the CLI startup path for audit logs

### DIFF
--- a/packages/taskdog-ui/src/taskdog/cli/commands/audit_logs.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/audit_logs.py
@@ -29,11 +29,12 @@ from taskdog.constants.audit_log import (
 )
 from taskdog.constants.common import HEADER_ID, TABLE_HEADER_STYLE
 from taskdog.constants.formatting import format_table_title
-from taskdog.tui.widgets.audit_log_entry_builder import format_audit_changes
+from taskdog.formatters.audit_log_formatter import compact_changes, truncate_error
+from taskdog.presenters.audit_log_presenter import AuditLogPresenter
 
 if TYPE_CHECKING:
     from taskdog.cli.context import CliContext
-    from taskdog_core.application.dto.audit_log_dto import AuditLogOutput
+    from taskdog.view_models.audit_log_view_model import AuditLogRowViewModel
 
 
 def _parse_date_filter(date_str: str, end_of_day: bool = False) -> datetime:
@@ -53,27 +54,23 @@ def _parse_date_filter(date_str: str, end_of_day: bool = False) -> datetime:
         return datetime.fromisoformat(f"{date_str}{suffix}")
 
 
-def _format_resource(log: AuditLogOutput) -> str:
+def _format_resource(row: AuditLogRowViewModel) -> str:
     """Format resource display for audit log entry."""
-    if log.resource_id and log.resource_name:
-        return f"[cyan]#{log.resource_id}[/cyan] {log.resource_name}"
-    if log.resource_id:
-        return f"[cyan]#{log.resource_id}[/cyan]"
-    if log.resource_name:
-        return log.resource_name
+    if row.resource_id and row.resource_name:
+        return f"[cyan]#{row.resource_id}[/cyan] {row.resource_name}"
+    if row.resource_id:
+        return f"[cyan]#{row.resource_id}[/cyan]"
+    if row.resource_name:
+        return row.resource_name
     return "[dim]-[/dim]"
 
 
-def _format_changes(log: AuditLogOutput) -> str:
+def _format_changes(row: AuditLogRowViewModel) -> str:
     """Format changes display for audit log entry."""
-    if not log.success and log.error_message:
-        error_msg = log.error_message[:AUDIT_CHANGES_WIDTH]
-        if len(log.error_message) > AUDIT_CHANGES_WIDTH:
-            error_msg += "..."
+    if not row.success and row.error_message:
+        error_msg = truncate_error(row.error_message, AUDIT_CHANGES_WIDTH)
         return f"[red]{error_msg}[/red]"
-    return format_audit_changes(
-        log.old_values, log.new_values, max_length=AUDIT_CHANGES_WIDTH
-    )
+    return compact_changes(row.changes, AUDIT_CHANGES_WIDTH)
 
 
 @click.command(
@@ -174,14 +171,16 @@ def audit_logs_command(
         limit=limit,
     )
 
-    if not result.logs:
+    view_model = AuditLogPresenter().present(result)
+
+    if not view_model.rows:
         console_writer.info("No audit logs found matching the criteria.")
         return
 
     # Create Rich table
     table = Table(
         title=format_table_title(
-            f"Audit Logs ({len(result.logs)} of {result.total_count})"
+            f"Audit Logs ({len(view_model.rows)} of {view_model.total_count})"
         ),
         show_header=True,
         header_style=TABLE_HEADER_STYLE,
@@ -198,29 +197,28 @@ def audit_logs_command(
     table.add_column(HEADER_AUDIT_CLIENT, width=AUDIT_CLIENT_WIDTH)
     table.add_column(HEADER_AUDIT_STATUS, width=AUDIT_STATUS_WIDTH)
 
-    for log in result.logs:
+    for row in view_model.rows:
         status_style = (
             COLUMN_AUDIT_STATUS_OK_STYLE
-            if log.success
+            if row.success
             else COLUMN_AUDIT_STATUS_FAIL_STYLE
         )
-        status_label = "OK" if log.success else "FAILED"
-        changes = _format_changes(log)
+        status_label = "OK" if row.success else "FAILED"
         table.add_row(
-            str(log.id),
-            log.timestamp.strftime("%Y-%m-%d %H:%M:%S"),
-            _format_resource(log),
-            log.operation,
-            changes,
-            log.client_name or "[dim]anonymous[/dim]",
+            str(row.id),
+            row.timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+            _format_resource(row),
+            row.operation,
+            _format_changes(row),
+            row.client_name or "[dim]anonymous[/dim]",
             f"[{status_style}]{status_label}[/{status_style}]",
         )
 
     console_writer.print(table)
 
     # Show pagination info if there are more logs
-    if result.total_count > len(result.logs):
+    if view_model.total_count > len(view_model.rows):
         console_writer.info(
-            f"Showing {len(result.logs)} of {result.total_count} logs. "
+            f"Showing {len(view_model.rows)} of {view_model.total_count} logs. "
             f"Use --limit to see more."
         )

--- a/packages/taskdog-ui/src/taskdog/formatters/audit_log_formatter.py
+++ b/packages/taskdog-ui/src/taskdog/formatters/audit_log_formatter.py
@@ -1,0 +1,41 @@
+"""Rich-free display helpers for audit log changes.
+
+These helpers compact a presentation-ready list of changes into a single,
+width-bounded string. They depend only on the audit log ViewModels, so they
+are shared by both the CLI renderer and the TUI widgets without pulling in
+Rich or Textual.
+"""
+
+from collections.abc import Sequence
+
+from taskdog.view_models.audit_log_view_model import AuditChangeViewModel
+
+MAX_VISIBLE_CHANGES = 2
+
+
+def compact_changes(changes: Sequence[AuditChangeViewModel], max_length: int) -> str:
+    """Join changes into a compact, width-bounded string.
+
+    Shows at most ``MAX_VISIBLE_CHANGES`` changes with a ``(+N)`` suffix for
+    the rest, then truncates the whole string to ``max_length``.
+    """
+    if not changes:
+        return ""
+
+    parts = [f"{c.key}: {c.old} → {c.new}" for c in changes]
+    if len(parts) > MAX_VISIBLE_CHANGES:
+        visible = parts[:MAX_VISIBLE_CHANGES]
+        result = ", ".join(visible) + f" (+{len(parts) - MAX_VISIBLE_CHANGES})"
+    else:
+        result = ", ".join(parts)
+
+    if len(result) > max_length:
+        return result[: max_length - 3] + "..."
+    return result
+
+
+def truncate_error(message: str, max_length: int) -> str:
+    """Truncate an error message to ``max_length``, appending ``...`` if cut."""
+    if len(message) > max_length:
+        return message[:max_length] + "..."
+    return message

--- a/packages/taskdog-ui/src/taskdog/presenters/audit_log_presenter.py
+++ b/packages/taskdog-ui/src/taskdog/presenters/audit_log_presenter.py
@@ -1,0 +1,78 @@
+"""Presenter for converting AuditLogListOutput DTO to AuditLogViewModel.
+
+This presenter owns the audit-log *mapping* logic: selecting which fields
+changed between old and new values and formatting each value for display. It
+is free of rendering-technology dependencies (no Rich, no Textual) so it can
+be used from both the CLI and the TUI.
+"""
+
+from typing import Any
+
+from taskdog.view_models.audit_log_view_model import (
+    AuditChangeViewModel,
+    AuditLogRowViewModel,
+    AuditLogViewModel,
+)
+from taskdog_core.application.dto.audit_log_dto import (
+    AuditLogListOutput,
+    AuditLogOutput,
+)
+
+MAX_VALUE_LENGTH = 15
+
+
+class AuditLogPresenter:
+    """Convert AuditLogListOutput DTO to AuditLogViewModel."""
+
+    def present(self, output: AuditLogListOutput) -> AuditLogViewModel:
+        return AuditLogViewModel(
+            rows=tuple(self._map_row(log) for log in output.logs),
+            total_count=output.total_count,
+        )
+
+    def _map_row(self, log: AuditLogOutput) -> AuditLogRowViewModel:
+        return AuditLogRowViewModel(
+            id=log.id,
+            timestamp=log.timestamp,
+            operation=log.operation,
+            client_name=log.client_name,
+            resource_id=log.resource_id,
+            resource_name=log.resource_name,
+            success=log.success,
+            error_message=log.error_message,
+            changes=self._compute_changes(log.old_values, log.new_values),
+        )
+
+    def _compute_changes(
+        self,
+        old_values: dict[str, Any] | None,
+        new_values: dict[str, Any] | None,
+    ) -> tuple[AuditChangeViewModel, ...]:
+        all_keys: set[str] = set()
+        if old_values:
+            all_keys.update(old_values.keys())
+        if new_values:
+            all_keys.update(new_values.keys())
+
+        changes: list[AuditChangeViewModel] = []
+        for key in sorted(all_keys):
+            old_val = old_values.get(key) if old_values else None
+            new_val = new_values.get(key) if new_values else None
+            if old_val != new_val:
+                changes.append(
+                    AuditChangeViewModel(
+                        key=key,
+                        old=self._format_value(old_val),
+                        new=self._format_value(new_val),
+                    )
+                )
+        return tuple(changes)
+
+    def _format_value(self, value: Any) -> str:
+        if value is None:
+            return "∅"
+        if isinstance(value, bool):
+            return "✓" if value else "✗"
+        if isinstance(value, str) and len(value) > MAX_VALUE_LENGTH:
+            return value[:MAX_VALUE_LENGTH] + "..."
+        return str(value)

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/task_detail_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/task_detail_dialog.py
@@ -12,6 +12,7 @@ from textual.widgets import Label, Markdown, Static, TabbedContent, TabPane, Tab
 
 from taskdog.constants.colors import STATUS_COLORS_BOLD
 from taskdog.formatters.date_time_formatter import DateTimeFormatter
+from taskdog.presenters.audit_log_presenter import AuditLogPresenter
 from taskdog.tui.dialogs.base_dialog import BaseModalDialog
 from taskdog.tui.widgets.audit_log_entry_builder import create_audit_log_table
 from taskdog.tui.widgets.vi_navigation_mixin import ViNavigationMixin
@@ -368,7 +369,9 @@ class TaskDetailDialog(BaseModalDialog[tuple[str, int] | None], ViNavigationMixi
         except NoMatches:
             return
 
-        if not result.logs:
+        view_model = AuditLogPresenter().present(result)
+
+        if not view_model.rows:
             scroll.mount(
                 Static(
                     "[dim]No audit logs for this task.[/dim]",
@@ -377,7 +380,7 @@ class TaskDetailDialog(BaseModalDialog[tuple[str, int] | None], ViNavigationMixi
             )
             return
 
-        table = create_audit_log_table(result.logs)
+        table = create_audit_log_table(view_model.rows)
         scroll.mount(table)
 
     def _show_audit_error(self, message: str) -> None:

--- a/packages/taskdog-ui/src/taskdog/tui/screens/audit_log_screen.py
+++ b/packages/taskdog-ui/src/taskdog/tui/screens/audit_log_screen.py
@@ -8,6 +8,7 @@ from textual.binding import Binding
 from textual.screen import ModalScreen
 from textual.widgets import Header
 
+from taskdog.presenters.audit_log_presenter import AuditLogPresenter
 from taskdog.tui.widgets.audit_log_table import AuditLogTable
 
 
@@ -55,8 +56,9 @@ class AuditLogScreen(ModalScreen[None]):
         try:
             since = datetime.now() - timedelta(days=7)
             result = self._api_client.list_audit_logs(start_date=since, limit=10000)
+            view_model = AuditLogPresenter().present(result)
             table = self.query_one("#audit-log-table", AuditLogTable)
-            table.load_logs(result.logs)
+            table.load_logs(view_model.rows)
         except Exception as e:
             self.app.notify(f"Failed to load audit logs: {e}", severity="error")
             self.app.pop_screen()

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/audit_log_entry_builder.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/audit_log_entry_builder.py
@@ -4,8 +4,6 @@ Reusable across TUI components
 (e.g., AuditLogTable, TaskDetailDialog audit tab).
 """
 
-from typing import Any
-
 from rich.text import Text
 from textual.widgets import DataTable
 
@@ -24,123 +22,55 @@ from taskdog.constants.audit_log import (
     JUSTIFY_AUDIT_STATUS,
     JUSTIFY_AUDIT_TIMESTAMP,
 )
-from taskdog_core.application.dto.audit_log_dto import AuditLogOutput
+from taskdog.formatters.audit_log_formatter import compact_changes, truncate_error
+from taskdog.view_models.audit_log_view_model import AuditLogRowViewModel
 
-MAX_CHANGES_LENGTH = 40
+MAX_CHANGES_LENGTH = AUDIT_TUI_CHANGES_WIDTH
 MAX_ERROR_LENGTH = 40
 
 
-def format_audit_changes(
-    old_values: dict[str, Any] | None,
-    new_values: dict[str, Any] | None,
-    max_length: int = MAX_CHANGES_LENGTH,
-) -> str:
-    """Format changes between old and new values.
-
-    Args:
-        old_values: Values before the change
-        new_values: Values after the change
-        max_length: Maximum length for the result string
-
-    Returns:
-        Formatted change string (e.g., "priority: 3 -> 5")
-    """
-    if not old_values and not new_values:
-        return ""
-
-    changes: list[str] = []
-
-    all_keys: set[str] = set()
-    if old_values:
-        all_keys.update(old_values.keys())
-    if new_values:
-        all_keys.update(new_values.keys())
-
-    for key in sorted(all_keys):
-        old_val = old_values.get(key) if old_values else None
-        new_val = new_values.get(key) if new_values else None
-
-        if old_val != new_val:
-            old_str = format_audit_value(old_val)
-            new_str = format_audit_value(new_val)
-            changes.append(f"{key}: {old_str} \u2192 {new_str}")
-
-    # Limit to 2 changes to keep it compact
-    if len(changes) > 2:
-        result = ", ".join(changes[:2]) + f" (+{len(changes) - 2})"
-    else:
-        result = ", ".join(changes)
-
-    # Truncate to max_length if needed
-    if len(result) > max_length:
-        return result[: max_length - 3] + "..."
-    return result
-
-
-def format_audit_value(value: Any) -> str:
-    """Format a single value for display.
-
-    Args:
-        value: Value to format
-
-    Returns:
-        Formatted string representation
-    """
-    if value is None:
-        return "\u2205"
-    if isinstance(value, bool):
-        return "\u2713" if value else "\u2717"
-    if isinstance(value, str) and len(value) > 15:
-        return value[:15] + "..."
-    return str(value)
-
-
-def build_changes_text(log: AuditLogOutput, style: str = "") -> Text:
+def build_changes_text(row: AuditLogRowViewModel, style: str = "") -> Text:
     """Build the changes/error column text for an audit log entry.
 
     Args:
-        log: Audit log entry
+        row: Audit log row view model
         style: Base style to apply (e.g., "red" for failed entries)
 
     Returns:
         Formatted Rich Text for changes column
     """
-    if not log.success and log.error_message:
-        error_msg = (
-            log.error_message[:MAX_ERROR_LENGTH] + "..."
-            if len(log.error_message) > MAX_ERROR_LENGTH
-            else log.error_message
-        )
-        return Text(error_msg, style="red")
+    if not row.success and row.error_message:
+        return Text(truncate_error(row.error_message, MAX_ERROR_LENGTH), style="red")
 
-    changes_str = format_audit_changes(log.old_values, log.new_values)
-    return Text(changes_str, style=style)
+    return Text(compact_changes(row.changes, MAX_CHANGES_LENGTH), style=style)
 
 
-def build_status_text(log: AuditLogOutput) -> Text:
+def build_status_text(row: AuditLogRowViewModel) -> Text:
     """Build the status column text for an audit log entry.
 
     Args:
-        log: Audit log entry
+        row: Audit log row view model
 
     Returns:
         "OK" in green or "ER" in red
     """
     return (
         Text("OK", style=COLUMN_AUDIT_STATUS_OK_STYLE)
-        if log.success
+        if row.success
         else Text("ER", style=COLUMN_AUDIT_STATUS_FAIL_STYLE)
     )
 
 
-def create_audit_log_table(logs: list[AuditLogOutput]) -> DataTable:  # type: ignore[type-arg]
+def create_audit_log_table(
+    rows: tuple[AuditLogRowViewModel, ...],
+) -> DataTable:  # type: ignore[type-arg]
     """Create a DataTable widget for displaying audit log entries.
 
     Used by TaskDetailDialog for compact, tabular audit log display.
     Resource info (ID, name) is omitted since the dialog already shows it.
 
     Args:
-        logs: List of audit log entries to display
+        rows: Audit log row view models to display
 
     Returns:
         DataTable widget with audit log data
@@ -170,15 +100,15 @@ def create_audit_log_table(logs: list[AuditLogOutput]) -> DataTable:  # type: ig
         Text(HEADER_AUDIT_STATUS_SHORT, justify=JUSTIFY_AUDIT_STATUS), key="status"
     )
 
-    for log in logs:
-        ts = log.timestamp.strftime("%m-%d %H:%M:%S")
+    for row in rows:
+        ts = row.timestamp.strftime("%m-%d %H:%M:%S")
 
         table.add_row(
             Text(ts),
-            Text(log.operation),
-            build_changes_text(log),
-            Text(log.client_name or ""),
-            build_status_text(log),
+            Text(row.operation),
+            build_changes_text(row),
+            Text(row.client_name or ""),
+            build_status_text(row),
         )
 
     return table

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/audit_log_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/audit_log_table.py
@@ -35,7 +35,7 @@ from taskdog.tui.widgets.audit_log_entry_builder import (
 )
 from taskdog.tui.widgets.base_widget import TUIWidget
 from taskdog.tui.widgets.vi_navigation_mixin import ViNavigationMixin
-from taskdog_core.application.dto.audit_log_dto import AuditLogOutput
+from taskdog.view_models.audit_log_view_model import AuditLogRowViewModel
 
 
 class AuditLogTable(DataTable, TUIWidget, ViNavigationMixin):  # type: ignore[type-arg]
@@ -120,42 +120,42 @@ class AuditLogTable(DataTable, TUIWidget, ViNavigationMixin):  # type: ignore[ty
             width=AUDIT_TUI_STATUS_WIDTH,
         )
 
-    def load_logs(self, logs: list[AuditLogOutput]) -> None:
+    def load_logs(self, rows: tuple[AuditLogRowViewModel, ...]) -> None:
         """Load audit log entries into the table.
 
         Args:
-            logs: List of audit log entries (newest first from API)
+            rows: Audit log row view models (newest first from API)
         """
         with self.app.batch_update():
             self.clear(columns=False)
 
-            for log in logs:
-                style = "red" if not log.success else ""
+            for row in rows:
+                style = "red" if not row.success else ""
 
-                ts = Text(log.timestamp.strftime("%m-%d %H:%M:%S"), style=style)
+                ts = Text(row.timestamp.strftime("%m-%d %H:%M:%S"), style=style)
                 id_text = Text(
-                    str(log.resource_id) if log.resource_id else "", style=style
+                    str(row.resource_id) if row.resource_id else "", style=style
                 )
 
                 # Resource name (truncated)
-                if log.resource_name:
+                if row.resource_name:
                     name = (
-                        log.resource_name[:AUDIT_TUI_NAME_WIDTH] + "\u2026"
-                        if len(log.resource_name) > AUDIT_TUI_NAME_WIDTH
-                        else log.resource_name
+                        row.resource_name[:AUDIT_TUI_NAME_WIDTH] + "\u2026"
+                        if len(row.resource_name) > AUDIT_TUI_NAME_WIDTH
+                        else row.resource_name
                     )
                     name_text = Text(name, style=style)
                 else:
                     name_text = Text("", style=style)
 
-                op_text = Text(log.operation, style=style)
+                op_text = Text(row.operation, style=style)
 
                 self.add_row(
                     ts,
                     id_text,
                     name_text,
                     op_text,
-                    build_changes_text(log, style),
-                    Text(log.client_name or "", style=style),
-                    build_status_text(log),
+                    build_changes_text(row, style),
+                    Text(row.client_name or "", style=style),
+                    build_status_text(row),
                 )

--- a/packages/taskdog-ui/src/taskdog/view_models/__init__.py
+++ b/packages/taskdog-ui/src/taskdog/view_models/__init__.py
@@ -4,6 +4,11 @@ ViewModels transform Application layer DTOs into presentation-ready data structu
 They contain only the data needed for rendering in CLI/TUI, without domain entities.
 """
 
+from taskdog.view_models.audit_log_view_model import (
+    AuditChangeViewModel,
+    AuditLogRowViewModel,
+    AuditLogViewModel,
+)
 from taskdog.view_models.base import BaseViewModel
 from taskdog.view_models.gantt_view_model import GanttViewModel, TaskGanttRowViewModel
 from taskdog.view_models.statistics_view_model import (
@@ -15,6 +20,9 @@ from taskdog.view_models.statistics_view_model import (
 from taskdog.view_models.task_view_model import TaskRowViewModel
 
 __all__ = [
+    "AuditChangeViewModel",
+    "AuditLogRowViewModel",
+    "AuditLogViewModel",
     "BaseViewModel",
     "EstimationAccuracyStatisticsViewModel",
     "GanttViewModel",

--- a/packages/taskdog-ui/src/taskdog/view_models/audit_log_view_model.py
+++ b/packages/taskdog-ui/src/taskdog/view_models/audit_log_view_model.py
@@ -1,0 +1,47 @@
+"""ViewModels for audit log presentation.
+
+These ViewModels hold presentation-ready audit log data without domain
+entities or rendering-technology dependencies (no Rich, no Textual). Width
+truncation and coloring are applied by the renderers/widgets that consume them.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from taskdog.view_models.base import BaseViewModel
+
+
+@dataclass(frozen=True)
+class AuditChangeViewModel(BaseViewModel):
+    """A single changed field in an audit log entry.
+
+    ``old`` and ``new`` are already value-formatted strings (e.g. ``∅`` for
+    None, ``✓``/``✗`` for booleans, long strings truncated).
+    """
+
+    key: str
+    old: str
+    new: str
+
+
+@dataclass(frozen=True)
+class AuditLogRowViewModel(BaseViewModel):
+    """A single audit log entry, presentation-ready."""
+
+    id: int
+    timestamp: datetime
+    operation: str
+    client_name: str | None
+    resource_id: int | None
+    resource_name: str | None
+    success: bool
+    error_message: str | None
+    changes: tuple[AuditChangeViewModel, ...]
+
+
+@dataclass(frozen=True)
+class AuditLogViewModel(BaseViewModel):
+    """A page of audit log entries."""
+
+    rows: tuple[AuditLogRowViewModel, ...]
+    total_count: int

--- a/packages/taskdog-ui/tests/formatters/test_audit_log_formatter.py
+++ b/packages/taskdog-ui/tests/formatters/test_audit_log_formatter.py
@@ -1,0 +1,46 @@
+"""Tests for audit_log_formatter (Rich-free helpers)."""
+
+from taskdog.formatters.audit_log_formatter import compact_changes, truncate_error
+from taskdog.view_models.audit_log_view_model import AuditChangeViewModel
+
+
+def _c(key, old, new):
+    return AuditChangeViewModel(key=key, old=old, new=new)
+
+
+class TestCompactChanges:
+    def test_empty_returns_empty_string(self):
+        assert compact_changes((), max_length=40) == ""
+
+    def test_single_change(self):
+        assert compact_changes((_c("priority", "3", "5"),), max_length=40) == (
+            "priority: 3 → 5"
+        )
+
+    def test_two_changes_joined(self):
+        result = compact_changes((_c("a", "1", "2"), _c("b", "3", "4")), max_length=40)
+        assert result == "a: 1 → 2, b: 3 → 4"
+
+    def test_more_than_two_changes_are_capped(self):
+        result = compact_changes(
+            (_c("a", "1", "2"), _c("b", "3", "4"), _c("c", "5", "6")),
+            max_length=40,
+        )
+        assert result == "a: 1 → 2, b: 3 → 4 (+1)"
+
+    def test_truncates_to_max_length(self):
+        result = compact_changes(
+            (_c("description", "old value here", "new value here"),),
+            max_length=10,
+        )
+        assert result == "descrip..."
+        assert len(result) == 10
+
+
+class TestTruncateError:
+    def test_short_message_unchanged(self):
+        assert truncate_error("boom", max_length=40) == "boom"
+
+    def test_long_message_truncated_with_ellipsis(self):
+        msg = "x" * 50
+        assert truncate_error(msg, max_length=40) == "x" * 40 + "..."

--- a/packages/taskdog-ui/tests/presenters/test_audit_log_presenter.py
+++ b/packages/taskdog-ui/tests/presenters/test_audit_log_presenter.py
@@ -1,0 +1,101 @@
+"""Tests for AuditLogPresenter."""
+
+from datetime import datetime
+
+from taskdog.presenters.audit_log_presenter import AuditLogPresenter
+from taskdog.view_models.audit_log_view_model import (
+    AuditChangeViewModel,
+    AuditLogRowViewModel,
+    AuditLogViewModel,
+)
+from taskdog_core.application.dto.audit_log_dto import (
+    AuditLogListOutput,
+    AuditLogOutput,
+)
+
+
+def _log(**overrides) -> AuditLogOutput:
+    defaults = {
+        "id": 1,
+        "timestamp": datetime(2025, 1, 2, 3, 4, 5),
+        "client_name": "claude-code",
+        "operation": "update_task",
+        "resource_type": "task",
+        "resource_id": 42,
+        "resource_name": "Some task",
+        "old_values": None,
+        "new_values": None,
+        "success": True,
+        "error_message": None,
+    }
+    defaults.update(overrides)
+    return AuditLogOutput(**defaults)
+
+
+class TestAuditLogPresenter:
+    def test_passes_through_scalar_fields(self):
+        out = AuditLogListOutput(logs=[_log()], total_count=7)
+        vm = AuditLogPresenter().present(out)
+
+        assert isinstance(vm, AuditLogViewModel)
+        assert vm.total_count == 7
+        assert len(vm.rows) == 1
+        row = vm.rows[0]
+        assert isinstance(row, AuditLogRowViewModel)
+        assert row.id == 1
+        assert row.timestamp == datetime(2025, 1, 2, 3, 4, 5)
+        assert row.operation == "update_task"
+        assert row.client_name == "claude-code"
+        assert row.resource_id == 42
+        assert row.resource_name == "Some task"
+        assert row.success is True
+        assert row.error_message is None
+
+    def test_no_values_yields_empty_changes(self):
+        vm = AuditLogPresenter().present(
+            AuditLogListOutput(logs=[_log(old_values=None, new_values=None)])
+        )
+        assert vm.rows[0].changes == ()
+
+    def test_only_changed_keys_are_included_and_sorted(self):
+        vm = AuditLogPresenter().present(
+            AuditLogListOutput(
+                logs=[
+                    _log(
+                        old_values={"priority": 3, "name": "a", "same": 1},
+                        new_values={"priority": 5, "name": "b", "same": 1},
+                    )
+                ]
+            )
+        )
+        changes = vm.rows[0].changes
+        assert changes == (
+            AuditChangeViewModel(key="name", old="a", new="b"),
+            AuditChangeViewModel(key="priority", old="3", new="5"),
+        )
+
+    def test_key_present_on_one_side_only(self):
+        vm = AuditLogPresenter().present(
+            AuditLogListOutput(logs=[_log(old_values=None, new_values={"tags": ["x"]})])
+        )
+        assert vm.rows[0].changes == (
+            AuditChangeViewModel(key="tags", old="∅", new="['x']"),
+        )
+
+    def test_value_formatting_none_bool_and_long_string(self):
+        long = "x" * 20
+        vm = AuditLogPresenter().present(
+            AuditLogListOutput(
+                logs=[
+                    _log(
+                        old_values={"a": None, "b": True, "c": "short", "d": long},
+                        new_values={"a": 1, "b": False, "c": "short", "d": "y"},
+                    )
+                ]
+            )
+        )
+        changes = {c.key: (c.old, c.new) for c in vm.rows[0].changes}
+        assert changes["a"] == ("∅", "1")
+        assert changes["b"] == ("✓", "✗")
+        assert "c" not in changes  # unchanged
+        assert changes["d"] == ("x" * 15 + "...", "y")


### PR DESCRIPTION
## Summary

Every `taskdog` CLI invocation eagerly imported the entire **Textual** framework, even for non-TUI commands. Root cause: the audit-logs command imported `format_audit_changes` from `taskdog.tui.widgets.audit_log_entry_builder`, which imports Textual (`DataTable`) at module top — and `cli_main.py` eagerly imports every command module. This accounted for ~62% of `taskdog.cli_main` import time.

This moves the audit-log **mapping** out of the TUI layer and onto the existing presenter/ViewModel/renderer pattern the rest of the UI already uses (the diff computation is really a DTO→ViewModel mapper, not "formatting"):

- `presenters/audit_log_presenter.py` — old/new diff selection + value formatting (`∅`/`✓`/`✗`/15-char). Rich/Textual-free.
- `view_models/audit_log_view_model.py` — `AuditChangeViewModel` / `AuditLogRowViewModel` / `AuditLogViewModel` (frozen).
- `formatters/audit_log_formatter.py` — `compact_changes` (join / 2-item cap / width truncate) and `truncate_error` — shared Rich-free helpers.

CLI and TUI both consume the presenter now; per-surface width, color, status label and resource layout stay in their respective renderers. The Rich-`Text` builders and the `DataTable` factory remain in the TUI layer (lazy-loaded as before).

### Result (`-X importtime`, same machine)

| | before | after |
|---|---|---|
| `taskdog.cli_main` cumulative | ~727ms | ~145ms |
| `audit_logs` path | ~497ms | ~65ms |
| Textual on CLI path | loaded | **none** |

## Test Plan

- [x] `make test-ui` — 926 passed (914 baseline + 12 new presenter/formatter tests)
- [x] `ruff` / `mypy` / `vulture` clean
- [x] `python -X importtime -c "from taskdog.cli_main import cli"` — confirms zero `textual` imports on the CLI path
- [x] Rendered representative logs (changed-fields entry + failed-with-error entry) through both the CLI table and the TUI `Text` builders; output matches pre-change behavior

Closes #941