### PR TITLE
refactor(tui): single-source the Gantt legend via LEGEND_SPEC

### DIFF
--- a/packages/taskdog-ui/src/taskdog/renderers/gantt_cell_formatter.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/gantt_cell_formatter.py
@@ -64,6 +64,50 @@ class DateMetadata:
         return self.is_weekend or self.is_holiday
 
 
+@dataclass(frozen=True)
+class LegendSegment:
+    """A single styled segment of the Gantt legend.
+
+    Dialect-neutral single source of truth shared by the CLI (Rich Text)
+    and TUI (Textual markup) renderers. ``accent`` segments leave the color
+    to the renderer: the CLI uses a literal color, the TUI uses ``$primary``.
+    """
+
+    text: str
+    style: str
+    accent: bool = False
+
+
+# Single source for the Gantt legend. Renderers translate it into their own
+# dialect (Rich Text for CLI, Textual markup for TUI).
+LEGEND_SPEC: list[LegendSegment] = [
+    LegendSegment("Legend: ", "bold", accent=True),
+    LegendSegment("   ", f"on {BACKGROUND_COLOR_PLANNED_LIGHT}"),
+    LegendSegment(" Planned period  ", "dim"),
+    LegendSegment("   ", f"on {BACKGROUND_COLOR}"),
+    LegendSegment(" Allocated hours  ", "dim"),
+    LegendSegment(SYMBOL_IN_PROGRESS, "bold blue"),
+    LegendSegment(f" {TaskStatus.IN_PROGRESS.value}  ", "dim"),
+    LegendSegment(SYMBOL_COMPLETED, "bold green"),
+    LegendSegment(f" {TaskStatus.COMPLETED.value}  ", "dim"),
+    LegendSegment(SYMBOL_CANCELED, "bold red"),
+    LegendSegment(f" {TaskStatus.CANCELED.value}  ", "dim"),
+    LegendSegment("   ", f"on {BACKGROUND_COLOR_DEADLINE}"),
+    LegendSegment(" Deadline  ", "dim"),
+    LegendSegment(SYMBOL_TODAY, "bold yellow"),
+    LegendSegment(" Today  ", "dim"),
+    LegendSegment("   ", f"on {BACKGROUND_COLOR_HOLIDAY}"),
+    LegendSegment(" Holiday  ", "dim"),
+    LegendSegment("   ", f"on {BACKGROUND_COLOR_SATURDAY}"),
+    LegendSegment(" Saturday  ", "dim"),
+    LegendSegment("   ", f"on {BACKGROUND_COLOR_SUNDAY}"),
+    LegendSegment(" Sunday", "dim"),
+]
+
+# Accent color for the CLI legend title (Textual resolves $primary instead).
+LEGEND_ACCENT_CLI = "yellow"
+
+
 class GanttCellFormatter:
     """Formatter for Gantt chart cells and headers.
 
@@ -344,27 +388,9 @@ class GanttCellFormatter:
             Rich Text object with legend
         """
         legend = Text()
-        legend.append("Legend: ", style="bold yellow")
-        legend.append("   ", style=f"on {BACKGROUND_COLOR_PLANNED_LIGHT}")
-        legend.append(" Planned period  ", style="dim")
-        legend.append("   ", style=f"on {BACKGROUND_COLOR}")
-        legend.append(" Allocated hours  ", style="dim")
-        legend.append(SYMBOL_IN_PROGRESS, style="bold blue")
-        legend.append(f" {TaskStatus.IN_PROGRESS.value}  ", style="dim")
-        legend.append(SYMBOL_COMPLETED, style="bold green")
-        legend.append(f" {TaskStatus.COMPLETED.value}  ", style="dim")
-        legend.append(SYMBOL_CANCELED, style="bold red")
-        legend.append(f" {TaskStatus.CANCELED.value}  ", style="dim")
-        legend.append("   ", style=f"on {BACKGROUND_COLOR_DEADLINE}")
-        legend.append(" Deadline  ", style="dim")
-        legend.append(SYMBOL_TODAY, style="bold yellow")
-        legend.append(" Today  ", style="dim")
-        legend.append("   ", style=f"on {BACKGROUND_COLOR_HOLIDAY}")
-        legend.append(" Holiday  ", style="dim")
-        legend.append("   ", style=f"on {BACKGROUND_COLOR_SATURDAY}")
-        legend.append(" Saturday  ", style="dim")
-        legend.append("   ", style=f"on {BACKGROUND_COLOR_SUNDAY}")
-        legend.append(" Sunday", style="dim")
+        for seg in LEGEND_SPEC:
+            style = f"{seg.style} {LEGEND_ACCENT_CLI}" if seg.accent else seg.style
+            legend.append(seg.text, style=style)
         return legend
 
     @staticmethod

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_data_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_data_table.py
@@ -636,11 +636,3 @@ class GanttDataTable(DataTable):  # type: ignore[type-arg]
             TaskGanttRowViewModel if cursor is on a task row, None otherwise.
         """
         return self._task_map.get(self.cursor_row)
-
-    def get_legend_text(self) -> Text:
-        """Build legend text for the Gantt chart.
-
-        Returns:
-            Rich Text object with legend
-        """
-        return GanttCellFormatter.build_legend()

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
@@ -20,6 +20,7 @@ from taskdog.constants.gantt import (
     MIN_GANTT_DISPLAY_DAYS,
     MIN_TIMELINE_WIDTH,
 )
+from taskdog.renderers.gantt_cell_formatter import LEGEND_SPEC
 from taskdog.tui.widgets.base_widget import TUIWidget
 from taskdog.tui.widgets.gantt_data_table import GanttDataTable
 from taskdog.view_models.gantt_view_model import GanttViewModel
@@ -196,50 +197,17 @@ class GanttWidget(Vertical, TUIWidget):
 
     @staticmethod
     def _build_legend_markup() -> str:
-        """Build legend as a markup string.
+        """Build the legend as a Textual markup string from the shared spec.
 
-        Using markup instead of Rich Text so that Textual CSS variables
-        like ``$primary`` are resolved by the Static widget.
+        Markup (not Rich Text) is used so Textual resolves CSS variables like
+        ``$primary`` when the Static renders it. The accent segment defers its
+        color to ``$primary``; the CLI renderer uses a literal color instead.
         """
