### PR TITLE
refactor(core): introduce AuditLog entity to fix domain → application dependency

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/dto/audit_log_dto.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/audit_log_dto.py
@@ -1,87 +1,15 @@
-"""DTOs for audit logging operations.
+"""Output DTOs for audit logging operations.
 
-This module defines data transfer objects for audit log operations,
-including the audit event structure and query parameters.
+These are the presentation-facing representations of audit logs returned by the
+application layer. The domain types (``AuditLog`` entity and ``AuditQuery``)
+live in ``domain/entities/audit_log.py``.
 """
 
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
-
-@dataclass(frozen=True)
-class AuditEvent:
-    """Represents a single audit log event.
-
-    This DTO is used to capture audit information when API operations
-    are performed. It tracks who did what, when, and what changed.
-    """
-
-    timestamp: datetime
-    """When the operation occurred."""
-
-    operation: str
-    """The type of operation (e.g., 'create_task', 'complete_task')."""
-
-    resource_type: str
-    """The type of resource (e.g., 'task', 'schedule')."""
-
-    success: bool
-    """Whether the operation succeeded."""
-
-    client_name: str | None = None
-    """The authenticated client name (e.g., 'claude-code')."""
-
-    resource_id: int | None = None
-    """The ID of the affected resource (task ID, etc.)."""
-
-    resource_name: str | None = None
-    """The name of the affected resource (task name, etc.)."""
-
-    old_values: dict[str, Any] | None = None
-    """Values before the change (for update operations)."""
-
-    new_values: dict[str, Any] | None = None
-    """Values after the change."""
-
-    error_message: str | None = None
-    """Error message if the operation failed."""
-
-
-@dataclass(frozen=True)
-class AuditQuery:
-    """Query parameters for filtering audit logs.
-
-    All fields are optional. If not specified, no filtering is applied
-    for that field.
-    """
-
-    client_name: str | None = None
-    """Filter by client name."""
-
-    operation: str | None = None
-    """Filter by operation type."""
-
-    resource_type: str | None = None
-    """Filter by resource type."""
-
-    resource_id: int | None = None
-    """Filter by resource ID (task ID)."""
-
-    success: bool | None = None
-    """Filter by success status."""
-
-    start_date: datetime | None = None
-    """Filter logs from this date onwards."""
-
-    end_date: datetime | None = None
-    """Filter logs up to this date."""
-
-    limit: int = 100
-    """Maximum number of logs to return."""
-
-    offset: int = 0
-    """Number of logs to skip (for pagination)."""
+from taskdog_core.domain.entities.audit_log import AuditLog
 
 
 @dataclass(frozen=True)
@@ -120,6 +48,24 @@ class AuditLogOutput:
 
     error_message: str | None
     """Error message if the operation failed."""
+
+    @classmethod
+    def from_entity(cls, log: AuditLog) -> "AuditLogOutput":
+        """Build an output DTO from a persisted ``AuditLog`` entity."""
+        assert log.id is not None, "cannot build output DTO from an unpersisted log"
+        return cls(
+            id=log.id,
+            timestamp=log.timestamp,
+            client_name=log.client_name,
+            operation=log.operation,
+            resource_type=log.resource_type,
+            resource_id=log.resource_id,
+            resource_name=log.resource_name,
+            old_values=log.old_values,
+            new_values=log.new_values,
+            success=log.success,
+            error_message=log.error_message,
+        )
 
 
 @dataclass(frozen=True)

--- a/packages/taskdog-core/src/taskdog_core/controllers/audit_log_controller.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/audit_log_controller.py
@@ -9,11 +9,10 @@ import logging
 from typing import Any
 
 from taskdog_core.application.dto.audit_log_dto import (
-    AuditEvent,
     AuditLogListOutput,
     AuditLogOutput,
-    AuditQuery,
 )
+from taskdog_core.domain.entities.audit_log import AuditLog, AuditQuery
 from taskdog_core.domain.repositories.audit_log_repository import AuditLogRepository
 from taskdog_core.domain.services.time_provider import ITimeProvider
 
@@ -46,17 +45,17 @@ class AuditLogController:
         self._repository = repository
         self._time_provider = time_provider
 
-    def save(self, event: AuditEvent) -> None:
-        """Save an audit event to the database.
+    def save(self, log: AuditLog) -> None:
+        """Save an audit log record to the database.
 
         Args:
-            event: The audit event to save
+            log: The audit log to save
         """
