### PR TITLE
build(aur): ship taskdog on the AUR and auto-publish on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,3 +147,27 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  publish-aur:
+    name: Publish to AUR
+    runs-on: ubuntu-latest
+    needs: [release]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Sync pkgver to release tag
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          sed -i "s/^pkgver=.*/pkgver=${version}/" contrib/aur/PKGBUILD
+
+      - name: Publish taskdog to the AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
+        with:
+          pkgname: taskdog
+          pkgbuild: contrib/aur/PKGBUILD
+          updpkgsums: true
+          commit_username: ${{ github.actor }}
+          commit_email: program3152019@gmail.com
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "Update to ${{ github.ref_name }}"

--- a/contrib/aur/.gitignore
+++ b/contrib/aur/.gitignore
@@ -1,0 +1,4 @@
+/src/
+/pkg/
+*.tar.gz
+*.pkg.tar.zst

--- a/contrib/aur/PKGBUILD
+++ b/contrib/aur/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Kohei Wada <program3152019@gmail.com>
-pkgname=taskdog-venv
+pkgname=taskdog
 _pkgname=taskdog
-pkgver=0.20.1
+pkgver=0.22.0
 pkgrel=1
 pkgdesc="Task management system with CLI/TUI and a REST API server (GTD, time tracking, schedule optimization)"
 arch=('x86_64')
@@ -9,10 +9,8 @@ url="https://github.com/Kohei-Wada/taskdog"
 license=('MIT')
 depends=('python')
 makedepends=('uv')
