### PR TITLE
refactor(ui): unify task-list reload into a single debounced funnel

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -9,6 +9,7 @@ from textual.command import CommandPalette
 
 if TYPE_CHECKING:
     from taskdog_client import TaskdogApiClient
+    from textual.timer import Timer
 
     from taskdog.infrastructure.cli_config_manager import CliConfig
 
@@ -22,6 +23,7 @@ from taskdog.tui.commands.factory import CommandFactory
 from taskdog.tui.constants.command_mapping import ACTION_TO_COMMAND_MAP
 from taskdog.tui.constants.ui_settings import (
     AUTO_REFRESH_INTERVAL_SECONDS,
+    RELOAD_DEBOUNCE_SECONDS,
     SORT_KEY_LABELS,
 )
 from taskdog.tui.context import TUIContext
@@ -270,6 +272,9 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         # TaskUIManager will be initialized in on_mount (needs MainScreen)
         self.task_ui_manager: TaskUIManager | None = None
 
+        # Debounce timer for the single reload funnel (request_reload)
+        self._reload_timer: Timer | None = None
+
         # Initialize WebSocket client for real-time updates
         self.websocket_client = websocket_client
         self.websocket_client.set_callback(self._handle_websocket_message)
@@ -451,8 +456,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         self.state.sort_reverse = not self.state.sort_reverse
 
         # Reload tasks with new sort direction
-        if self.task_ui_manager:
-            self.task_ui_manager.load_tasks(keep_scroll_position=True)
+        self.request_reload()
 
         # Show notification with current direction
         direction = "descending" if self.state.sort_reverse else "ascending"
@@ -488,8 +492,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         Called from Command Palette via ArchiveCommandProvider.
         """
         self.state.show_archived = not self.state.show_archived
-        if self.task_ui_manager:
-            self.task_ui_manager.load_tasks(keep_scroll_position=True)
+        self.request_reload()
         status = "shown" if self.state.show_archived else "hidden"
         self.notify(f"Archived tasks {status}")
 
@@ -510,9 +513,28 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         if self.main_screen and self.main_screen.task_table:
             self.main_screen.task_table.refresh_elapsed_only()
 
+    def request_reload(self) -> None:
+        """Single, debounced funnel for task-list reloads.
+
+        Every "data changed" trigger — local command events, WebSocket
+        broadcasts, batch completions — routes here. A change often fires both
+        a local event and its own WebSocket echo; debouncing collapses those
+        (and rapid batch events) into a single reload instead of several full
+        reloads.
+        """
+        if self._reload_timer is not None:
+            self._reload_timer.stop()
+        self._reload_timer = self.set_timer(RELOAD_DEBOUNCE_SECONDS, self._flush_reload)
+
+    def _flush_reload(self) -> None:
+        """Run the coalesced reload (called when the debounce window elapses)."""
+        self._reload_timer = None
+        if self.task_ui_manager:
+            self.task_ui_manager.load_tasks(keep_scroll_position=True)
+
     # Event handlers for task operations
     def _handle_task_change_event(self, event: Any) -> None:
-        """Handle any task change event by reloading tasks.
+        """Handle any task change event by requesting a reload.
 
         This generic handler is used for all task modification events
         (created, updated, deleted, refreshed) as they all require
@@ -521,8 +543,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         Args:
             event: Task change event (TaskCreated/Updated/Deleted/Refreshed)
         """
-        if self.task_ui_manager:
-            self.task_ui_manager.load_tasks(keep_scroll_position=True)
+        self.request_reload()
 
     # Alias all task change event handlers to the generic handler
     on_task_created = _handle_task_change_event

--- a/packages/taskdog-ui/src/taskdog/tui/constants/ui_settings.py
+++ b/packages/taskdog-ui/src/taskdog/tui/constants/ui_settings.py
@@ -12,6 +12,7 @@ __all__ = [
     "AUTO_REFRESH_INTERVAL_SECONDS",
     "MAX_HOURS_PER_DAY",
     "OPTIMIZATION_FAILURE_DETAIL_THRESHOLD",
+    "RELOAD_DEBOUNCE_SECONDS",
     "SORT_KEY_LABELS",
     "TAGS_MAX_DISPLAY_LENGTH",
 ]