-        self._repository.save(event)
+        self._repository.save(log)
         logger.debug(
-            f"Audit log saved: operation={event.operation}, "
-            f"resource_type={event.resource_type}, "
-            f"resource_id={event.resource_id}"
+            f"Audit log saved: operation={log.operation}, "
+            f"resource_type={log.resource_type}, "
+            f"resource_id={log.resource_id}"
         )
 
     def log_operation(
@@ -74,7 +73,7 @@ class AuditLogController:
     ) -> None:
         """Log an operation with a convenience method.
 
-        This is a shortcut for creating an AuditEvent and calling save().
+        This is a shortcut for creating an AuditLog and calling save().
 
         Args:
             operation: The operation type (e.g., 'create_task')
@@ -87,7 +86,7 @@ class AuditLogController:
             new_values: Values after the change
             error_message: Error message if the operation failed
         """
-        event = AuditEvent(
+        log = AuditLog(
             timestamp=self._time_provider.now(),
             operation=operation,
             resource_type=resource_type,
@@ -99,7 +98,7 @@ class AuditLogController:
             new_values=new_values,
             error_message=error_message,
         )
-        self.save(event)
+        self.save(log)
 
     def get_logs(self, query: AuditQuery) -> AuditLogListOutput:
         """Query audit logs with filtering and pagination.
@@ -110,7 +109,14 @@ class AuditLogController:
         Returns:
             AuditLogListOutput containing logs and pagination info
         """
-        return self._repository.get_logs(query)
+        logs = self._repository.get_logs(query)
+        total_count = self._repository.count_logs(query)
+        return AuditLogListOutput(
+            logs=[AuditLogOutput.from_entity(log) for log in logs],
+            total_count=total_count,
+            limit=query.limit,
+            offset=query.offset,
+        )
 
     def get_by_id(self, log_id: int) -> AuditLogOutput | None:
         """Get a single audit log by ID.
@@ -121,7 +127,8 @@ class AuditLogController:
         Returns:
             AuditLogOutput if found, None otherwise
         """
-        return self._repository.get_by_id(log_id)
+        log = self._repository.get_by_id(log_id)
+        return AuditLogOutput.from_entity(log) if log is not None else None
 
     def count_logs(self, query: AuditQuery) -> int:
         """Count audit logs matching the query.

--- a/packages/taskdog-core/src/taskdog_core/domain/entities/audit_log.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/entities/audit_log.py
@@ -1,0 +1,95 @@
+"""Audit log domain entity and query value object.
+
+An audit log records who did what, when, and what changed. These are pure
+domain types with no framework or application-layer dependencies, so the
+repository interface can speak in domain terms (see
+``domain/repositories/audit_log_repository.py``). The application layer maps
+``AuditLog`` to its output DTOs.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+
+@dataclass(frozen=True)
+class AuditLog:
+    """A single audit log record.
+
+    ``id`` is ``None`` before the record is persisted and set once the
+    repository has stored it.
+
+    Audit records are deliberately not validated in ``__post_init__``: failing
+    to construct one would drop an entry from the audit trail, which is worse
+    than recording an imperfect one.
+    """
+
+    timestamp: datetime
+    """When the operation occurred."""
+
+    operation: str
+    """The type of operation (e.g., 'create_task', 'complete_task')."""
+
+    resource_type: str
+    """The type of resource (e.g., 'task', 'schedule')."""
+
+    success: bool
+    """Whether the operation succeeded."""
+
+    client_name: str | None = None
+    """The authenticated client name (e.g., 'claude-code')."""
+
+    resource_id: int | None = None
+    """The ID of the affected resource (task ID, etc.)."""
+
+    resource_name: str | None = None
+    """The name of the affected resource (task name, etc.)."""
+
+    old_values: dict[str, Any] | None = None
+    """Values before the change (for update operations)."""
+
+    new_values: dict[str, Any] | None = None
+    """Values after the change."""
+
+    error_message: str | None = None
+    """Error message if the operation failed."""
+
+    id: int | None = None
+    """Unique identifier, assigned by the repository on persistence."""
+
+
+@dataclass(frozen=True)
+class AuditQuery:
+    """Query parameters for filtering audit logs.
+
+    All fields are optional. If not specified, no filtering is applied for
+    that field. This is a repository query value object, not persistence- or
+    presentation-specific.
+    """
+
+    client_name: str | None = None
+    """Filter by client name."""
+
+    operation: str | None = None
+    """Filter by operation type."""
+
+    resource_type: str | None = None
+    """Filter by resource type."""
+
+    resource_id: int | None = None
+    """Filter by resource ID (task ID)."""
+
+    success: bool | None = None
+    """Filter by success status."""
+
+    start_date: datetime | None = None
+    """Filter logs from this date onwards."""
+
+    end_date: datetime | None = None
+    """Filter logs up to this date."""
+
+    limit: int = 100
+    """Maximum number of logs to return."""
+
+    offset: int = 0
+    """Number of logs to skip (for pagination)."""

--- a/packages/taskdog-core/src/taskdog_core/domain/repositories/audit_log_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/repositories/audit_log_repository.py
@@ -6,12 +6,7 @@ abstracting away implementation details like database operations.
 
 from abc import ABC, abstractmethod
 
-from taskdog_core.application.dto.audit_log_dto import (
-    AuditEvent,
-    AuditLogListOutput,
-    AuditLogOutput,
-    AuditQuery,
-)
+from taskdog_core.domain.entities.audit_log import AuditLog, AuditQuery
 
 
 class AuditLogRepository(ABC):
@@ -23,26 +18,26 @@ class AuditLogRepository(ABC):
     """
 
     @abstractmethod
-    def save(self, event: AuditEvent) -> None:
-        """Persist an audit event.
+    def save(self, log: AuditLog) -> None:
+        """Persist an audit log record.
 
         Args:
-            event: The audit event to save
+            log: The audit log to save
         """
 
     @abstractmethod
-    def get_logs(self, query: AuditQuery) -> AuditLogListOutput:
+    def get_logs(self, query: AuditQuery) -> list[AuditLog]:
         """Query audit logs with filtering and pagination.
 
         Args:
             query: Query parameters for filtering
 
         Returns:
-            AuditLogListOutput containing logs and pagination info
+            The matching audit logs (already ordered and paginated)
         """
 
     @abstractmethod
-    def get_by_id(self, log_id: int) -> AuditLogOutput | None:
+    def get_by_id(self, log_id: int) -> AuditLog | None:
         """Get a single audit log by ID.
 
         Args:

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_audit_log_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_audit_log_repository.py
@@ -14,12 +14,7 @@ from sqlalchemy import delete, func, select
 if TYPE_CHECKING:
     from sqlalchemy.engine import Engine
 
-from taskdog_core.application.dto.audit_log_dto import (
-    AuditEvent,
-    AuditLogListOutput,
-    AuditLogOutput,
-    AuditQuery,
-)
+from taskdog_core.domain.entities.audit_log import AuditLog, AuditQuery
 from taskdog_core.domain.repositories.audit_log_repository import AuditLogRepository
 from taskdog_core.infrastructure.persistence.database.base_repository import (
     SqliteBaseRepository,
@@ -49,65 +44,47 @@ class SqliteAuditLogRepository(SqliteBaseRepository, AuditLogRepository):
         """
         super().__init__(database_url, engine)
 
-    def save(self, event: AuditEvent) -> None:
-        """Persist an audit event to the database.
+    def save(self, log: AuditLog) -> None:
+        """Persist an audit log record to the database.
 
         Args:
-            event: The audit event to save
+            log: The audit log to save
         """
         with self.Session() as session:
             model = AuditLogModel(
-                timestamp=event.timestamp,
-                client_name=event.client_name,
-                operation=event.operation,
-                resource_type=event.resource_type,
-                resource_id=event.resource_id,
-                resource_name=event.resource_name,
-                old_values=json.dumps(event.old_values) if event.old_values else None,
-                new_values=json.dumps(event.new_values) if event.new_values else None,
-                success=event.success,
-                error_message=event.error_message,
+                timestamp=log.timestamp,
+                client_name=log.client_name,
+                operation=log.operation,
+                resource_type=log.resource_type,
+                resource_id=log.resource_id,
+                resource_name=log.resource_name,
+                old_values=json.dumps(log.old_values) if log.old_values else None,
+                new_values=json.dumps(log.new_values) if log.new_values else None,
+                success=log.success,
+                error_message=log.error_message,
             )
             session.add(model)
             session.commit()
 
-    def get_logs(self, query: AuditQuery) -> AuditLogListOutput:
+    def get_logs(self, query: AuditQuery) -> list[AuditLog]:
         """Query audit logs with filtering and pagination.
 
         Args:
             query: Query parameters for filtering
 
         Returns:
-            AuditLogListOutput containing logs and pagination info
+            The matching audit logs, newest first
         """
         with self.Session() as session:
-            # Build base query
             stmt = select(AuditLogModel)
             stmt = self._apply_filters(stmt, query)
-
-            # Get total count before pagination
-            count_stmt = select(func.count(AuditLogModel.id))
-            count_stmt = self._apply_filters(count_stmt, query)
-            total_count = session.scalar(count_stmt) or 0
-
-            # Apply ordering and pagination
             stmt = stmt.order_by(AuditLogModel.timestamp.desc())  # type: ignore[attr-defined]
             stmt = stmt.offset(query.offset).limit(query.limit)
 
-            # Execute query
             models = session.scalars(stmt).all()
+            return [self._model_to_entity(model) for model in models]
 
-            # Convert to output DTOs
-            logs = [self._model_to_output(model) for model in models]
-
-            return AuditLogListOutput(
-                logs=logs,
-                total_count=total_count,
-                limit=query.limit,
-                offset=query.offset,
-            )
-
-    def get_by_id(self, log_id: int) -> AuditLogOutput | None:
+    def get_by_id(self, log_id: int) -> AuditLog | None:
         """Get a single audit log by ID.
 
         Args:
@@ -120,7 +97,7 @@ class SqliteAuditLogRepository(SqliteBaseRepository, AuditLogRepository):
             model = session.get(AuditLogModel, log_id)
             if model is None:
                 return None
-            return self._model_to_output(model)
+            return self._model_to_entity(model)
 
     def count_logs(self, query: AuditQuery) -> int:
         """Count audit logs matching the query.
@@ -173,14 +150,14 @@ class SqliteAuditLogRepository(SqliteBaseRepository, AuditLogRepository):
 
         return stmt
 
-    def _model_to_output(self, model: AuditLogModel) -> AuditLogOutput:
-        """Convert an AuditLogModel to AuditLogOutput DTO.
+    def _model_to_entity(self, model: AuditLogModel) -> AuditLog:
+        """Convert an AuditLogModel to an AuditLog domain entity.
 
         Args:
             model: The database model (must be a persisted model with all required fields)
 
         Returns:
-            AuditLogOutput DTO
+            AuditLog entity
         """
         # These assertions ensure the model is a persisted instance with valid data
         assert model.id is not None
@@ -200,7 +177,7 @@ class SqliteAuditLogRepository(SqliteBaseRepository, AuditLogRepository):
         except json.JSONDecodeError:
             new_values = None
 
-        return AuditLogOutput(
+        return AuditLog(
             id=model.id,
             timestamp=model.timestamp,
             client_name=model.client_name,

--- a/packages/taskdog-core/tests/controllers/test_audit_log_controller.py
+++ b/packages/taskdog-core/tests/controllers/test_audit_log_controller.py
@@ -6,12 +6,11 @@ from unittest.mock import Mock, patch
 import pytest
 
 from taskdog_core.application.dto.audit_log_dto import (
-    AuditEvent,
     AuditLogListOutput,
     AuditLogOutput,
-    AuditQuery,
 )
 from taskdog_core.controllers.audit_log_controller import AuditLogController
+from taskdog_core.domain.entities.audit_log import AuditLog, AuditQuery
 from taskdog_core.domain.repositories.audit_log_repository import AuditLogRepository
 from taskdog_core.domain.services.time_provider import ITimeProvider
 
@@ -28,7 +27,7 @@ class TestAuditLogController:
 
     def test_save_delegates_to_repository(self):
         """Test that save delegates to repository.save."""
-        event = AuditEvent(
+        log = AuditLog(
             timestamp=datetime(2026, 1, 1, 12, 0),
             operation="create_task",
             resource_type="task",
@@ -36,14 +35,14 @@ class TestAuditLogController:
             resource_id=1,
         )
 
-        self.controller.save(event)
+        self.controller.save(log)
 
-        self.repository.save.assert_called_once_with(event)
+        self.repository.save.assert_called_once_with(log)
 
     @patch("taskdog_core.controllers.audit_log_controller.logger")
     def test_save_logs_debug_message(self, mock_logger):
         """Test that save calls logger.debug."""
-        event = AuditEvent(
+        log = AuditLog(
             timestamp=datetime(2026, 1, 1, 12, 0),
             operation="create_task",
             resource_type="task",
@@ -51,7 +50,7 @@ class TestAuditLogController:
             resource_id=42,
         )
 
-        self.controller.save(event)
+        self.controller.save(log)
 
         mock_logger.debug.assert_called_once()
         log_message = mock_logger.debug.call_args[0][0]
@@ -59,8 +58,8 @@ class TestAuditLogController:
         assert "task" in log_message
         assert "42" in log_message
 
-    def test_log_operation_creates_event_with_correct_fields(self):
-        """Test that log_operation constructs AuditEvent with correct fields."""
+    def test_log_operation_creates_log_with_correct_fields(self):
+        """Test that log_operation constructs an AuditLog with correct fields."""
         fixed_time = datetime(2026, 2, 19, 10, 30)
         self.time_provider.now.return_value = fixed_time
 
@@ -75,17 +74,19 @@ class TestAuditLogController:
             new_values={"status": "COMPLETED"},
         )
 
-        saved_event = self.repository.save.call_args[0][0]
-        assert saved_event.timestamp == fixed_time
-        assert saved_event.operation == "complete_task"
-        assert saved_event.resource_type == "task"
-        assert saved_event.success is True
-        assert saved_event.client_name == "test-client"
-        assert saved_event.resource_id == 5
-        assert saved_event.resource_name == "My Task"
-        assert saved_event.old_values == {"status": "IN_PROGRESS"}
-        assert saved_event.new_values == {"status": "COMPLETED"}
-        assert saved_event.error_message is None
+        saved = self.repository.save.call_args[0][0]
+        assert isinstance(saved, AuditLog)
+        assert saved.id is None
+        assert saved.timestamp == fixed_time
+        assert saved.operation == "complete_task"
+        assert saved.resource_type == "task"
+        assert saved.success is True
+        assert saved.client_name == "test-client"
+        assert saved.resource_id == 5
+        assert saved.resource_name == "My Task"
+        assert saved.old_values == {"status": "IN_PROGRESS"}
+        assert saved.new_values == {"status": "COMPLETED"}
+        assert saved.error_message is None
 
     def test_log_operation_uses_time_provider(self):
         """Test that log_operation uses time_provider.now(), not datetime.now()."""
@@ -99,8 +100,8 @@ class TestAuditLogController:
         )
 
         self.time_provider.now.assert_called_once()
-        saved_event = self.repository.save.call_args[0][0]
-        assert saved_event.timestamp == injected_time
+        saved = self.repository.save.call_args[0][0]
+        assert saved.timestamp == injected_time
 
     def test_log_operation_optional_fields_default_to_none(self):
         """Test that optional fields are None when omitted."""
@@ -112,65 +113,62 @@ class TestAuditLogController:
             success=False,
         )
 
-        saved_event = self.repository.save.call_args[0][0]
-        assert saved_event.client_name is None
-        assert saved_event.resource_id is None
-        assert saved_event.resource_name is None
-        assert saved_event.old_values is None
-        assert saved_event.new_values is None
-        assert saved_event.error_message is None
+        saved = self.repository.save.call_args[0][0]
+        assert saved.client_name is None
+        assert saved.resource_id is None
+        assert saved.resource_name is None
+        assert saved.old_values is None
+        assert saved.new_values is None
+        assert saved.error_message is None
 
-    def test_get_logs_delegates_to_repository(self):
-        """Test that get_logs delegates to repository and returns its result."""
+    def test_get_logs_maps_entities_to_output(self):
+        """get_logs maps repository entities into a paginated output DTO."""
         query = AuditQuery(operation="create_task", limit=50)
-        expected_output = AuditLogListOutput(
-            logs=[
-                AuditLogOutput(
-                    id=1,
-                    timestamp=datetime(2026, 1, 1),
-                    client_name=None,
-                    operation="create_task",
-                    resource_type="task",
-                    resource_id=1,
-                    resource_name="Task 1",
-                    old_values=None,
-                    new_values=None,
-                    success=True,
-                    error_message=None,
-                )
-            ],
-            total_count=1,
-            limit=50,
-            offset=0,
-        )
-        self.repository.get_logs.return_value = expected_output
+        self.repository.get_logs.return_value = [
+            AuditLog(
+                id=1,
+                timestamp=datetime(2026, 1, 1),
+                operation="create_task",
+                resource_type="task",
+                success=True,
+                resource_id=1,
+                resource_name="Task 1",
+            )
+        ]
+        self.repository.count_logs.return_value = 1
 
         result = self.controller.get_logs(query)
 
         self.repository.get_logs.assert_called_once_with(query)
-        assert result is expected_output
+        self.repository.count_logs.assert_called_once_with(query)
+        assert isinstance(result, AuditLogListOutput)
+        assert result.total_count == 1
+        assert result.limit == 50
+        assert result.offset == 0
+        assert len(result.logs) == 1
+        assert isinstance(result.logs[0], AuditLogOutput)
+        assert result.logs[0].id == 1
+        assert result.logs[0].operation == "create_task"
 
-    def test_get_by_id_delegates_to_repository(self):
-        """Test that get_by_id delegates to repository."""
-        expected_output = AuditLogOutput(
+    def test_get_by_id_maps_entity_to_output(self):
+        """get_by_id maps the repository entity to an output DTO."""
+        self.repository.get_by_id.return_value = AuditLog(
             id=7,
             timestamp=datetime(2026, 1, 1),
-            client_name="cli",
             operation="start_task",
             resource_type="task",
+            success=True,
+            client_name="cli",
             resource_id=3,
             resource_name="Task 3",
-            old_values=None,
-            new_values=None,
-            success=True,
-            error_message=None,
         )
-        self.repository.get_by_id.return_value = expected_output
 
         result = self.controller.get_by_id(7)
 
         self.repository.get_by_id.assert_called_once_with(7)
-        assert result is expected_output
+        assert isinstance(result, AuditLogOutput)
+        assert result.id == 7
+        assert result.operation == "start_task"
 
     def test_get_by_id_returns_none_when_not_found(self):
         """Test that get_by_id returns None when log is not found."""

--- a/packages/taskdog-server/src/taskdog_server/api/routers/audit.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/audit.py
@@ -4,7 +4,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query, status
 
-from taskdog_core.application.dto.audit_log_dto import AuditQuery
+from taskdog_core.domain.entities.audit_log import AuditQuery
 from taskdog_server.api.dependencies import (
     AuditLogControllerDep,
     AuthenticatedClientDep,

--- a/packages/taskdog-server/tests/api/routers/test_audit.py
+++ b/packages/taskdog-server/tests/api/routers/test_audit.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from taskdog_core.application.dto.audit_log_dto import AuditEvent
+from taskdog_core.domain.entities.audit_log import AuditLog
 
 
 class TestAuditLogsRouter:
@@ -50,7 +50,7 @@ class TestAuditLogsRouter:
         """Test filtering audit logs by operation type."""
         # Arrange - create a specific audit log
         audit_log_repository.save(
-            AuditEvent(
+            AuditLog(
                 timestamp=datetime.now(),
                 client_name="test-client",
                 operation="complete_task",
@@ -76,7 +76,7 @@ class TestAuditLogsRouter:
         """Test filtering audit logs by client name."""
         # Arrange - create audit logs with different clients
         audit_log_repository.save(
-            AuditEvent(
+            AuditLog(
                 timestamp=datetime.now(),
                 client_name="claude-code",
                 operation="create_task",
@@ -90,7 +90,7 @@ class TestAuditLogsRouter:
             )
         )
         audit_log_repository.save(
-            AuditEvent(
+            AuditLog(
                 timestamp=datetime.now(),
                 client_name="web-ui",
                 operation="create_task",
@@ -117,7 +117,7 @@ class TestAuditLogsRouter:
         # Arrange - create audit logs with different resource IDs
         for i in range(3):
             audit_log_repository.save(
-                AuditEvent(
+                AuditLog(
                     timestamp=datetime.now(),
                     client_name="test",
                     operation="update_task",
@@ -144,7 +144,7 @@ class TestAuditLogsRouter:
         # Arrange - create multiple audit logs
         for i in range(15):
             audit_log_repository.save(
-                AuditEvent(
+                AuditLog(
                     timestamp=datetime.now(),
                     client_name="test",
                     operation="test_operation",
@@ -182,7 +182,7 @@ class TestAuditLogsRouter:
         """Test filtering audit logs by success status."""
         # Arrange - create success and failure logs
         audit_log_repository.save(
-            AuditEvent(
+            AuditLog(
                 timestamp=datetime.now(),
                 client_name="test",
                 operation="success_op",
@@ -196,7 +196,7 @@ class TestAuditLogsRouter:
             )
         )
         audit_log_repository.save(
-            AuditEvent(
+            AuditLog(
                 timestamp=datetime.now(),
                 client_name="test",
                 operation="failed_op",
@@ -222,7 +222,7 @@ class TestAuditLogsRouter:
         """Test getting a single audit log by ID."""
         # Arrange - create an audit log
         audit_log_repository.save(
-            AuditEvent(
+            AuditLog(
                 timestamp=datetime.now(),
                 client_name="test-client",
                 operation="get_by_id_test",

--- a/packages/taskdog-server/tests/api/routers/test_tasks.py
+++ b/packages/taskdog-server/tests/api/routers/test_tasks.py
@@ -4,7 +4,7 @@ from datetime import date, datetime, timedelta
 
 import pytest
 
-from taskdog_core.application.dto.audit_log_dto import AuditQuery
+from taskdog_core.domain.entities.audit_log import AuditQuery
 from taskdog_core.domain.entities.task import TaskStatus
 
 
@@ -400,11 +400,11 @@ class TestTasksRouter:
 
         # Verify audit log contains properly serialized datetime values
         query = AuditQuery(operation="update_task", limit=10, offset=0)
-        result = audit_log_repository.get_logs(query)
-        assert result.total_count >= 1
+        logs = audit_log_repository.get_logs(query)
+        assert len(logs) >= 1
 
         # Check that new_values contains ISO-formatted strings, not datetime objects
-        update_log = result.logs[0]
+        update_log = logs[0]
         if update_log.new_values:
             for key, value in update_log.new_values.items():
                 if "planned" in key:
@@ -447,5 +447,5 @@ class TestTasksRouter:
 
         # Verify audit log was written successfully
         query = AuditQuery(operation="update_task", limit=10, offset=0)
-        result = audit_log_repository.get_logs(query)
-        assert result.total_count >= 1
+        logs = audit_log_repository.get_logs(query)
+        assert len(logs) >= 1


### PR DESCRIPTION
Closes #955.

## Problem

`domain/repositories/audit_log_repository.py` imported `AuditEvent` / `AuditQuery` / `AuditLogOutput` / `AuditLogListOutput` from `taskdog_core.application.dto`, reversing the Clean Architecture dependency direction. It was the only such violation in `domain/`.

## Fix (option chosen: AuditLog entity)

Introduce an `AuditLog` domain entity and an `AuditQuery` value object in `domain/entities/audit_log.py`, and have the repository interface speak in domain terms:

- `save(AuditLog)`, `get_logs(query) -> list[AuditLog]`, `get_by_id -> AuditLog | None`, `count_logs -> int`
- `AuditEvent` (write side, no id) and `AuditLogOutput` (read side, with id) were near-duplicates — they **collapse into one `AuditLog` entity** with `id: int | None` (None until persisted)
- the SQLite repository maps rows → `AuditLog` entities
- `AuditLogController` maps entities → output DTOs via `AuditLogOutput.from_entity`; pagination is assembled in the controller (`get_logs` + `count_logs`)
- `AuditLogOutput` / `AuditLogListOutput` stay in `application/dto` — **server, client, and UI keep consuming them unchanged**

Audit records are intentionally not validated in `__post_init__`: failing to construct one would drop an entry from the audit trail.

## Result

- `domain` no longer imports `application` (verified by grep) — the violation is gone.
- Write path (`log_operation`) is unchanged, so the server routers needed no changes beyond one import move (`AuditQuery` now from `domain`).
- All suites pass: core 1094, server 307, ui 1080, client 232, mcp 88. `make check` (ruff, mypy, codespell, vulture) clean.

## Trade-off note

`get_logs` + `count_logs` is now two queries instead of one combined pass. Negligible for the individual-scale audit-log view, and it keeps the repository returning pure domain types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)