-provides=('taskdog')
-conflicts=('taskdog')
 source=("$_pkgname-$pkgver.tar.gz::https://github.com/Kohei-Wada/taskdog/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('f37e889f2dde17561c347c74289cfce50b87ebbc328c79a40d4d9fb6250650b3')
+sha256sums=('ff66b405e2d855872b690a976c974d4677788f28debae30d170f2e6327420f6d')
 options=('!strip')
 
 _prefix=/usr/lib/taskdog

--- a/contrib/aur/PKGBUILD
+++ b/contrib/aur/PKGBUILD
@@ -1,0 +1,66 @@
+# Maintainer: Kohei Wada <program3152019@gmail.com>
+pkgname=taskdog-venv
+_pkgname=taskdog
+pkgver=0.20.1
+pkgrel=1
+pkgdesc="Task management system with CLI/TUI and a REST API server (GTD, time tracking, schedule optimization)"
+arch=('x86_64')
+url="https://github.com/Kohei-Wada/taskdog"
+license=('MIT')
+depends=('python')
+makedepends=('uv')
+provides=('taskdog')
+conflicts=('taskdog')
+source=("$_pkgname-$pkgver.tar.gz::https://github.com/Kohei-Wada/taskdog/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('f37e889f2dde17561c347c74289cfce50b87ebbc328c79a40d4d9fb6250650b3')
+options=('!strip')
+
+_prefix=/usr/lib/taskdog
+
+build() {
+  # Run from $srcdir (not the source tree) so the repo's .python-version does
+  # not pull a uv-managed interpreter — we want the system python.
+  cd "$srcdir"
+
+  # Bundled, relocatable venv on the system python so we don't have to map
+  # every Python dep to an Arch package. taskdog's own 5 packages are built
+  # from this tarball (non-editable); third-party deps come from PyPI.
+  uv venv --clear --no-managed-python --python /usr/bin/python3 --relocatable venv
+  UV_NO_INSTALLER_METADATA=1 \
+  UV_NO_CACHE=1 \
+  UV_LINK_MODE=copy \
+  uv pip install --python "$srcdir/venv/bin/python" --no-editable \
+    "$srcdir/$_pkgname-$pkgver/packages/taskdog-core" \
+    "$srcdir/$_pkgname-$pkgver/packages/taskdog-client" \
+    "$srcdir/$_pkgname-$pkgver/packages/taskdog-server" \
+    "$srcdir/$_pkgname-$pkgver/packages/taskdog-ui" \
+    "$srcdir/$_pkgname-$pkgver/packages/taskdog-mcp"
+
+  # Ship precompiled bytecode so the read-only /usr install never recompiles at
+  # runtime. unchecked-hash makes the .pyc trusted without source-mtime checks,
+  # which is correct for an immutable system package.
+  "$srcdir/venv/bin/python" -m compileall -q -f \
+    --invalidation-mode unchecked-hash "$srcdir/venv/lib"
+}
+
+package() {
+  cd "$srcdir/$_pkgname-$pkgver"
+
+  # Ship the venv under /usr/lib/taskdog and expose the three entry points.
+  install -dm755 "$pkgdir$_prefix"
+  cp -a "$srcdir/venv/." "$pkgdir$_prefix/"
+
+  install -dm755 "$pkgdir/usr/bin"
+  local bin
+  for bin in taskdog taskdog-server taskdog-mcp; do
+    ln -s "$_prefix/bin/$bin" "$pkgdir/usr/bin/$bin"
+  done
+
+  # Systemd user service, with ExecStart pointed at the packaged binary.
+  install -dm755 "$pkgdir/usr/lib/systemd/user"
+  sed 's|%h/.local/bin/taskdog-server|/usr/bin/taskdog-server|' \
+    contrib/systemd/taskdog-server.service \
+    > "$pkgdir/usr/lib/systemd/user/taskdog-server.service"
+
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/contrib/aur/README.md
+++ b/contrib/aur/README.md
@@ -1,0 +1,52 @@
+# AUR package (`taskdog-venv`)
+
+A `PKGBUILD` for installing taskdog on Arch Linux via `pacman`/`yay`, as an
+alternative to `make install` (which uses `uv tool install` into `~/.local`).
+
+## What it does
+
+- Builds a relocatable, self-contained virtualenv on the system Python and
+  ships it under `/usr/lib/taskdog`.
+- Exposes the three entry points in `/usr/bin`: `taskdog`, `taskdog-server`,
+  `taskdog-mcp`.
+- Installs the systemd **user** service to `/usr/lib/systemd/user/`
+  (enable per-user with `systemctl --user enable --now taskdog-server`).
+- Precompiles bytecode (`compileall --invalidation-mode unchecked-hash`) so the
+  read-only `/usr` install never recompiles at runtime.
+
+This is the **venv-bundled** approach: taskdog's five packages are built from
+the release tarball, third-party deps come from PyPI at build time, and
+everything is vendored into the package. The `-venv` suffix and
+`provides`/`conflicts=('taskdog')` follow the AUR convention used by packages
+like `aider-chat-venv` and `paperless-ngx-venv`, reserving the plain `taskdog`
+name for a future native (`python-*` dependency) package.
+
+## Build & install
+
+```bash
+cd contrib/aur
+makepkg -si          # build and install
+```
+
+Data lives per-user in `$XDG_DATA_HOME/taskdog/` (default
+`~/.local/share/taskdog/`); the package never touches it.
+
+## Updating
+
+Bump `pkgver` (and run `makepkg -g` to refresh `sha256sums`), then
+`makepkg -si` again.
+
+## Caveats
+
+- `arch=('x86_64')` because the bundled wheels (e.g. `pydantic-core`) are
+  platform-specific.
+- The venv is built against the system Python, so a major Python upgrade
+  (e.g. 3.14 → 3.15) requires a rebuild.
+- Build downloads third-party deps from PyPI, which is outside `makepkg`'s
+  source control — fine for personal/AUR use, not for the official repos.
+
+## Not published to the AUR yet
+
+This `PKGBUILD` is kept in-repo for local builds. Publishing it as `taskdog-venv`
+on aur.archlinux.org (so `yay -S taskdog-venv` works for everyone) requires an
+AUR account + SSH key and is a separate manual step.

--- a/contrib/aur/README.md
+++ b/contrib/aur/README.md
@@ -1,7 +1,8 @@
-# AUR package (`taskdog-venv`)
+# AUR package (`taskdog`)
 
-A `PKGBUILD` for installing taskdog on Arch Linux via `pacman`/`yay`, as an
-alternative to `make install` (which uses `uv tool install` into `~/.local`).
+A `PKGBUILD` for installing taskdog on Arch Linux via `pacman`/`yay`
+(`yay -S taskdog`), as an alternative to `make install` (which uses
+`uv tool install` into `~/.local`).
 
 ## What it does
 
@@ -16,10 +17,10 @@ alternative to `make install` (which uses `uv tool install` into `~/.local`).
 
 This is the **venv-bundled** approach: taskdog's five packages are built from
 the release tarball, third-party deps come from PyPI at build time, and
-everything is vendored into the package. The `-venv` suffix and
-`provides`/`conflicts=('taskdog')` follow the AUR convention used by packages
-like `aider-chat-venv` and `paperless-ngx-venv`, reserving the plain `taskdog`
-name for a future native (`python-*` dependency) package.
+everything is vendored into the package. It is non-idiomatic for the AUR
+(the official-repo route would package each `python-*` dependency natively),
+but self-contained and low-maintenance — the same approach taken by
+`aider-chat-venv` and `paperless-ngx-venv`.
 
 ## Build & install
 
@@ -31,10 +32,19 @@ makepkg -si          # build and install
 Data lives per-user in `$XDG_DATA_HOME/taskdog/` (default
 `~/.local/share/taskdog/`); the package never touches it.
 
-## Updating
+## Updating (automated)
 
-Bump `pkgver` (and run `makepkg -g` to refresh `sha256sums`), then
-`makepkg -si` again.
+The package is published on the AUR and refreshed automatically: the `Release`
+workflow (`.github/workflows/release.yml`) has a `publish-aur` job that, on every
+`v*` tag, rewrites `pkgver`/`sha256sums` from the tagged release tarball,
+regenerates `.SRCINFO`, and pushes to `ssh://aur@aur.archlinux.org/taskdog.git`.
+
+This in-repo `PKGBUILD` is the source the CI pushes from; the `pkgver`/`sha256sums`
+values here are a snapshot and are overwritten by CI from the tag, so they do not
+need to be kept current by hand.
+
+To update by hand instead, bump `pkgver`, run `makepkg -g` to refresh
+`sha256sums`, then `makepkg -si`.
 
 ## Caveats
 
@@ -45,8 +55,14 @@ Bump `pkgver` (and run `makepkg -g` to refresh `sha256sums`), then
 - Build downloads third-party deps from PyPI, which is outside `makepkg`'s
   source control — fine for personal/AUR use, not for the official repos.
 
-## Not published to the AUR yet
+## CI setup (one-time)
 
-This `PKGBUILD` is kept in-repo for local builds. Publishing it as `taskdog-venv`
-on aur.archlinux.org (so `yay -S taskdog-venv` works for everyone) requires an
-AUR account + SSH key and is a separate manual step.
+The `publish-aur` job needs an SSH key authorized to push to the AUR package:
+
+1. Create an AUR account and add its SSH **public** key (My Account → SSH Public
+   Key). Use a dedicated key, not a personal one.
+2. Register the matching **private** key as the GitHub Actions secret
+   `AUR_SSH_PRIVATE_KEY` (`gh secret set AUR_SSH_PRIVATE_KEY < ~/.ssh/aur`).
+3. The AUR package must already exist — CI only updates it. The initial import
+   (push of `PKGBUILD` + `.SRCINFO` to a fresh `taskdog.git`) is a manual step
+   done once by the maintainer.


### PR DESCRIPTION
## What

Adds `contrib/aur/` with a `PKGBUILD` so taskdog installs on Arch Linux via
`yay -S taskdog`, and wires the `Release` workflow to keep the AUR package in
sync automatically on every `v*` tag.

The package is **already published** at https://aur.archlinux.org/packages/taskdog
(initial import done manually, since the AUR only lets CI *update* an existing
package, not create one).

## Approach (venv-bundled, plain `taskdog` name)

Two routes exist for shipping a Python app on the AUR:
- **Native** (`depends=('python-*')`): idiomatic but several deps (`uvicorn[standard]`
  extras, etc.) aren't in the official repos/AUR, so they'd have to be packaged and
  maintained too.
- **venv-bundled** (this PR): vendors deps into a relocatable venv. Non-idiomatic
  but self-contained and low-maintenance — same as `aider-chat-venv` / `paperless-ngx-venv`.

Shipped under the plain `taskdog` name (no `-venv` suffix) since this is the
project's own package and the maintainer owns the name on the AUR.

## What the PKGBUILD does

- Builds a **relocatable** venv on the system Python (`uv venv --relocatable`),
  installs taskdog's 5 packages from the release tarball (non-editable), deps from PyPI.
- Ships the venv under `/usr/lib/taskdog`, symlinks `taskdog` / `taskdog-server` /
  `taskdog-mcp` into `/usr/bin`.
- Installs the systemd **user** service to `/usr/lib/systemd/user/`.
- `UV_NO_INSTALLER_METADATA=1` + `compileall --invalidation-mode unchecked-hash`
  so the read-only `/usr` install never recompiles at runtime.

## Auto-publish (`publish-aur` job)

On every `v*` tag, after the GitHub Release is created, a new `publish-aur` job:
- syncs `pkgver` to the tag,
- refreshes `sha256sums` from the tagged tarball (`updpkgsums`),
- regenerates `.SRCINFO` and pushes to `ssh://aur@aur.archlinux.org/taskdog.git`
  via `KSXGitHub/github-actions-deploy-aur` (no in-CI build).

Auth via the `AUR_SSH_PRIVATE_KEY` repo secret (dedicated CI key). One-time setup
documented in `contrib/aur/README.md`.

## Verified

- `makepkg` builds cleanly as `taskdog 0.22.0-1`; binaries run; `taskdog --version`
  reports `0.22.0`; systemd user service + `/usr/bin` symlinks present.
- Initial import pushed to the AUR; package page live.

## Caveats (documented in `contrib/aur/README.md`)

- `arch=('x86_64')` (bundled wheels like `pydantic-core` are platform-specific).
- venv built against the system Python → a major Python upgrade needs a rebuild.
- Build pulls deps from PyPI at build time — fine for personal/AUR use, not
  official-repo quality.

Build artifacts (`src/`, `pkg/`, `*.tar.gz`, `*.pkg.tar.zst`) are gitignored.