### PR TITLE
refactor(tui): make ViNavigationMixin a real behavior mixin

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/help_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/help_dialog.py
@@ -118,42 +118,6 @@ class HelpDialog(BaseModalDialog[None], ViNavigationMixin):
         except NoMatches:
             return None
 
-    def action_vi_down(self) -> None:
-        """Scroll down one line (j key)."""
-        widget = self._get_active_scroll_widget()
-        if widget:
-            widget.scroll_relative(y=1, animate=False)
-
-    def action_vi_up(self) -> None:
-        """Scroll up one line (k key)."""
-        widget = self._get_active_scroll_widget()
-        if widget:
-            widget.scroll_relative(y=-1, animate=False)
-
-    def action_vi_page_down(self) -> None:
-        """Scroll down half page (Ctrl+D)."""
-        widget = self._get_active_scroll_widget()
-        if widget:
-            widget.scroll_relative(y=widget.size.height // 2, animate=False)
-
-    def action_vi_page_up(self) -> None:
-        """Scroll up half page (Ctrl+U)."""
-        widget = self._get_active_scroll_widget()
-        if widget:
-            widget.scroll_relative(y=-(widget.size.height // 2), animate=False)
-
-    def action_vi_home(self) -> None:
-        """Scroll to top (g key)."""
-        widget = self._get_active_scroll_widget()
-        if widget:
-            widget.scroll_home(animate=False)
-
-    def action_vi_end(self) -> None:
-        """Scroll to bottom (G key)."""
-        widget = self._get_active_scroll_widget()
-        if widget:
-            widget.scroll_end(animate=False)
-
     def action_next_tab(self) -> None:
         """Switch to the next tab (> key)."""
         try:

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/scrollable_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/scrollable_dialog.py
@@ -55,30 +55,10 @@ class ScrollableDialogBase[T](BaseModalDialog[T], ViNavigationMixin):
                 f"not a VerticalScroll widget in {self.__class__.__name__}"
             ) from e
 
-    def action_vi_down(self) -> None:
-        """Scroll down one line (j key)."""
-        self._get_scroll_widget().scroll_relative(y=1, animate=False)
+    def _get_active_scroll_widget(self) -> VerticalScroll:
+        """Return the single scroll container for Vi navigation.
 
-    def action_vi_up(self) -> None:
-        """Scroll up one line (k key)."""
-        self._get_scroll_widget().scroll_relative(y=-1, animate=False)
-
-    def action_vi_page_down(self) -> None:
-        """Scroll down half page (Ctrl+D)."""
-        scroll_widget = self._get_scroll_widget()
-        scroll_widget.scroll_relative(y=scroll_widget.size.height // 2, animate=False)
-
-    def action_vi_page_up(self) -> None:
-        """Scroll up half page (Ctrl+U)."""
-        scroll_widget = self._get_scroll_widget()
-        scroll_widget.scroll_relative(
-            y=-(scroll_widget.size.height // 2), animate=False
-        )
-
-    def action_vi_home(self) -> None:
-        """Scroll to top (g key)."""
-        self._get_scroll_widget().scroll_home(animate=False)
-
-    def action_vi_end(self) -> None:
-        """Scroll to bottom (G key)."""
-        self._get_scroll_widget().scroll_end(animate=False)
+        Plugs into ViNavigationMixin's action_vi_* methods. Raises (via
+        _get_scroll_widget) if the container is misconfigured.
+        """
+        return self._get_scroll_widget()

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/stats_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/stats_dialog.py
@@ -473,42 +473,6 @@ class StatsDialog(BaseModalDialog[None], ViNavigationMixin):
         except NoMatches:
             return None
 
-    def action_vi_down(self) -> None:
-        """Scroll down one line (j key)."""
-        widget = self._get_active_scroll_widget()
-        if widget:
-            widget.scroll_relative(y=1, animate=False)
-
-    def action_vi_up(self) -> None:
-        """Scroll up one line (k key)."""
-        widget = self._get_active_scroll_widget()
-        if widget:
-            widget.scroll_relative(y=-1, animate=False)
-
-    def action_vi_page_down(self) -> None:
-        """Scroll down half page (Ctrl+D)."""
-        widget = self._get_active_scroll_widget()
-        if widget:
-            widget.scroll_relative(y=widget.size.height // 2, animate=False)
-
-    def action_vi_page_up(self) -> None:
-        """Scroll up half page (Ctrl+U)."""
-        widget = self._get_active_scroll_widget()
-        if widget:
-            widget.scroll_relative(y=-(widget.size.height // 2), animate=False)
-
-    def action_vi_home(self) -> None:
-        """Scroll to top (g key)."""
-        widget = self._get_active_scroll_widget()
-        if widget:
-            widget.scroll_home(animate=False)
-
-    def action_vi_end(self) -> None:
-        """Scroll to bottom (G key)."""
-        widget = self._get_active_scroll_widget()
-        if widget:
-            widget.scroll_end(animate=False)
-
     # ── Tab switching ──────────────────────────────────────────────────
 
     def action_next_tab(self) -> None:

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/task_detail_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/task_detail_dialog.py
@@ -272,42 +272,6 @@ class TaskDetailDialog(BaseModalDialog[tuple[str, int] | None], ViNavigationMixi
         except NoMatches:
             return None
 
-    def action_vi_down(self) -> None:
-        """Scroll down one line (j key)."""
-        widget = self._get_active_scroll_widget()
-        if widget:
-            widget.scroll_relative(y=1, animate=False)
-
-    def action_vi_up(self) -> None:
-        """Scroll up one line (k key)."""
-        widget = self._get_active_scroll_widget()
-        if widget:
-            widget.scroll_relative(y=-1, animate=False)
-
-    def action_vi_page_down(self) -> None:
-        """Scroll down half page (Ctrl+D)."""
-        widget = self._get_active_scroll_widget()
-        if widget:
-            widget.scroll_relative(y=widget.size.height // 2, animate=False)
-
-    def action_vi_page_up(self) -> None:
-        """Scroll up half page (Ctrl+U)."""
-        widget = self._get_active_scroll_widget()
-        if widget:
-            widget.scroll_relative(y=-(widget.size.height // 2), animate=False)
-
-    def action_vi_home(self) -> None:
-        """Scroll to top (g key)."""
-        widget = self._get_active_scroll_widget()
-        if widget:
-            widget.scroll_home(animate=False)
-
-    def action_vi_end(self) -> None:
-        """Scroll to bottom (G key)."""
-        widget = self._get_active_scroll_widget()
-        if widget:
-            widget.scroll_end(animate=False)
-
     # ── Tab switching ──────────────────────────────────────────────────
 
     def action_next_tab(self) -> None:

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/vi_navigation_mixin.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/vi_navigation_mixin.py
@@ -1,29 +1,26 @@
 """Vi-style navigation mixin for TUI widgets.
 
-This module provides a mixin class for adding Vi-style keybindings to Textual widgets.
-Different widget types can use appropriate binding sets based on their navigation needs.
+Provides Vi-style keybindings AND their default scroll behavior. Scroll-based
+widgets only need to implement ``_get_active_scroll_widget()``; the action
+methods here delegate to it. Cursor-based consumers (e.g. Select overlays,
+DataTables) override the ``action_vi_*`` methods instead.
 """
 
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 from textual.binding import Binding
 
+if TYPE_CHECKING:
+    from textual.containers import VerticalScroll
+
 
 class ViNavigationMixin:
-    """Mixin providing Vi-style keybindings for navigation.
+    """Mixin providing Vi-style keybindings and scroll behavior.
 
-    This mixin provides common Vi-style keyboard shortcuts that can be used
-    across different widget types. Widgets should:
-    1. Include this mixin in their inheritance
-    2. Use appropriate BINDINGS class variable sets
-    3. Implement corresponding action_* methods
-
-    The mixin provides several binding sets for different use cases:
-    - VI_VERTICAL_BINDINGS: Basic vertical navigation (j/k/g/G)
-    - VI_PAGE_BINDINGS: Half-page scrolling (Ctrl+d/u)
-    - VI_HORIZONTAL_BINDINGS: Horizontal scrolling (h/l)
-    - VI_HORIZONTAL_JUMP_BINDINGS: Jump to horizontal edges (0/$)
-    - VI_ALL_BINDINGS: Complete set of all Vi bindings
+    Binding sets are exposed as class variables so widgets can compose the
+    subset they need into their own ``BINDINGS``. The ``action_vi_*`` methods
+    implement the default (scroll-based) behavior, delegating to
+    ``_get_active_scroll_widget()``.
     """
 
     # Basic vertical navigation (j/k for up/down, g/G for top/bottom)
@@ -92,43 +89,40 @@ class ViNavigationMixin:
         ),
     ]
 
-    # Complete set of all Vi bindings
-    VI_ALL_BINDINGS: ClassVar = (
-        VI_VERTICAL_BINDINGS
-        + VI_PAGE_BINDINGS
-        + VI_HORIZONTAL_BINDINGS
-        + VI_HORIZONTAL_JUMP_BINDINGS
-    )
+    def _get_active_scroll_widget(self) -> "VerticalScroll | None":
+        """Return the scroll widget the vi actions should act on.
 
-    # Scroll-compatible bindings for VerticalScroll containers
-    # These map to built-in scroll_* actions instead of vi_* actions
-    VI_SCROLL_BINDINGS: ClassVar = [
-        Binding("j", "scroll_down", "Down", show=False),
-        Binding("k", "scroll_up", "Up", show=False),
-        Binding("g", "scroll_home", "Top", show=False),
-        Binding("G", "scroll_end", "Bottom", show=False),
-        Binding("ctrl+d", "page_down", "Page Down", show=False),
-        Binding("ctrl+u", "page_up", "Page Up", show=False),
-    ]
+        Default returns None (actions become no-ops). Scroll-based subclasses
+        override this; cursor-based consumers override the action_vi_* methods.
+        """
+        return None
 
-    # Complete scroll bindings including horizontal scroll and jump
-    # For widgets that need full Vi-style navigation with scroll_* actions
-    VI_SCROLL_ALL_BINDINGS: ClassVar = [
-        # Vertical navigation
-        Binding("j", "scroll_down", "Down", show=False),
-        Binding("k", "scroll_up", "Up", show=False),
-        Binding("g", "scroll_home", "Top", show=False),
-        Binding("G", "scroll_end", "Bottom", show=False),
-        Binding("ctrl+d", "page_down", "Page Down", show=False),
-        Binding("ctrl+u", "page_up", "Page Up", show=False),
-        # Horizontal navigation
-        Binding("h", "scroll_left", "Left", show=False),
-        Binding("l", "scroll_right", "Right", show=False),
-        # Horizontal jump (0 = line start, $ = line end)
-        Binding("0", "scroll_home_horizontal", "Line Start", show=False),
-        Binding("$", "scroll_end_horizontal", "Line End", show=False),
-    ]
+    def action_vi_down(self) -> None:
+        """Scroll down one line (j key)."""
+        if (widget := self._get_active_scroll_widget()) is not None:
+            widget.scroll_relative(y=1, animate=False)
 
-    # Note: Widgets must implement action_vi_* methods corresponding to the bindings
-    # they use. Default implementations are not provided as behavior varies by widget type.
-    # For scroll containers, use VI_SCROLL_BINDINGS which map to built-in scroll actions.
+    def action_vi_up(self) -> None:
+        """Scroll up one line (k key)."""
+        if (widget := self._get_active_scroll_widget()) is not None:
+            widget.scroll_relative(y=-1, animate=False)
+
+    def action_vi_page_down(self) -> None:
+        """Scroll down half a page (Ctrl+D)."""
+        if (widget := self._get_active_scroll_widget()) is not None:
+            widget.scroll_relative(y=widget.size.height // 2, animate=False)
+
+    def action_vi_page_up(self) -> None:
+        """Scroll up half a page (Ctrl+U)."""
+        if (widget := self._get_active_scroll_widget()) is not None:
+            widget.scroll_relative(y=-(widget.size.height // 2), animate=False)
+
+    def action_vi_home(self) -> None:
+        """Scroll to top (g key)."""
+        if (widget := self._get_active_scroll_widget()) is not None:
+            widget.scroll_home(animate=False)
+
+    def action_vi_end(self) -> None:
+        """Scroll to bottom (G key)."""
+        if (widget := self._get_active_scroll_widget()) is not None:
+            widget.scroll_end(animate=False)


### PR DESCRIPTION
## Summary

`ViNavigationMixin` was a *binding catalog*, not a mixin: it only held `ClassVar` `Binding` lists and provided **no** behavior, on the premise (per its docstring) that "behavior varies by widget type."

That premise was false. Four classes each reimplemented the same six `action_vi_*` methods (`down`/`up`/`page_down`/`page_up`/`home`/`end`):

- `HelpDialog`, `TaskDetailDialog`, `StatsDialog` — **byte-identical** across all three.
- `ScrollableDialogBase` — nearly identical.

The only thing that genuinely varied was *which* scroll widget to act on. So the keybindings lived in the mixin while their handlers were scattered (and duplicated) across files.

## Changes

- Move the six scroll actions into `ViNavigationMixin`, delegating to an overridable hook `_get_active_scroll_widget() -> VerticalScroll | None` (default `None` → no-op).
- Each consumer now keeps only that hook:
  - tabbed dialogs keep their existing tab-aware getter;
  - `ScrollableDialogBase` gets a thin adapter over its `_get_scroll_widget()` (preserving raise-on-misconfiguration);
  - `ViSelectOverlay` is unchanged — it overrides the actions with cursor-based ones.
- Delete three binding sets with **zero** usages: `VI_ALL_BINDINGS`, `VI_SCROLL_BINDINGS`, `VI_SCROLL_ALL_BINDINGS`.

Net −134 lines. Bindings and their handlers now live together; the responsibility split is "mixin = how to scroll, consumer = what to scroll."

## Verification

- Behavior unchanged: `test_help_dialog.py` calls `action_vi_down/up/page_down/...` directly (incl. the None-guard "should not raise" cases) and still passes via the inherited methods.
- `mypy`: pass · `ruff` (check + format): pass · UI suite: 926 passed