### PR TITLE
feat(ui): TUI archive toggle + gantt time-window panning

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -27,6 +27,7 @@ from taskdog.tui.constants.ui_settings import (
 from taskdog.tui.context import TUIContext
 from taskdog.tui.events import FilterChanged, GanttResizeRequested, TasksRefreshed
 from taskdog.tui.palette.providers import (
+    ArchiveCommandProvider,
     AuditCommandProvider,
     ExportCommandProvider,
     ExportFormatProvider,
@@ -190,6 +191,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
 
     # Register custom command providers
     COMMANDS = App.COMMANDS | {
+        ArchiveCommandProvider,
         AuditCommandProvider,
         SortCommandProvider,
         OptimizeCommandProvider,
@@ -479,6 +481,17 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
     def action_command_palette(self) -> None:
         """Show the command palette."""
         self.push_screen(CommandPalette())
+
+    def toggle_archive(self) -> None:
+        """Toggle inclusion of archived tasks in the task list.
+
+        Called from Command Palette via ArchiveCommandProvider.
+        """
+        self.state.show_archived = not self.state.show_archived
+        if self.task_ui_manager:
+            self.task_ui_manager.load_tasks(keep_scroll_position=True)
+        status = "shown" if self.state.show_archived else "hidden"
+        self.notify(f"Archived tasks {status}")
 
     def show_audit_logs(self) -> None:
         """Toggle the audit log screen.

--- a/packages/taskdog-ui/src/taskdog/tui/events.py
+++ b/packages/taskdog-ui/src/taskdog/tui/events.py
@@ -101,6 +101,25 @@ class GanttResizeRequested(Message):
         self.end_date = end_date
 
 
+class GanttPanRequested(Message):
+    """Event sent when the user pans the gantt window through time.
+
+    The gantt window has a fixed width; panning shifts its anchor backward
+    (into the past) or forward without changing the width, keeping the rendered
+    column count — and thus cost — constant regardless of history size.
+
+    Attributes:
+        weeks: Number of weeks to shift (negative = past, positive = future).
+            Ignored when reset is True.
+        reset: When True, snap the window back to the current week (today).
+    """
+
+    def __init__(self, weeks: int = 0, reset: bool = False) -> None:
+        super().__init__()
+        self.weeks = weeks
+        self.reset = reset
+
+
 class FilterChanged(Message):
     """Event sent when the search filter state changes.
 

--- a/packages/taskdog-ui/src/taskdog/tui/palette/providers/__init__.py
+++ b/packages/taskdog-ui/src/taskdog/tui/palette/providers/__init__.py
@@ -1,5 +1,6 @@
 """Command providers for Taskdog TUI Command Palette."""
 
+from taskdog.tui.palette.providers.archive_provider import ArchiveCommandProvider
 from taskdog.tui.palette.providers.audit_provider import AuditCommandProvider
 from taskdog.tui.palette.providers.base import BaseListProvider
 from taskdog.tui.palette.providers.export_providers import (
@@ -16,6 +17,7 @@ from taskdog.tui.palette.providers.sort_providers import (
 
 __all__ = [
     "EXPORT_FORMATS",
+    "ArchiveCommandProvider",
     "AuditCommandProvider",
     "BaseListProvider",
     "ExportCommandProvider",

--- a/packages/taskdog-ui/src/taskdog/tui/palette/providers/archive_provider.py
+++ b/packages/taskdog-ui/src/taskdog/tui/palette/providers/archive_provider.py
@@ -1,0 +1,13 @@
+"""Command provider for toggling archived task visibility."""
+
+from __future__ import annotations
+
+from taskdog.tui.palette.providers.base import SimpleSingleCommandProvider
+
+
+class ArchiveCommandProvider(SimpleSingleCommandProvider):
+    """Command provider for toggling archived tasks in the task list."""
+
+    COMMAND_NAME = "Toggle Archive"
+    COMMAND_HELP = "Show or hide archived tasks in the task list"
+    COMMAND_CALLBACK_NAME = "toggle_archive"

--- a/packages/taskdog-ui/src/taskdog/tui/services/task_ui_manager.py
+++ b/packages/taskdog-ui/src/taskdog/tui/services/task_ui_manager.py
@@ -80,6 +80,10 @@ class TaskUIManager:
     def _calculate_gantt_date_range(self) -> tuple[date, date]:
         """Calculate the date range for Gantt chart display.
 
+        The window has a fixed width; the gantt widget's pan offset shifts it
+        through time, so archived/past tasks are viewed by panning rather than
+        unbounded expansion.
+
         Returns:
             Tuple of (start_date, end_date) for Gantt chart
         """
@@ -103,7 +107,7 @@ class TaskUIManager:
             date_range = self._calculate_gantt_date_range()
 
             return self.task_data_loader.load_tasks(
-                include_archived=False,  # Non-archived by default
+                include_archived=self.state.show_archived,
                 sort_by=self.state.sort_by,
                 reverse=self.state.sort_reverse,
                 date_range=date_range,
@@ -165,7 +169,6 @@ class TaskUIManager:
             task_ids = [t.id for t in task_data.all_tasks]
             main_screen.gantt_widget.update_gantt(
                 task_ids=task_ids,
-                include_archived=False,
                 keep_scroll_position=keep_scroll_position,
             )
 
@@ -202,16 +205,14 @@ class TaskUIManager:
         Returns:
             GanttViewModel or None if no data
         """
-        # Get current filter/sort state from gantt widget if available
-        all_tasks = False  # Default to non-archived
+        # Get current sort state from gantt widget if available
         sort_by = self.state.sort_by
         main_screen = self._get_main_screen()
         if main_screen and main_screen.gantt_widget:
-            all_tasks = main_screen.gantt_widget.get_filter_include_archived()
             sort_by = main_screen.gantt_widget.get_sort_by()
 
         task_list_output = self.task_data_loader.api_client.list_tasks(
-            include_archived=all_tasks,
+            include_archived=self.state.show_archived,
             sort_by=sort_by,
             reverse=self.state.sort_reverse,
             include_gantt=True,
@@ -242,4 +243,7 @@ class TaskUIManager:
 
         main_screen = self._get_main_screen()
         if main_screen and main_screen.gantt_widget:
-            main_screen.gantt_widget.update_view_model_and_render()
+            # Preserve cursor/scroll on zoom & pan (range change = full rebuild)
+            main_screen.gantt_widget.update_view_model_and_render(
+                keep_scroll_position=True
+            )

--- a/packages/taskdog-ui/src/taskdog/tui/state/tui_state.py
+++ b/packages/taskdog-ui/src/taskdog/tui/state/tui_state.py
@@ -53,6 +53,9 @@ class TUIState:
     gantt_filter_enabled: bool = False
     """Whether to apply search filter to Gantt chart."""
 
+    show_archived: bool = False
+    """Whether to include archived tasks in the task list."""
+
     # === Data Caches ===
     tasks_cache: list[TaskRowDto] = field(default_factory=list)
     """Cache of all tasks (DTO format) from last API fetch."""

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_data_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_data_table.py
@@ -18,6 +18,7 @@ from taskdog.constants.gantt import CHARS_PER_DAY, GANTT_WORKLOAD_LABEL
 from taskdog.constants.task_table import ESTIMATED_COLUMN_WIDTH, TASK_NAME_COLUMN_WIDTH
 from taskdog.formatters.text_formatter import format_finished_name
 from taskdog.renderers.gantt_cell_formatter import DateMetadata, GanttCellFormatter
+from taskdog.tui.events import GanttPanRequested
 from taskdog.view_models.gantt_view_model import GanttViewModel, TaskGanttRowViewModel
 from taskdog_core.shared.constants import (
     WORKLOAD_COMFORTABLE_HOURS,
@@ -52,6 +53,9 @@ class GanttDataTable(DataTable):  # type: ignore[type-arg]
         # w/b -> jump by one week (7 columns)
         Binding("w", "cursor_forward_week", "Week Forward", show=False),
         Binding("b", "cursor_backward_week", "Week Backward", show=False),
+        # H/L -> pan the whole window one week into the past / future
+        Binding("H", "pan_backward", "Pan Past", show=False),
+        Binding("L", "pan_forward", "Pan Future", show=False),
         # 0/$ -> jump to leftmost/rightmost column
         Binding("0", "cursor_home_horizontal", "Line Start", show=False),
         Binding("$", "cursor_end_horizontal", "Line End", show=False),
@@ -610,15 +614,28 @@ class GanttDataTable(DataTable):  # type: ignore[type-arg]
             self.move_cursor(column=len(self.columns) - 1)
 
     def action_jump_to_today(self) -> None:
-        """Jump cursor to today's date column (T key)."""
+        """Jump back to today (T key).
+
+        If today is in the visible window, move the cursor to it; otherwise the
+        window has been panned away, so reset the pan back to the current week.
+        """
         today = date.today()
         try:
             date_index = self._date_columns.index(today)
         except ValueError:
-            self.app.notify("Today is not in the visible range", severity="warning")
+            # Today is outside the panned window: snap the window back.
+            self.post_message(GanttPanRequested(reset=True))
             return
         # Fixed columns: ID, Name, Est (3 columns before date columns)
         self.move_cursor(column=date_index + GANTT_FIXED_COLUMN_COUNT)
+
+    def action_pan_backward(self) -> None:
+        """Pan the gantt window one week into the past (H key)."""
+        self.post_message(GanttPanRequested(weeks=-1))
+
+    def action_pan_forward(self) -> None:
+        """Pan the gantt window one week into the future (L key)."""
+        self.post_message(GanttPanRequested(weeks=1))
 
     def get_selected_task_id(self) -> int | None:
         """Get the task ID at the current cursor row.

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
@@ -21,6 +21,7 @@ from taskdog.constants.gantt import (
     MIN_TIMELINE_WIDTH,
 )
 from taskdog.renderers.gantt_cell_formatter import LEGEND_SPEC
+from taskdog.tui.events import GanttPanRequested
 from taskdog.tui.widgets.base_widget import TUIWidget
 from taskdog.tui.widgets.gantt_data_table import GanttDataTable
 from taskdog.view_models.gantt_view_model import GanttViewModel
@@ -47,9 +48,7 @@ class GanttWidget(Vertical, TUIWidget):
         super().__init__(*args, **kwargs)
         self.can_focus = False
         self._task_ids: list[int] = []
-        self._filter_include_archived: bool = (
-            False  # Include archived tasks flag for recalculation
-        )
+        self._pan_offset_days: int = 0  # Window shift through time (days from today)
         self._keep_scroll_position: bool = False  # Preserve scroll position on refresh
         self._gantt_table: GanttDataTable | None = None
         self._title_widget: Static | None = None
@@ -77,7 +76,6 @@ class GanttWidget(Vertical, TUIWidget):
     def update_gantt(
         self,
         task_ids: list[int],
-        include_archived: bool = False,
         keep_scroll_position: bool = False,
     ) -> None:
         """Update the gantt chart with new data from TUIState.gantt_cache.
@@ -87,12 +85,10 @@ class GanttWidget(Vertical, TUIWidget):
 
         Args:
             task_ids: List of task IDs (used to detect if data exists on resize)
-            include_archived: Include archived tasks (default: False)
             keep_scroll_position: Whether to preserve scroll position during refresh.
                                  Set to True for periodic updates to avoid scroll stuttering.
         """
         self._task_ids = task_ids
-        self._filter_include_archived = include_archived
         self._keep_scroll_position = keep_scroll_position
         self._render_gantt()
 
@@ -263,7 +259,11 @@ class GanttWidget(Vertical, TUIWidget):
             Tuple of (start_date, end_date)
         """
         today = date.today()
-        start_date = today - timedelta(days=today.weekday())
+        start_date = (
+            today
+            - timedelta(days=today.weekday())
+            + timedelta(days=self._pan_offset_days)
+        )
         end_date = start_date + timedelta(days=display_days - 1)
         return start_date, end_date
 
@@ -309,6 +309,27 @@ class GanttWidget(Vertical, TUIWidget):
 
         self.post_message(GanttResizeRequested(display_days, start_date, end_date))
 
+    def on_gantt_pan_requested(self, event: GanttPanRequested) -> None:
+        """Shift the gantt window through time and refetch the new range.
+
+        Keeps the window width constant (so render cost stays flat) and moves
+        its anchor; the existing resize path re-fetches gantt data for the new
+        date range.
+
+        Args:
+            event: Pan request carrying a week delta or a reset flag.
+        """
+        event.stop()
+        if event.reset:
+            if self._pan_offset_days == 0:
+                return
+            self._pan_offset_days = 0
+        else:
+            self._pan_offset_days += event.weeks * DAYS_PER_WEEK
+
+        display_days = self._calculate_display_days()
+        self._recalculate_gantt_for_width(display_days)
+
     def render_filtered_gantt(self) -> None:
         """Render gantt from TUIState.filtered_gantt.
 
@@ -331,14 +352,6 @@ class GanttWidget(Vertical, TUIWidget):
         if self._gantt_table:
             return self._gantt_table.get_selected_task_id()
         return None
-
-    def get_filter_include_archived(self) -> bool:
-        """Get current archive filter setting.
-
-        Returns:
-            Whether to include archived tasks
-        """
-        return self._filter_include_archived
 
     def get_sort_by(self) -> str:
         """Get current sort order.

--- a/packages/taskdog-ui/tests/tui/services/test_task_ui_manager.py
+++ b/packages/taskdog-ui/tests/tui/services/test_task_ui_manager.py
@@ -343,7 +343,6 @@ class TestRecalculateGantt:
         self.main_screen = MagicMock()
         self.main_screen.gantt_widget = MagicMock()
         # Setup default return values for gantt_widget methods
-        self.main_screen.gantt_widget.get_filter_include_archived.return_value = False
         self.main_screen.gantt_widget.get_sort_by.return_value = "deadline"
         self.on_error = MagicMock()
 
@@ -377,13 +376,13 @@ class TestRecalculateGantt:
         # Execute
         self.manager.recalculate_gantt(start_date, end_date)
 
-        # Verify API was called with parameters from gantt_widget
+        # Verify API was called with parameters from state/gantt_widget
         self.task_data_loader.api_client.list_tasks.assert_called_once_with(
-            include_archived=False,  # from gantt_widget.get_filter_include_archived()
+            include_archived=False,  # from state.show_archived (default)
             sort_by="deadline",  # from gantt_widget.get_sort_by()
             reverse=self.state.sort_reverse,
             include_gantt=True,
-            gantt_start_date=start_date,
+            gantt_start_date=start_date,  # honored when archived not shown
             gantt_end_date=end_date,
         )
 
@@ -394,10 +393,15 @@ class TestRecalculateGantt:
         assert self.state.gantt_cache == gantt
         self.main_screen.gantt_widget.update_view_model_and_render.assert_called_once()
 
-    def test_recalculate_gantt_respects_gantt_widget_filter_state(self):
-        """Test recalculate_gantt uses filter/sort state from gantt_widget."""
-        # Setup - gantt_widget has "all tasks" filter enabled
-        self.main_screen.gantt_widget.get_filter_include_archived.return_value = True
+    def test_recalculate_gantt_respects_show_archived_state(self):
+        """Test recalculate_gantt respects state.show_archived on zoom/pan.
+
+        When archived tasks are shown they must be included for the requested
+        (fixed-width) window; the requested start/end are honored verbatim
+        (the window is moved by panning, not auto-expanded).
+        """
+        # Setup - archived tasks are shown
+        self.state.show_archived = True
         self.main_screen.gantt_widget.get_sort_by.return_value = "priority"
 
         gantt = create_gantt_viewmodel()
@@ -413,14 +417,12 @@ class TestRecalculateGantt:
         # Execute
         self.manager.recalculate_gantt(date(2024, 1, 1), date(2024, 1, 31))
 
-        # Verify API was called with filter state from gantt_widget
+        # Verify API was called with archived included and the exact window
         call_kwargs = self.task_data_loader.api_client.list_tasks.call_args[1]
-        assert (
-            call_kwargs["include_archived"] is True
-        )  # Respects gantt_widget.get_filter_include_archived()
-        assert (
-            call_kwargs["sort_by"] == "priority"
-        )  # Respects gantt_widget.get_sort_by()
+        assert call_kwargs["include_archived"] is True  # Respects state.show_archived
+        assert call_kwargs["gantt_start_date"] == date(2024, 1, 1)  # Honored verbatim
+        assert call_kwargs["gantt_end_date"] == date(2024, 1, 31)
+        assert call_kwargs["sort_by"] == "priority"  # Respects gantt_widget sort
 
     def test_recalculate_gantt_handles_connection_error(self):
         """Test recalculate_gantt calls error callback on failure."""
@@ -503,7 +505,6 @@ class TestErrorHandling:
             date.today(),
             date.today() + timedelta(days=7),
         )
-        self.main_screen.gantt_widget.get_filter_include_archived.return_value = False
         self.main_screen.gantt_widget.get_sort_by.return_value = "deadline"
         self.on_error = MagicMock()
 

--- a/packages/taskdog-ui/tests/tui/widgets/test_gantt_data_table_pan.py
+++ b/packages/taskdog-ui/tests/tui/widgets/test_gantt_data_table_pan.py
@@ -1,0 +1,29 @@
+"""Tests for GanttDataTable pan key bindings."""
+
+from textual.binding import Binding
+
+from taskdog.tui.widgets.gantt_data_table import GanttDataTable
+
+
+def _bindings_by_key() -> dict[str, Binding]:
+    return {b.key: b for b in GanttDataTable.BINDINGS if isinstance(b, Binding)}
+
+
+class TestPanBindings:
+    """H/L pan the window; lowercase h/l stay cursor movement."""
+
+    def test_capital_h_pans_backward(self) -> None:
+        assert _bindings_by_key()["H"].action == "pan_backward"
+
+    def test_capital_l_pans_forward(self) -> None:
+        assert _bindings_by_key()["L"].action == "pan_forward"
+
+    def test_lowercase_h_l_remain_cursor_movement(self) -> None:
+        keys = _bindings_by_key()
+        assert keys["h"].action == "cursor_left"
+        assert keys["l"].action == "cursor_right"
+
+    def test_pan_actions_exist(self) -> None:
+        assert callable(GanttDataTable.action_pan_backward)
+        assert callable(GanttDataTable.action_pan_forward)
+        assert callable(GanttDataTable.action_jump_to_today)

--- a/packages/taskdog-ui/tests/tui/widgets/test_gantt_widget_pan.py
+++ b/packages/taskdog-ui/tests/tui/widgets/test_gantt_widget_pan.py
@@ -1,0 +1,66 @@
+"""Tests for GanttWidget time-window panning."""
+
+from datetime import date, timedelta
+from unittest.mock import MagicMock
+
+from taskdog.tui.events import GanttPanRequested
+from taskdog.tui.widgets.gantt_widget import GanttWidget
+from taskdog_core.shared.constants.time import DAYS_PER_WEEK
+
+
+def _this_monday() -> date:
+    today = date.today()
+    return today - timedelta(days=today.weekday())
+
+
+class TestPanOffsetMath:
+    """The window start shifts by the pan offset while width stays fixed."""
+
+    def test_zero_offset_starts_this_monday(self) -> None:
+        widget = GanttWidget()
+        start, end = widget._calculate_date_range_for_display(7)
+        assert start == _this_monday()
+        assert (end - start).days + 1 == 7
+
+    def test_negative_offset_shifts_into_past(self) -> None:
+        widget = GanttWidget()
+        widget._pan_offset_days = -2 * DAYS_PER_WEEK
+        start, end = widget._calculate_date_range_for_display(7)
+        assert start == _this_monday() - timedelta(days=14)
+        assert (end - start).days + 1 == 7  # width unchanged
+
+
+class TestPanHandler:
+    """on_gantt_pan_requested updates the offset and triggers a refetch."""
+
+    def _widget(self) -> GanttWidget:
+        widget = GanttWidget()
+        widget._calculate_display_days = MagicMock(return_value=7)  # type: ignore[method-assign]
+        widget._recalculate_gantt_for_width = MagicMock()  # type: ignore[method-assign]
+        return widget
+
+    def test_pan_backward_accumulates(self) -> None:
+        widget = self._widget()
+        widget.on_gantt_pan_requested(GanttPanRequested(weeks=-1))
+        widget.on_gantt_pan_requested(GanttPanRequested(weeks=-1))
+        assert widget._pan_offset_days == -2 * DAYS_PER_WEEK
+        assert widget._recalculate_gantt_for_width.call_count == 2
+
+    def test_pan_forward_then_back_nets_out(self) -> None:
+        widget = self._widget()
+        widget.on_gantt_pan_requested(GanttPanRequested(weeks=3))
+        widget.on_gantt_pan_requested(GanttPanRequested(weeks=-3))
+        assert widget._pan_offset_days == 0
+
+    def test_reset_snaps_to_today(self) -> None:
+        widget = self._widget()
+        widget._pan_offset_days = -5 * DAYS_PER_WEEK
+        widget.on_gantt_pan_requested(GanttPanRequested(reset=True))
+        assert widget._pan_offset_days == 0
+        widget._recalculate_gantt_for_width.assert_called_once()
+
+    def test_reset_when_already_today_is_noop(self) -> None:
+        widget = self._widget()
+        widget.on_gantt_pan_requested(GanttPanRequested(reset=True))
+        assert widget._pan_offset_days == 0
+        widget._recalculate_gantt_for_width.assert_not_called()

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -3,6 +3,7 @@ estimation  # unused variable (packages/taskdog-server/src/taskdog_server/api/mo
 trends  # unused variable (packages/taskdog-server/src/taskdog_server/api/models/responses.py:270)
 _.format_commands  # Click override called via duck-typing (packages/taskdog-ui/src/taskdog/cli_main.py:138)
 _.show_audit_logs  # unused method (packages/taskdog-ui/src/taskdog/tui/app.py:478)
+_.toggle_archive  # palette callback via getattr (packages/taskdog-ui/src/taskdog/tui/app.py)
 SelectionProvider  # unused import (packages/taskdog-ui/src/taskdog/tui/context.py:12)
 SelectionProvider  # unused class (packages/taskdog-ui/src/taskdog/tui/selection.py:9)
 last_update  # unused variable (packages/taskdog-ui/src/taskdog/tui/state/connection_status.py:19)


### PR DESCRIPTION
## What

Let archived tasks be viewed from the TUI.

- **Archive toggle**: adds a **Toggle Archive** entry to the command palette (`Ctrl+P`) that shows/hides archived tasks in the task list (`state.show_archived`, applied at fetch time).
- **Gantt time-window panning**: to view past/archived work on the gantt without unbounded growth, the live gantt now uses a **fixed-width window that pans through time**.
  - `H` = pan one week into the past / `L` = one week into the future / `T` = snap back to the current week (or jump the cursor to today when it is in view).
  - The window width is constant, so the rendered column count — and thus render cost — stays flat regardless of how much history accumulates. This sidesteps Textual `DataTable`'s lack of column virtualization ([discussion #5953](https://github.com/Textualize/textual/discussions/5953)).
  - Cursor/scroll position is preserved across pan & zoom rebuilds.
- Gantt archived inclusion is unified on `state.show_archived` (the dead gantt-widget archive flag is removed).

## Why

Archived tasks are finished, past work. An earlier approach auto-expanded the gantt back to the earliest task date, but that **grows without bound as time passes** (more days → more columns → slower), so it was dropped. A fixed window you pan through time keeps the cost constant and scales.

## Test

- New: `test_gantt_widget_pan.py` (offset arithmetic, pan/reset handler), `test_gantt_data_table_pan.py` (H/L bindings).
- Updated: `test_task_ui_manager.py` for the fixed-window model.
- `make check` (lint / typecheck / spell / deadcode) + full UI suite (1090 tests) green.

## Not verified

The live TUI was not exercised in an automated way (no headless harness); `H`/`L`/`T` were checked manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)