### PR TITLE
fix(core): make remove_task atomic — delete notes and task in single transaction

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/remove_task.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/remove_task.py
@@ -40,10 +40,8 @@ class RemoveTaskUseCase(UseCase[SingleTaskInput, TaskOperationOutput]):
         # Capture task info before deletion
         result = TaskOperationOutput.from_task(task)
 
-        # Delete notes first (idempotent - won't fail if notes don't exist)
-        self.notes_repository.delete_notes(input_dto.task_id)
-
-        # Then delete the task
+        # Delete the task and its associated notes atomically
+        # (SqliteTaskRepository handles both in a single transaction)
         self.repository.delete(input_dto.task_id)
 
         return result

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_task_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_task_repository.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import delete as sa_delete, func, select
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import func, select
 
 from taskdog_core.domain.entities.task import Task, TaskStatus
 from taskdog_core.domain.exceptions.tag_exceptions import TagNotFoundException

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_task_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_task_repository.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import func, select
+from sqlalchemy import delete as sa_delete, func, select
 
 from taskdog_core.domain.entities.task import Task, TaskStatus
 from taskdog_core.domain.exceptions.tag_exceptions import TagNotFoundException
@@ -22,6 +22,7 @@ from taskdog_core.infrastructure.persistence.database.base_repository import (
 )
 from taskdog_core.infrastructure.persistence.database.models import (
     DailyAllocationModel,
+    NoteModel,
     TagModel,
     TaskModel,
     TaskTagModel,
@@ -309,14 +310,21 @@ class SqliteTaskRepository(SqliteBaseRepository, TaskRepository):
             session.commit()
 
     def delete(self, task_id: int) -> None:
-        """Delete a task by its ID.
+        """Delete a task and its associated notes by ID.
 
         Uses TaskDeleteBuilder to handle DELETE operation.
+        Notes are deleted in the same transaction as the task to ensure
+        atomicity (both succeed or both fail together).
 
         Args:
             task_id: The ID of the task to delete
         """
         with self.Session() as session:
+            # Delete associated notes first (idempotent — no-op if none exist)
+            session.execute(
+                sa_delete(NoteModel).where(NoteModel.task_id == task_id)
+            )
+            # Then delete the task (CASCADE handles related records like task_tags)
             delete_builder = TaskDeleteBuilder(session)
             delete_builder.delete_task(task_id)
             session.commit()

--- a/packages/taskdog-core/tests/application/use_cases/test_remove_task_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_remove_task_use_case.py
@@ -31,8 +31,8 @@ class TestRemoveTaskUseCase:
         # Verify task removed
         assert self.repository.get_by_id(task.id) is None
 
-        # Verify notes deletion was called
-        self.notes_repository.delete_notes.assert_called_once_with(task.id)
+        # Verify notes deletion was not called separately (handled by repository)
+        self.notes_repository.delete_notes.assert_not_called()
 
     def test_remove_nonexistent_task(self):
         """Test removing a task that doesn't exist."""

--- a/packages/taskdog-core/tests/controllers/test_task_crud_controller.py
+++ b/packages/taskdog-core/tests/controllers/test_task_crud_controller.py
@@ -119,8 +119,8 @@ class TestTaskCrudController:
         deleted_task = self.repository.get_by_id(task.id)
         assert deleted_task is None
 
-        # Assert - notes deletion should be called
-        self.notes_repository.delete_notes.assert_called_once_with(task.id)
+        # Assert - notes deletion should be handled by repository, not called separately
+        self.notes_repository.delete_notes.assert_not_called()
 
     def test_controller_inherits_from_base_controller(self):
         """Test that controller has repository and config from base class."""


### PR DESCRIPTION
## Summary

`RemoveTaskUseCase` was deleting notes and the task in two separate transactions: `notes_repository.delete_notes()` commits, then `repository.delete()` commits independently. If the second step fails (lock timeout, crash) the notes are already gone while the task remains — an inconsistent state.

Closes #969

## Changes

1. **SqliteTaskRepository.delete()** — now also deletes associated notes in the same session before deleting the task, so both operations commit (or roll back) together
2. **RemoveTaskUseCase** — removed the separate `notes_repository.delete_notes()` call since the repository handles cleanup atomically

## Testing

All 1094 core tests pass. New behavior verified: the `delete_notes` method is no longer called from the use case (verified by mock assertions), and task removal still succeeds.