### PR TITLE
perf(ui): run task-list reload on a thread worker (non-blocking)

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -6,12 +6,14 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from textual.app import App, InvalidThemeError
 from textual.binding import Binding
 from textual.command import CommandPalette
+from textual.worker import get_current_worker
 
 if TYPE_CHECKING:
     from taskdog_client import TaskdogApiClient
     from textual.timer import Timer
 
     from taskdog.infrastructure.cli_config_manager import CliConfig
+    from taskdog.tui.services.task_ui_manager import FetchParams
 
 from taskdog_client import WebSocketClient
 
@@ -527,10 +529,38 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         self._reload_timer = self.set_timer(RELOAD_DEBOUNCE_SECONDS, self._flush_reload)
 
     def _flush_reload(self) -> None:
-        """Run the coalesced reload (called when the debounce window elapses)."""
+        """Run the coalesced reload off the UI thread (debounce elapsed).
+
+        Fetch inputs are gathered here (UI thread), the blocking API fetch runs
+        in an exclusive thread worker, and results are applied back on the UI
+        thread — so reloads never freeze the interface. The exclusive group
+        means a newer reload supersedes an in-flight one.
+        """
         self._reload_timer = None
-        if self.task_ui_manager:
-            self.task_ui_manager.load_tasks(keep_scroll_position=True)
+        mgr = self.task_ui_manager
+        if not mgr:
+            return
+        params = mgr.gather_fetch_params()
+        self.run_worker(
+            lambda: self._reload_in_thread(mgr, params),
+            group="reload",
+            exclusive=True,
+            thread=True,
+        )
+
+    def _reload_in_thread(self, mgr: TaskUIManager, params: "FetchParams") -> None:
+        """Worker body: fetch in a thread, apply on the UI thread."""
+        worker = get_current_worker()
+        try:
+            task_data = mgr.fetch_with_params(params)
+        except (ServerConnectionError, AuthenticationError, ServerError) as e:
+            if not worker.is_cancelled:
+                self.call_from_thread(mgr.handle_api_error, e)
+            return
+        except Exception:
+            task_data = mgr.empty_task_data()
+        if not worker.is_cancelled:
+            self.call_from_thread(mgr.apply_task_data, task_data, True)
 
     # Event handlers for task operations
     def _handle_task_change_event(self, event: Any) -> None:

--- a/packages/taskdog-ui/src/taskdog/tui/services/task_ui_manager.py
+++ b/packages/taskdog-ui/src/taskdog/tui/services/task_ui_manager.py
@@ -1,6 +1,7 @@
 """Task UI Manager for orchestrating data lifecycle in TUI."""
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import date, timedelta
 from typing import TYPE_CHECKING
 
