### PR TITLE
refactor(tui): expose cli_config via TUIWidget instead of private app access

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -290,6 +290,11 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         """
         self.websocket_handler.handle_message(message)
 
+    @property
+    def cli_config(self) -> "CliConfig":
+        """Public accessor for the CLI configuration."""
+        return self._cli_config
+
     def __getattr__(self, name: str) -> Any:
         """Dynamically handle action_* methods by delegating to command_factory.
 

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/base_widget.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/base_widget.py
@@ -7,6 +7,7 @@ access to the TUI application state.
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from taskdog.infrastructure.cli_config_manager import CliConfig
     from taskdog.tui.app import TaskdogTUI
     from taskdog.tui.state import TUIState
 
@@ -58,3 +59,12 @@ class TUIWidget:
             This is a convenience property equivalent to self.tui_app.state
         """
         return self.tui_app.state
+
+    @property
+    def cli_config(self) -> "CliConfig":
+        """Get reference to the CLI configuration.
+
+        Returns:
+            The CliConfig instance from the app
+        """
+        return self.tui_app.cli_config

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
@@ -155,7 +155,7 @@ class GanttWidget(Vertical, TUIWidget):
         try:
             gantt_view_model = self._get_gantt_from_state()
             if gantt_view_model and self._gantt_table:
-                gantt_config = self.app._cli_config.gantt  # type: ignore[attr-defined]
+                gantt_config = self.cli_config.gantt
                 self._gantt_table.load_gantt(
                     gantt_view_model,
                     keep_scroll_position=self._keep_scroll_position,
@@ -278,7 +278,7 @@ class GanttWidget(Vertical, TUIWidget):
         weeks = max(max_days // DAYS_PER_WEEK, 1)
         calculated_days = weeks * DAYS_PER_WEEK
         try:
-            min_days: int = self.app._cli_config.gantt.min_display_days  # type: ignore[attr-defined]
+            min_days: int = self.cli_config.gantt.min_display_days
         except (AttributeError, TypeError):
             min_days = MIN_GANTT_DISPLAY_DAYS
         return max(calculated_days, min_days)


### PR DESCRIPTION
## Summary

`GanttWidget` reached into the app's **private** `_cli_config` attribute with `# type: ignore[attr-defined]`:

```python
gantt_config = self.app._cli_config.gantt  # type: ignore[attr-defined]
min_days = self.app._cli_config.gantt.min_display_days  # type: ignore[attr-defined]
```

This bypassed `TUIWidget`, the base class that exists **precisely** to provide type-safe app/state access without scattered `type: ignore` comments (it already exposes `tui_state`). Config was the one escape hatch breaking that pattern.

## Changes

- `app.py`: add a public `cli_config` property (symmetric with the public `state`).
- `base_widget.py` (`TUIWidget`): add a `cli_config` property mirroring `tui_state`.
- `gantt_widget.py`: read config via `self.cli_config.gantt`, removing both private-attribute accesses and their `type: ignore`.

No behavior change — pure structural cleanup so `state` and `cli_config` share one type-safe access pattern.

## Verification

- `mypy`: pass
- `ruff check`: pass
- UI test suite: 926 passed