@@ -19,6 +20,13 @@ __all__ = [
 # Auto-refresh settings
 AUTO_REFRESH_INTERVAL_SECONDS = 1.0
 """Interval in seconds for auto-refreshing elapsed time display."""
+
+RELOAD_DEBOUNCE_SECONDS = 0.1
+"""Debounce window for coalescing rapid task-list reload triggers.
+
+A single change can fire both a local refresh and its WebSocket echo (and
+batch operations fire many events); collapsing them within this window into
+one reload avoids redundant full reloads."""
 
 # Time validation constants
 MAX_HOURS_PER_DAY = 24

--- a/packages/taskdog-ui/src/taskdog/tui/services/event_handler_registry.py
+++ b/packages/taskdog-ui/src/taskdog/tui/services/event_handler_registry.py
@@ -152,11 +152,8 @@ class EventHandlerRegistry:
             self.app.notify(msg, severity="information")
 
     def _reload_tasks(self) -> None:
-        """Reload tasks via TaskUIManager."""
-        if self.app.task_ui_manager:
-            self.app.call_later(
-                self.app.task_ui_manager.load_tasks, keep_scroll_position=True
-            )
+        """Reload tasks via the app's single debounced reload funnel."""
+        self.app.request_reload()
 
     def _get_display_source(self, message: dict[str, Any]) -> str | None:
         """Get display source (user name or client ID) if different from this client.

--- a/packages/taskdog-ui/tests/tui/services/test_event_handler_registry.py
+++ b/packages/taskdog-ui/tests/tui/services/test_event_handler_registry.py
@@ -15,7 +15,6 @@ class TestEventHandlerRegistry:
         self.mock_app.api_client = MagicMock()
         self.mock_app.api_client.client_id = "test-client-id"
         self.mock_app.task_ui_manager = MagicMock()
-        self.mock_app.call_later = MagicMock()
         self.mock_app.notify = MagicMock()
         # Set main_screen to None by default to avoid audit panel refresh
         self.mock_app.main_screen = None
@@ -59,7 +58,7 @@ class TestEventHandlerRegistry:
             "task_name": "New Task",
         }
         self.registry.dispatch(message)
-        self.mock_app.call_later.assert_called_once()
+        self.mock_app.request_reload.assert_called_once()
         self.mock_app.notify.assert_called_once()
 
     def test_dispatch_task_updated_shows_fields(self) -> None:
@@ -71,7 +70,7 @@ class TestEventHandlerRegistry:
             "updated_fields": ["priority", "deadline"],
         }
         self.registry.dispatch(message)
-        self.mock_app.call_later.assert_called_once()
+        self.mock_app.request_reload.assert_called_once()
         self.mock_app.notify.assert_called_once()
 
     def test_dispatch_task_deleted_shows_warning(self) -> None:
@@ -82,7 +81,7 @@ class TestEventHandlerRegistry:
             "task_name": "Deleted Task",
         }
         self.registry.dispatch(message)
-        self.mock_app.call_later.assert_called_once()
+        self.mock_app.request_reload.assert_called_once()
         self.mock_app.notify.assert_called_once()
         # Verify warning severity
         call_args = self.mock_app.notify.call_args
@@ -98,7 +97,7 @@ class TestEventHandlerRegistry:
             "new_status": "IN_PROGRESS",
         }
         self.registry.dispatch(message)
-        self.mock_app.call_later.assert_called_once()
+        self.mock_app.request_reload.assert_called_once()
         self.mock_app.notify.assert_called_once()
 
     def test_dispatch_schedule_optimized(self) -> None:
@@ -110,7 +109,7 @@ class TestEventHandlerRegistry:
             "algorithm": "greedy",
         }
         self.registry.dispatch(message)
-        self.mock_app.call_later.assert_called_once()
+        self.mock_app.request_reload.assert_called_once()
         self.mock_app.notify.assert_called_once()
 
     def test_dispatch_unknown_event_type_ignored(self) -> None:
@@ -256,7 +255,7 @@ class TestEventHandlerRegistry:
             "task_ids": [1, 2, 3],
         }
         self.registry.dispatch(message)
-        self.mock_app.call_later.assert_called_once()
+        self.mock_app.request_reload.assert_called_once()
         self.mock_app.notify.assert_called_once()
         call_args = self.mock_app.notify.call_args
         assert "3/3" in call_args[0][0]
@@ -272,7 +271,7 @@ class TestEventHandlerRegistry:
             "task_ids": [1, 2, 3],
         }
         self.registry.dispatch(message)
-        self.mock_app.call_later.assert_called_once()
+        self.mock_app.request_reload.assert_called_once()
         self.mock_app.notify.assert_called_once()
         call_args = self.mock_app.notify.call_args
         assert "2/3" in call_args[0][0]
@@ -287,18 +286,15 @@ class TestEventHandlerRegistry:
         assert "0/0" in call_args[0][0]
         assert "unknown" in call_args[0][0]
 
-    def test_reload_tasks_called_with_keep_scroll_position(self) -> None:
-        """Test that reload_tasks is called with keep_scroll_position=True."""
+    def test_reload_routes_through_request_reload_funnel(self) -> None:
+        """Reloads are delegated to the app's single debounced reload funnel."""
         message = {
             "type": "task_created",
             "task_id": 1,
             "task_name": "Task",
         }
         self.registry.dispatch(message)
-        # Verify call_later was called with load_tasks and keep_scroll_position=True
-        call_args = self.mock_app.call_later.call_args_list[0]
-        assert call_args[0][0] == self.mock_app.task_ui_manager.load_tasks
-        assert call_args[1]["keep_scroll_position"] is True
+        self.mock_app.request_reload.assert_called_once_with()
 
 
 class TestWebSocketHandler:
@@ -311,7 +307,6 @@ class TestWebSocketHandler:
         self.mock_app.api_client = MagicMock()
         self.mock_app.api_client.client_id = "test-client-id"
         self.mock_app.task_ui_manager = MagicMock()
-        self.mock_app.call_later = MagicMock()
         self.mock_app.notify = MagicMock()
 
     def test_handle_message_delegates_to_registry(self) -> None:


### PR DESCRIPTION
## What

Consolidate all task-list reload triggers into one debounced funnel, `TaskdogTUI.request_reload()`.

## Why

Reload triggers were scattered across **three** entry points:
- `app._handle_task_change_event` (local `TaskCreated`/`TaskUpdated`/`TasksRefreshed`)
- `event_handler_registry._reload_tasks` (WebSocket broadcasts)
- command base `reload_tasks()` → `TasksRefreshed`

And a single change often fired **both** a local event and its own WebSocket echo → **two full reloads for one operation** (add / edit / optimize / batch). Status changes, by contrast, went through WebSocket only (one reload). Inconsistent and wasteful.

## Change

- New `request_reload()` on the app: the single funnel. Debounced (`RELOAD_DEBOUNCE_SECONDS = 0.1`) so a local event + its WebSocket echo, and rapid batch events, collapse into **one** reload.
- `_handle_task_change_event`, `_reload_tasks`, `toggle_archive`, `toggle_sort_reverse` all route through it.
- Sets up the next step: wrapping this one place in a threaded worker makes **every** reload non-blocking.

## Notes

- Local posts are kept (WebSocket-independent fallback); dedup is handled by the debounce rather than removing them, so no per-command WebSocket-coverage analysis was needed.
- The manual `refresh` command still works as the explicit, WS-independent escape hatch.

## Test

- `test_event_handler_registry.py` updated: reload now asserts delegation to `request_reload` (the single funnel).
- `make check` (lint / typecheck / spell / deadcode) + full UI suite (1090 tests) green.

## Follow-up

Threaded-worker reload (non-blocking fetch) on top of this funnel; see the gantt data-dedup work in #974.

🤖 Generated with [Claude Code](https://claude.com/claude-code)