### PR TITLE
chore: Bump version to 0.20.1

### DIFF
--- a/packages/taskdog-client/pyproject.toml
+++ b/packages/taskdog-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "taskdog-client"
-version = "0.20.0"
+version = "0.20.1"
 description = "HTTP API client for Taskdog server"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -18,7 +18,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "taskdog-core==0.20.0",
+    "taskdog-core==0.20.1",
     "httpx>=0.27.0",
     "websockets>=14.0",
 ]

--- a/packages/taskdog-core/pyproject.toml
+++ b/packages/taskdog-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "taskdog-core"
-version = "0.20.0"
+version = "0.20.1"
 description = "Core business logic and infrastructure for Taskdog"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/taskdog-mcp/pyproject.toml
+++ b/packages/taskdog-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "taskdog-mcp"
-version = "0.20.0"
+version = "0.20.1"
 description = "MCP server for Taskdog - enables Claude Desktop integration"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -18,8 +18,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "taskdog-client==0.20.0",
-    "taskdog-core==0.20.0",
+    "taskdog-client==0.20.1",
+    "taskdog-core==0.20.1",
     "mcp>=1.2.0",
 ]
 

--- a/packages/taskdog-server/pyproject.toml
+++ b/packages/taskdog-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "taskdog-server"
-version = "0.20.0"
+version = "0.20.1"
 description = "FastAPI server for Taskdog task management system"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -18,7 +18,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "taskdog-core==0.20.0",
+    "taskdog-core==0.20.1",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.48.0",
     "pydantic>=2.10.0",

--- a/packages/taskdog-ui/pyproject.toml
+++ b/packages/taskdog-ui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "taskdog-ui"
-version = "0.20.0"
+version = "0.20.1"
 description = "CLI and TUI for Taskdog task management system"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -18,8 +18,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "taskdog-core==0.20.0",
-    "taskdog-client==0.20.0",
+    "taskdog-core==0.20.1",
+    "taskdog-client==0.20.1",
     "click>=8.3.0",
     "rich>=14.2.0",
     "textual>=8.0.0",
@@ -36,7 +36,7 @@ dev = [
     "ruff>=0.7.0",
 ]
 server = [
-    "taskdog-server==0.20.0",
+    "taskdog-server==0.20.1",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "taskdog-workspace"
-version = "0.20.0"
+version = "0.20.1"
 description = "Taskdog monorepo workspace"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1351,7 +1351,7 @@ wheels = [
 
 [[package]]
 name = "taskdog-client"
-version = "0.20.0"
+version = "0.20.1"
 source = { editable = "packages/taskdog-client" }
 dependencies = [
     { name = "httpx" },
@@ -1383,7 +1383,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-core"
-version = "0.20.0"
+version = "0.20.1"
 source = { editable = "packages/taskdog-core" }
 dependencies = [
     { name = "alembic" },
@@ -1415,7 +1415,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-mcp"
-version = "0.20.0"
+version = "0.20.1"
 source = { editable = "packages/taskdog-mcp" }
 dependencies = [
     { name = "mcp" },
@@ -1447,7 +1447,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-server"
-version = "0.20.0"
+version = "0.20.1"
 source = { editable = "packages/taskdog-server" }
 dependencies = [
     { name = "fastapi" },
@@ -1483,7 +1483,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "taskdog-ui"
-version = "0.20.0"
+version = "0.20.1"
 source = { editable = "packages/taskdog-ui" }
 dependencies = [
     { name = "click" },
@@ -1527,7 +1527,7 @@ provides-extras = ["dev", "server"]
 
 [[package]]
 name = "taskdog-workspace"
-version = "0.20.0"
+version = "0.20.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Patch release. Bumps all packages 0.20.0 → 0.20.1 (+ uv.lock).

## Changes since v0.20.0

**Fixes**
- show `-` for empty tags; share field formatters (#951)
- experimental native Windows path/editor handling (#936)
- disable animated half-page scroll in audit log (#940)

**Performance**
- keep Textual off the CLI startup path for audit logs (#945)

**Internal (no user-facing change)**
- TUI structural refactors: cli_config via TUIWidget (#946), Gantt legend single-source (#947), ViNavigationMixin behavior (#948), CustomFooter via TUIWidget (#950)
- dependency bumps (#943, #944)

Patch bump: fixes + internal refactors only; no new features or breaking changes. Native Windows remains experimental (Linux/macOS supported).