### PR TITLE
test(ui): restore TUI tests excluded by collect_ignore

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,8 +153,8 @@ make format
 
 ### Test Framework
 
-- **Framework**: `unittest` (Python standard library)
-- **Coverage Tool**: `coverage`
+- **Framework**: `pytest` (with `pytest-cov`, `pytest-asyncio`)
+- **Coverage Tool**: `pytest-cov`
 
 ### Writing Tests
 
@@ -177,10 +177,10 @@ make test-ui
 # All test commands include coverage (sorted by coverage: low → high)
 
 # Run single test file (from package directory)
-cd packages/taskdog-core && PYTHONPATH=src uv run python -m unittest tests/test_module.py
+cd packages/taskdog-core && PYTHONPATH=src uv run python -m pytest tests/test_module.py -v
 
 # Run specific test method
-cd packages/taskdog-core && PYTHONPATH=src uv run python -m unittest tests.test_module.TestClass.test_method
+cd packages/taskdog-core && PYTHONPATH=src uv run python -m pytest tests/test_module.py::TestClass::test_method -v
 ```
 
 ### Coverage Requirements

--- a/packages/taskdog-ui/tests/conftest.py
+++ b/packages/taskdog-ui/tests/conftest.py
@@ -1,9 +1,4 @@
-"""Pytest configuration for taskdog-ui tests.
-
-This file configures pytest to ignore broken tests that were not previously
-discovered by unittest but are found by pytest. These tests need to be fixed
-in a separate PR.
-"""
+"""Pytest configuration for taskdog-ui tests."""
 
 import sys
 from pathlib import Path
@@ -14,11 +9,3 @@ _core_tests_path = (
 ).resolve()
 if str(_core_tests_path) not in sys.path:
     sys.path.insert(0, str(_core_tests_path))
-
-# List of paths to ignore during test collection
-# These tests use wrong types (Task entity instead of ViewModel) or have
-# missing __init__.py files that prevented unittest from discovering them
-collect_ignore = [
-    "presentation/tui/widgets",
-    "tui/services",
-]

--- a/packages/taskdog-ui/tests/presentation/tui/widgets/__init__.py
+++ b/packages/taskdog-ui/tests/presentation/tui/widgets/__init__.py
@@ -1,0 +1,1 @@
+"""TUI widgets presentation tests package."""

--- a/packages/taskdog-ui/tests/presentation/tui/widgets/test_task_table_row_builder.py
+++ b/packages/taskdog-ui/tests/presentation/tui/widgets/test_task_table_row_builder.py
@@ -6,7 +6,35 @@ import pytest
 from rich.text import Text
 
 from taskdog.tui.widgets.task_table_row_builder import TaskTableRowBuilder
-from taskdog_core.domain.entities.task import Task, TaskStatus
+from taskdog.view_models.task_view_model import TaskRowViewModel
+from taskdog_core.domain.entities.task import TaskStatus
+
+
+def make_vm(**overrides: object) -> TaskRowViewModel:
+    """Build a TaskRowViewModel with sensible defaults, overridable per test."""
+    now = datetime.now()
+    defaults: dict[str, object] = {
+        "id": 1,
+        "name": "Test task",
+        "status": TaskStatus.PENDING,
+        "priority": 2,
+        "is_fixed": False,
+        "estimated_duration": None,
+        "actual_duration_hours": None,
+        "deadline": None,
+        "planned_start": None,
+        "planned_end": None,
+        "actual_start": None,
+        "actual_end": None,
+        "depends_on": [],
+        "tags": [],
+        "is_finished": False,
+        "has_notes": False,
+        "created_at": now,
+        "updated_at": now,
+    }
+    defaults.update(overrides)
+    return TaskRowViewModel(**defaults)  # type: ignore[arg-type]
 
 
 class TestTaskTableRowBuilder:
@@ -19,14 +47,9 @@ class TestTaskTableRowBuilder:
 
     def test_build_row_basic_task(self):
         """Test building a row for a basic task."""
-        task = Task(
-            id=1,
-            name="Test task",
-            priority=2,
-            status=TaskStatus.PENDING,
-        )
+        vm = make_vm(id=1, name="Test task", priority=2, status=TaskStatus.PENDING)
 
-        row = self.builder.build_row(task)
+        row = self.builder.build_row(vm)
 
         # Should return tuple of 15 Text objects (15 columns)
         assert len(row) == 15
@@ -41,45 +64,39 @@ class TestTaskTableRowBuilder:
 
     def test_build_row_completed_task_has_strikethrough_and_dim(self):
         """Test that completed tasks have strikethrough and dim style on name."""
-        task = Task(
-            id=1,
+        vm = make_vm(
             name="Completed task",
             priority=1,
             status=TaskStatus.COMPLETED,
+            is_finished=True,
         )
 
-        row = self.builder.build_row(task)
+        row = self.builder.build_row(vm)
 
-        # Name column should have strikethrough + dim style
+        # Name column should have strikethrough + dim style (applied as a span)
         name_text = row[1]
-        assert name_text.style == "strike dim"
+        assert any(span.style == "strike dim" for span in name_text.spans)
 
     def test_build_row_pending_task_no_strikethrough(self):
         """Test that non-completed tasks don't have strikethrough."""
-        task = Task(
-            id=1,
-            name="Pending task",
-            priority=1,
-            status=TaskStatus.PENDING,
-        )
+        vm = make_vm(name="Pending task", priority=1, status=TaskStatus.PENDING)
 
-        row = self.builder.build_row(task)
+        row = self.builder.build_row(vm)
 
         # Name column should not have strikethrough
         name_text = row[1]
-        assert name_text.style is None
+        assert name_text.spans == []
 
     def test_build_row_fixed_task_shows_flag(self):
         """Test that fixed tasks show the fixed indicator."""
-        task = Task(
-            id=1,
+        vm = make_vm(
             name="Fixed task",
             priority=1,
             status=TaskStatus.PENDING,
             is_fixed=True,
         )
 
-        row = self.builder.build_row(task)
+        row = self.builder.build_row(vm)
 
         # Flags column should contain fixed indicator
         flags = str(row[4])
@@ -87,15 +104,14 @@ class TestTaskTableRowBuilder:
 
     def test_build_row_with_tags(self):
         """Test building a row with tags."""
-        task = Task(
-            id=1,
+        vm = make_vm(
             name="Tagged task",
             priority=1,
             status=TaskStatus.PENDING,
             tags=["urgent", "backend"],
         )
 
-        row = self.builder.build_row(task)
+        row = self.builder.build_row(vm)
 
         # Tags column should show comma-separated tags
         tags_text = str(row[14])
@@ -104,15 +120,14 @@ class TestTaskTableRowBuilder:
     def test_build_row_with_deadline(self):
         """Test building a row with deadline."""
         deadline = datetime.now() + timedelta(days=7)
-        task = Task(
-            id=1,
+        vm = make_vm(
             name="Task with deadline",
             priority=1,
             status=TaskStatus.PENDING,
             deadline=deadline,
         )
 
-        row = self.builder.build_row(task)
+        row = self.builder.build_row(vm)
 
         # Deadline column should be formatted (not "-")
         deadline_text = str(row[7])
@@ -120,7 +135,7 @@ class TestTaskTableRowBuilder:
 
     def test_build_row_with_dependencies(self):
         """Test building a row with dependencies."""
-        task = Task(
+        vm = make_vm(
             id=3,
             name="Dependent task",
             priority=1,
@@ -128,41 +143,22 @@ class TestTaskTableRowBuilder:
             depends_on=[1, 2],
         )
 
-        row = self.builder.build_row(task)
+        row = self.builder.build_row(vm)
 
         # Dependencies column should show comma-separated IDs
         deps_text = str(row[13])
         assert deps_text == "1,2"
 
-    def test_format_name_truncation(self):
-        """Test name truncation for long task names."""
-        long_name = "A" * 100  # Very long name
-
-        formatted = self.builder._format_name(long_name)
-
-        # Should be truncated with "..."
-        assert formatted.endswith("...")
-        assert len(formatted) < len(long_name)
-
-    def test_format_name_no_truncation(self):
-        """Test that short names are not truncated."""
-        short_name = "Short task"
-
-        formatted = self.builder._format_name(short_name)
-
-        assert formatted == short_name
-
     def test_build_row_in_progress_task_shows_elapsed_time(self):
         """Test that IN_PROGRESS tasks show elapsed time."""
-        task = Task(
-            id=1,
+        vm = make_vm(
             name="In progress task",
             priority=1,
             status=TaskStatus.IN_PROGRESS,
             actual_start=datetime.now() - timedelta(hours=2),
         )
 
-        row = self.builder.build_row(task)
+        row = self.builder.build_row(vm)
 
         # Elapsed time column should show time (not "-")
         elapsed_text = str(row[12])
@@ -170,16 +166,15 @@ class TestTaskTableRowBuilder:
 
     def test_build_row_with_estimated_duration(self):
         """Test building a row with estimated duration."""
-        task = Task(
-            id=1,
+        vm = make_vm(
             name="Task with estimate",
             priority=1,
             status=TaskStatus.PENDING,
             estimated_duration=8,
         )
 
-        row = self.builder.build_row(task)
+        row = self.builder.build_row(vm)
 
-        # Duration column should show estimate
+        # Duration column should show the estimated hours
         duration_text = str(row[5])
-        assert "E:8h" in duration_text
+        assert "8" in duration_text

--- a/packages/taskdog-ui/tests/tui/__init__.py
+++ b/packages/taskdog-ui/tests/tui/__init__.py
@@ -1,0 +1,1 @@
+"""TUI tests package."""

--- a/packages/taskdog-ui/tests/tui/services/test_task_ui_manager.py
+++ b/packages/taskdog-ui/tests/tui/services/test_task_ui_manager.py
@@ -10,6 +10,7 @@ from taskdog.tui.services.task_ui_manager import TaskUIManager
 from taskdog.tui.state.tui_state import TUIState
 from taskdog.view_models.gantt_view_model import GanttViewModel
 from taskdog.view_models.task_view_model import TaskRowViewModel
+from taskdog_core.application.dto.gantt_output import GanttDateRange, GanttOutput
 from taskdog_core.application.dto.task_dto import TaskRowDto
 from taskdog_core.application.dto.task_list_output import TaskListOutput
 from taskdog_core.domain.entities.task import TaskStatus
@@ -75,6 +76,20 @@ def create_gantt_viewmodel() -> GanttViewModel:
     return GanttViewModel(
         start_date=date.today(),
         end_date=date.today() + timedelta(days=7),
+        tasks=[],
+        task_daily_hours={},
+        daily_workload={},
+        holidays=set(),
+    )
+
+
+def create_gantt_output() -> GanttOutput:
+    """Helper to create a minimal GanttOutput for list_tasks responses."""
+    return GanttOutput(
+        date_range=GanttDateRange(
+            start_date=date.today(),
+            end_date=date.today() + timedelta(days=7),
+        ),
         tasks=[],
         task_daily_hours={},
         daily_workload={},
@@ -351,7 +366,7 @@ class TestRecalculateGantt:
             tasks=[],
             total_count=0,
             filtered_count=0,
-            gantt_data=MagicMock(),
+            gantt_data=create_gantt_output(),
         )
         self.task_data_loader.api_client.list_tasks.return_value = task_list_output
         self.task_data_loader.gantt_presenter.present.return_value = gantt
@@ -390,7 +405,7 @@ class TestRecalculateGantt:
             tasks=[],
             total_count=0,
             filtered_count=0,
-            gantt_data=MagicMock(),
+            gantt_data=create_gantt_output(),
         )
         self.task_data_loader.api_client.list_tasks.return_value = task_list_output
         self.task_data_loader.gantt_presenter.present.return_value = gantt
@@ -442,7 +457,7 @@ class TestRecalculateGantt:
             tasks=[],
             total_count=0,
             filtered_count=0,
-            gantt_data=MagicMock(),
+            gantt_data=create_gantt_output(),
         )
         self.task_data_loader.api_client.list_tasks.return_value = task_list_output
         self.task_data_loader.gantt_presenter.present.return_value = gantt


### PR DESCRIPTION
## What

`packages/taskdog-ui/tests/conftest.py` was skipping two whole test directories via `collect_ignore`:

```python
collect_ignore = ["presentation/tui/widgets", "tui/services"]
```

with a note that the tests were broken and "need to be fixed in a separate PR". This is that PR. Of the ignored tests, 111 already passed and only 14 actually failed — the failures were **stale tests written against an older API**, not product bugs.

## Changes

- **`test_task_table_row_builder.py`** — `TaskTableRowBuilder.build_row` now takes a `TaskRowViewModel`, not a `Task` entity. Rewrote the tests to build view models via a local `make_vm()` helper. Also:
  - strikethrough is applied as a Rich span (`stylize`), so assert on `name_text.spans` instead of `name_text.style`
  - estimated duration renders as plain hours (`"8"`), not `"E:8h"`
  - dropped the two `_format_name` tests — that private method was removed (the name column uses `vm.name` directly)
- **`test_task_ui_manager.py`** — `TaskListOutput.gantt_data` is a Pydantic `GanttOutput | None`, so `MagicMock()` no longer validates. Replaced the 3 occurrences with a real minimal `GanttOutput` via a `create_gantt_output()` helper.
- **`conftest.py`** — removed `collect_ignore` and the obsolete docstring.
- Added the missing `__init__.py` files (`tests/tui/`, `tests/presentation/tui/widgets/`) that kept these dirs uncollected.
- **`CONTRIBUTING.md`** — fixed test-framework drift (`unittest` → `pytest`).

## Verification

- `make test-ui` — **1055 passed**, coverage gate satisfied
- `make lint` — clean
- `make typecheck` — clean

## Not included

The other item from the review — the Clean Architecture violation where `domain/repositories/audit_log_repository.py` imports from `application.dto` — is a cross-package refactor (the audit DTOs are imported in 8 places across all 5 packages) and involves a design decision (move DTOs into the domain vs. have the repo return domain entities). Kept separate to keep this PR focused on the test/doc cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)