@@ -17,6 +18,21 @@ from taskdog_core.domain.exceptions.task_exceptions import (
 
 if TYPE_CHECKING:
     from taskdog.tui.screens.main_screen import MainScreen
+
+
+@dataclass(frozen=True)
+class FetchParams:
+    """Parameters for a task-list fetch, gathered on the UI thread.
+
+    Captures all UI/state-derived inputs (sort, archive filter, gantt window)
+    up front so the actual fetch can run on a worker thread without touching
+    any widget or app state.
+    """
+
+    include_archived: bool
+    sort_by: str
+    reverse: bool
+    date_range: tuple[date, date]
 
 
 class TaskUIManager:
@@ -53,10 +69,10 @@ class TaskUIManager:
         self._get_main_screen = main_screen_provider
         self._on_error = on_error
 
-    def _handle_api_error(
+    def handle_api_error(
         self, error: ServerConnectionError | AuthenticationError | ServerError
     ) -> None:
-        """Delegate API error to the error callback.
+        """Delegate API error to the error callback (UI thread only).
 
         Args:
             error: The API error to handle
@@ -65,15 +81,62 @@ class TaskUIManager:
             self._on_error(error)
 
     def load_tasks(self, keep_scroll_position: bool = False) -> None:
-        """Load tasks and update UI.
+        """Load tasks and update UI synchronously.
 
-        Performs a complete reload cycle: fetches data from API,
-        updates internal caches, and refreshes all UI components.
+        Performs a complete reload cycle on the calling thread: fetches data
+        from the API, updates internal caches, and refreshes all UI components.
+        Used for the initial load and tests; the app's debounced funnel runs
+        the same steps off the UI thread (see ``gather_fetch_params`` /
+        ``fetch_with_params`` / ``apply_task_data``).
 
         Args:
             keep_scroll_position: Whether to preserve scroll position during refresh
         """
         task_data = self._fetch_task_data()
+        self.apply_task_data(task_data, keep_scroll_position)
+
+    def gather_fetch_params(self) -> FetchParams:
+        """Collect fetch inputs from UI/state. Must run on the UI thread.
+
+        Returns:
+            FetchParams snapshot to hand to ``fetch_with_params``.
+        """
+        return FetchParams(
+            include_archived=self.state.show_archived,
+            sort_by=self.state.sort_by,
+            reverse=self.state.sort_reverse,
+            date_range=self._calculate_gantt_date_range(),
+        )
+
+    def fetch_with_params(self, params: FetchParams) -> TaskData:
+        """Fetch task data for the given params. Thread-safe; touches no UI.
+
+        Raises the underlying API exception on failure so the caller can
+        decide how to surface it (the UI-thread error callback must not run
+        here).
+
+        Args:
+            params: Snapshot from ``gather_fetch_params``.
+
+        Returns:
+            Loaded TaskData.
+        """
+        return self.task_data_loader.load_tasks(
+            include_archived=params.include_archived,
+            sort_by=params.sort_by,
+            reverse=params.reverse,
+            date_range=params.date_range,
+        )
+
+    def apply_task_data(
+        self, task_data: TaskData, keep_scroll_position: bool = False
+    ) -> None:
+        """Update caches and refresh widgets. Must run on the UI thread.
+
+        Args:
+            task_data: Data to cache and render
+            keep_scroll_position: Whether to preserve scroll position during refresh
+        """
         self._update_cache(task_data)
         self._refresh_ui(task_data, keep_scroll_position)
 
@@ -98,28 +161,22 @@ class TaskUIManager:
         return (start_date, end_date)
 
     def _fetch_task_data(self) -> TaskData:
-        """Fetch task data using TaskDataLoader.
+        """Fetch task data, handling API errors gracefully (UI thread).
 
         Returns:
-            TaskData object containing all task information
+            TaskData object containing all task information (empty on error)
         """
+        params = self.gather_fetch_params()
         try:
-            date_range = self._calculate_gantt_date_range()
-
-            return self.task_data_loader.load_tasks(
-                include_archived=self.state.show_archived,
-                sort_by=self.state.sort_by,
-                reverse=self.state.sort_reverse,
-                date_range=date_range,
-            )
+            return self.fetch_with_params(params)
         except (ServerConnectionError, AuthenticationError, ServerError) as e:
-            self._handle_api_error(e)
-            return self._create_empty_task_data()
+            self.handle_api_error(e)
+            return self.empty_task_data()
         except Exception:
-            return self._create_empty_task_data()
+            return self.empty_task_data()
 
-    def _create_empty_task_data(self) -> TaskData:
-        """Create empty TaskData to avoid crash on errors.
+    def empty_task_data(self) -> TaskData:
+        """Create empty TaskData to avoid crash on errors. Thread-safe.
 
         Returns:
             Empty TaskData object
@@ -189,7 +246,7 @@ class TaskUIManager:
             gantt_view_model = self._fetch_gantt_for_range(start_date, end_date)
             self._update_gantt_ui(gantt_view_model)
         except (ServerConnectionError, AuthenticationError, ServerError) as e:
-            self._handle_api_error(e)
+            self.handle_api_error(e)
         except Exception:
             pass
 

--- a/packages/taskdog-ui/tests/tui/services/test_task_ui_manager.py
+++ b/packages/taskdog-ui/tests/tui/services/test_task_ui_manager.py
@@ -269,6 +269,57 @@ class TestTaskUIManager:
         assert call_kwargs["sort_by"] == "priority"
         assert call_kwargs["reverse"] is True
 
+    def test_gather_fetch_params_snapshots_state_and_range(self):
+        """gather_fetch_params captures sort/archive/state and gantt window."""
+        self.state.sort_by = "priority"
+        self.state.sort_reverse = True
+        self.state.show_archived = True
+        window = (date.today(), date.today() + timedelta(days=7))
+        self.main_screen.gantt_widget.calculate_date_range.return_value = window
+
+        params = self.manager.gather_fetch_params()
+
+        assert params.include_archived is True
+        assert params.sort_by == "priority"
+        assert params.reverse is True
+        assert params.date_range == window
+
+    def test_fetch_with_params_raises_on_api_error(self):
+        """fetch_with_params propagates API errors (no UI-thread handling)."""
+        from taskdog.tui.services.task_ui_manager import FetchParams
+
+        self.task_data_loader.load_tasks.side_effect = ServerConnectionError(
+            base_url="http://localhost:8000",
+            original_error=ConnectionError("refused"),
+        )
+        params = FetchParams(
+            include_archived=False,
+            sort_by="id",
+            reverse=False,
+            date_range=(date.today(), date.today() + timedelta(days=7)),
+        )
+
+        with pytest.raises(ServerConnectionError):
+            self.manager.fetch_with_params(params)
+
+        # The error callback must NOT fire here (it is UI-thread only)
+        self.on_error.assert_not_called()
+
+    def test_apply_task_data_updates_cache_and_refreshes(self):
+        """apply_task_data writes caches and refreshes widgets."""
+        task = create_task_dto(1, "Test Task", TaskStatus.PENDING)
+        vm = create_task_viewmodel(1, "Test Task", TaskStatus.PENDING)
+        gantt = create_gantt_viewmodel()
+        task_data = create_task_data([task], [vm], gantt)
+
+        self.manager.apply_task_data(task_data, keep_scroll_position=True)
+
+        assert self.state.gantt_cache == gantt
+        assert len(self.state.viewmodels_cache) == 1
+        self.main_screen.refresh_tasks.assert_called_once_with(
+            keep_scroll_position=True
+        )
+
     def test_update_cache_updates_state(self):
         """Test _update_cache updates TUIState correctly."""
         # Setup
@@ -583,7 +634,7 @@ class TestCreateEmptyTaskData:
             main_screen_provider=lambda: None,
         )
 
-        result = manager._create_empty_task_data()
+        result = manager.empty_task_data()
 
         assert result.all_tasks == []
         assert result.table_view_models == []


### PR DESCRIPTION
## What

Move the task-list reload off the UI event loop onto an exclusive thread worker, so reloads no longer freeze the interface.

## Why

The reload funnel (`request_reload` → `_flush_reload`, added in #975) called `load_tasks()` **synchronously on the UI event loop**. The blocking `httpx` fetch + viewmodel build froze the TUI on every reload — status change, archive/sort toggle, manual refresh. This is the "待たされる" latency.

## Change

Split `TaskUIManager` into clear UI-thread / worker-thread seams:

| Method | Thread | Role |
|---|---|---|
| `gather_fetch_params()` | UI | snapshot sort / archive / gantt-window (reads widgets+state) |
| `fetch_with_params()` | any | pure blocking fetch; **raises** on error (no UI) |
| `apply_task_data()` | UI | update caches + refresh widgets |

`load_tasks()` keeps its synchronous behavior (initial load + tests) by composing these.

`_flush_reload` now:
1. gathers params on the UI thread,
2. runs `fetch_with_params` in an **exclusive** thread worker (`group="reload"`),
3. applies the result via `call_from_thread`.

The exclusive group + an `is_cancelled` check means a newer reload supersedes an in-flight one **without applying stale data**. The debounce from #975 still prevents spawning redundant workers.

## Test

- New seam tests: `gather_fetch_params` snapshot, `fetch_with_params` raises (no UI-thread error handling), `apply_task_data` updates cache + refreshes.
- Existing `load_tasks` / `_fetch_task_data` tests unchanged → behavior preserved.
- `make check` (lint / typecheck / spell / deadcode) + full UI suite (1093 tests) green.

## Not verified

The threaded worker path (`run_worker(thread=True)`, `call_from_thread`, exclusive cancellation) can't be exercised by the unit suite without a Textual app harness — needs manual TUI verification:
- toggle archive / sort / status change → UI stays responsive, list updates
- rapid repeated triggers → only the latest result applies (no stale fl: cancellation)
- server down → error notification still appears (marshaled to UI thread)

## Out of scope

`recalculate_gantt` (zoom/pan) still fetches synchronously — separate, smaller path; can get the same treatment later if it feels heavy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)