-        from taskdog.constants.colors import (
-            BACKGROUND_COLOR,
-            BACKGROUND_COLOR_DEADLINE,
-            BACKGROUND_COLOR_HOLIDAY,
-            BACKGROUND_COLOR_PLANNED_LIGHT,
-            BACKGROUND_COLOR_SATURDAY,
-            BACKGROUND_COLOR_SUNDAY,
-        )
-        from taskdog.constants.symbols import (
-            SYMBOL_CANCELED,
-            SYMBOL_COMPLETED,
-            SYMBOL_IN_PROGRESS,
-            SYMBOL_TODAY,
-        )
-        from taskdog_core.domain.entities.task import TaskStatus
-
-        return (
-            "[bold $primary]Legend: [/bold $primary]"
-            f"[on {BACKGROUND_COLOR_PLANNED_LIGHT}]   [/on {BACKGROUND_COLOR_PLANNED_LIGHT}]"
-            "[dim] Planned period  [/dim]"
-            f"[on {BACKGROUND_COLOR}]   [/on {BACKGROUND_COLOR}]"
-            "[dim] Allocated hours  [/dim]"
-            f"[bold blue]{SYMBOL_IN_PROGRESS}[/bold blue]"
-            f"[dim] {TaskStatus.IN_PROGRESS.value}  [/dim]"
-            f"[bold green]{SYMBOL_COMPLETED}[/bold green]"
-            f"[dim] {TaskStatus.COMPLETED.value}  [/dim]"
-            f"[bold red]{SYMBOL_CANCELED}[/bold red]"
-            f"[dim] {TaskStatus.CANCELED.value}  [/dim]"
-            f"[on {BACKGROUND_COLOR_DEADLINE}]   [/on {BACKGROUND_COLOR_DEADLINE}]"
-            "[dim] Deadline  [/dim]"
-            f"[bold yellow]{SYMBOL_TODAY}[/bold yellow]"
-            "[dim] Today  [/dim]"
-            f"[on {BACKGROUND_COLOR_HOLIDAY}]   [/on {BACKGROUND_COLOR_HOLIDAY}]"
-            "[dim] Holiday  [/dim]"
-            f"[on {BACKGROUND_COLOR_SATURDAY}]   [/on {BACKGROUND_COLOR_SATURDAY}]"
-            "[dim] Saturday  [/dim]"
-            f"[on {BACKGROUND_COLOR_SUNDAY}]   [/on {BACKGROUND_COLOR_SUNDAY}]"
-            "[dim] Sunday[/dim]"
-        )
+        parts = []
+        for seg in LEGEND_SPEC:
+            style = f"{seg.style} $primary" if seg.accent else seg.style
+            parts.append(f"[{style}]{seg.text}[/{style}]")
+        return "".join(parts)
 
     def _show_error_message(self, error: Exception) -> None:
         """Show error message when rendering fails.


### PR DESCRIPTION
## Summary

The Gantt legend was defined in **three** places:

| Location | Form | Used? |
|---|---|---|
| `GanttCellFormatter.build_legend()` | Rich `Text` (CLI) | yes |
| `GanttWidget._build_legend_markup()` | Textual markup (TUI) | yes — but re-declares the whole color/symbol/label mapping inline |
| `GanttDataTable.get_legend_text()` | delegates to `build_legend()` | **no — dead code** |

So the legend mapping was duplicated across the formatter and the widget, and a dead method sat on the grid widget where the legend doesn't even belong.

## Changes

- Add a dialect-neutral **`LEGEND_SPEC`** (`list[LegendSegment]`) in the shared `GanttCellFormatter` module — the single source of truth.
- Rewrite `build_legend()` (CLI/Rich) and `GanttWidget._build_legend_markup()` (TUI/Textual) to both render from that spec.
- The one theme-dependent segment (the `Legend:` title) defers its color via `accent`: a literal color for CLI, `$primary` for TUI. This keeps the formatter from learning about Textual — `$primary` resolution stays in the widget.
- Delete the dead, misplaced `GanttDataTable.get_legend_text()`.

Ownership after this: **shared spec = data**, **TUI markup (incl. `$primary`) = widget**, formatter never depends on TUI concepts.

## Verification

- CLI `Text` and TUI markup outputs are unchanged (title style `bold yellow` for CLI, `[bold $primary]Legend: …` for TUI — verified against the originals).
- `mypy`: pass · `ruff`: pass · UI suite: 926 passed