### PR TITLE
feat(ui): add file-based logging for the TUI

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/shared/xdg_utils.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/xdg_utils.py
@@ -41,6 +41,16 @@ class XDGDirectories:
         return Path.home() / ".config"
 
     @classmethod
+    def _default_state_base(cls) -> Path:
+        """Get platform default base directory for state data (e.g. logs)."""
+        if platform.system() == "Windows":
+            local_app_data = os.getenv("LOCALAPPDATA")
+            if local_app_data:
+                return Path(local_app_data)
+            return Path.home() / "AppData" / "Local"
+        return Path.home() / ".local" / "state"
+
+    @classmethod
     def get_data_home(cls, create: bool = True) -> Path:
         """Get application data directory for taskdog.
 
@@ -75,6 +85,24 @@ class XDGDirectories:
             config_dir.mkdir(parents=True, exist_ok=True)
 
         return config_dir
+
+    @classmethod
+    def get_state_home(cls, create: bool = True) -> Path:
+        """Get state directory for taskdog (logs, runtime state).
+
+        Returns:
+            Path to $XDG_STATE_HOME/taskdog, or the platform default.
+
+        Args:
+            create: Create directory if it doesn't exist (default: True)
+        """
+        base_dir = Path(os.getenv("XDG_STATE_HOME") or cls._default_state_base())
+        state_dir = Path(base_dir) / cls.APP_NAME
+
+        if create:
+            state_dir.mkdir(parents=True, exist_ok=True)
+
+        return state_dir
 
     @classmethod
     def get_config_file(cls) -> Path:

--- a/packages/taskdog-core/tests/shared/test_xdg_utils.py
+++ b/packages/taskdog-core/tests/shared/test_xdg_utils.py
@@ -34,6 +34,27 @@ class TestXDGDirectories:
             expected = Path("/tmp/test_data/taskdog")
             assert data_home == expected
 
+    def test_get_state_home_custom(self):
+        """Test get_state_home with custom XDG_STATE_HOME."""
+        with patch.dict(os.environ, {"XDG_STATE_HOME": "/tmp/test_state"}):
+            state_home = XDGDirectories.get_state_home(create=False)
+            assert state_home == Path("/tmp/test_state/taskdog")
+
+    def test_get_state_home_default(self):
+        """Test get_state_home defaults to ~/.local/state on Linux."""
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "taskdog_core.shared.xdg_utils.platform.system", return_value="Linux"
+            ),
+            patch(
+                "taskdog_core.shared.xdg_utils.Path.home",
+                return_value=Path("/home/test"),
+            ),
+        ):
+            state_home = XDGDirectories.get_state_home(create=False)
+            assert state_home == Path("/home/test/.local/state/taskdog")
+
     def test_get_config_home_default(self):
         """Test get_config_home with default XDG_CONFIG_HOME."""
         # Use patch.dict with clear=True to ensure complete environment isolation

--- a/packages/taskdog-ui/src/taskdog/cli/commands/tui.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/tui.py
@@ -10,6 +10,7 @@ from taskdog_client import WebSocketClient
 
 if TYPE_CHECKING:
     from taskdog.cli.context import CliContext
+from taskdog.infrastructure.logging_config import configure_tui_logging
 from taskdog.tui.app import TaskdogTUI
 
 
@@ -50,6 +51,9 @@ def tui_command(ctx: click.Context) -> None:
     ctx_obj: CliContext = ctx.obj
     api_client = ctx_obj.api_client
     cli_config = ctx_obj.config
+
+    # Route logs to a file; the TUI owns the terminal so stdout/stderr can't be used
+    configure_tui_logging()
 
     # Initialize WebSocket client for real-time updates
     ws_url = _get_websocket_url(api_client.base_url)

--- a/packages/taskdog-ui/src/taskdog/infrastructure/logging_config.py
+++ b/packages/taskdog-ui/src/taskdog/infrastructure/logging_config.py
@@ -1,0 +1,60 @@
+"""File-based logging configuration for the Taskdog TUI.
+
+A Textual TUI owns stdout/stderr, so logging there would corrupt the display.
+Instead, taskdog/taskdog_core log records are routed to a rotating file under
+the XDG state directory, where they can be inspected after the fact.
+"""
+
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+from taskdog_core.shared.xdg_utils import XDGDirectories
+
+LOG_FILE_NAME = "tui.log"
+_MAX_BYTES = 1_000_000
+_BACKUP_COUNT = 3
+_LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+# Logger namespaces whose records should reach the TUI log file.
+_TARGET_LOGGERS = ("taskdog", "taskdog_core")
+
+
+def configure_tui_logging(level: str | None = None) -> Path:
+    """Route taskdog log records to a rotating file under the state dir.
+
+    No stream handler is installed: the TUI controls the terminal, so anything
+    written to stdout/stderr would break the display.
+
+    Args:
+        level: Log level name (e.g. "DEBUG"). Defaults to env var
+            ``TASKDOG_LOG_LEVEL`` or "INFO".
+
+    Returns:
+        Path to the active log file.
+    """
+    log_level_str = (level or os.getenv("TASKDOG_LOG_LEVEL") or "INFO").upper()
+    log_level = getattr(logging, log_level_str, logging.INFO)
+
+    log_file = XDGDirectories.get_state_home() / LOG_FILE_NAME
+    handler = RotatingFileHandler(
+        log_file,
+        maxBytes=_MAX_BYTES,
+        backupCount=_BACKUP_COUNT,
+        encoding="utf-8",
+    )
+    handler.setFormatter(logging.Formatter(_LOG_FORMAT))
+    handler._taskdog_tui = True  # type: ignore[attr-defined]  # tag for idempotency
+
+    for name in _TARGET_LOGGERS:
+        logger = logging.getLogger(name)
+        logger.setLevel(log_level)
+        # Idempotent: drop any handler a previous call attached.
+        for existing in [
+            h for h in logger.handlers if getattr(h, "_taskdog_tui", False)
+        ]:
+            logger.removeHandler(existing)
+        logger.addHandler(handler)
+
+    return log_file

--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -1,5 +1,6 @@
 """Taskdog TUI application."""
 
+import logging
 from pathlib import PurePath
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -49,6 +50,8 @@ from taskdog_core.domain.exceptions.task_exceptions import (
     ServerConnectionError,
     ServerError,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class TaskdogTUI(App):  # type: ignore[type-arg]
@@ -558,6 +561,9 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
                 self.call_from_thread(mgr.handle_api_error, e)
             return
         except Exception:
+            # Unexpected (non-API) error — a real bug. Log it instead of
+            # silently showing an empty list, then degrade to empty data.
+            logger.exception("Unexpected error during task reload")
             task_data = mgr.empty_task_data()
         if not worker.is_cancelled:
             self.call_from_thread(mgr.apply_task_data, task_data, True)

--- a/packages/taskdog-ui/src/taskdog/tui/services/task_ui_manager.py
+++ b/packages/taskdog-ui/src/taskdog/tui/services/task_ui_manager.py
@@ -1,5 +1,6 @@
 """Task UI Manager for orchestrating data lifecycle in TUI."""
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date, timedelta
@@ -18,6 +19,8 @@ from taskdog_core.domain.exceptions.task_exceptions import (
 
 if TYPE_CHECKING:
     from taskdog.tui.screens.main_screen import MainScreen
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -173,6 +176,7 @@ class TaskUIManager:
             self.handle_api_error(e)
             return self.empty_task_data()
         except Exception:
+            logger.exception("Unexpected error fetching task data")
             return self.empty_task_data()
 
     def empty_task_data(self) -> TaskData:
@@ -248,7 +252,7 @@ class TaskUIManager:
         except (ServerConnectionError, AuthenticationError, ServerError) as e:
             self.handle_api_error(e)
         except Exception:
-            pass
+            logger.exception("Unexpected error recalculating gantt")
 
     def _fetch_gantt_for_range(
         self, start_date: date, end_date: date

--- a/packages/taskdog-ui/tests/infrastructure/test_logging_config.py
+++ b/packages/taskdog-ui/tests/infrastructure/test_logging_config.py
@@ -1,0 +1,67 @@
+"""Tests for TUI file-based logging configuration."""
+
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+from unittest.mock import patch
+
+from taskdog.infrastructure.logging_config import (
+    LOG_FILE_NAME,
+    configure_tui_logging,
+)
+
+
+class TestConfigureTuiLogging:
+    """configure_tui_logging routes taskdog logs to a state-dir file."""
+
+    def _cleanup(self) -> None:
+        for name in ("taskdog", "taskdog_core"):
+            log = logging.getLogger(name)
+            for h in [h for h in log.handlers if getattr(h, "_taskdog_tui", False)]:
+                log.removeHandler(h)
+
+    def test_writes_to_state_dir_file(self, tmp_path):
+        with patch.dict(os.environ, {"XDG_STATE_HOME": str(tmp_path)}):
+            log_file = configure_tui_logging()
+        try:
+            assert log_file == tmp_path / "taskdog" / LOG_FILE_NAME
+
+            logging.getLogger("taskdog.test").error("boom")
+            for h in logging.getLogger("taskdog").handlers:
+                h.flush()
+
+            assert log_file.exists()
+            assert "boom" in log_file.read_text(encoding="utf-8")
+        finally:
+            self._cleanup()
+
+    def test_no_stream_handler_installed(self, tmp_path):
+        """The TUI owns the terminal: only a file handler may be attached."""
+        with patch.dict(os.environ, {"XDG_STATE_HOME": str(tmp_path)}):
+            configure_tui_logging()
+        try:
+            handlers = logging.getLogger("taskdog").handlers
+            tui_handlers = [h for h in handlers if getattr(h, "_taskdog_tui", False)]
+            assert tui_handlers
+            assert all(isinstance(h, RotatingFileHandler) for h in tui_handlers)
+        finally:
+            self._cleanup()
+
+    def test_idempotent_no_duplicate_handlers(self, tmp_path):
+        with patch.dict(os.environ, {"XDG_STATE_HOME": str(tmp_path)}):
+            configure_tui_logging()
+            configure_tui_logging()
+        try:
+            handlers = logging.getLogger("taskdog").handlers
+            tui_handlers = [h for h in handlers if getattr(h, "_taskdog_tui", False)]
+            assert len(tui_handlers) == 1
+        finally:
+            self._cleanup()
+
+    def test_respects_level_argument(self, tmp_path):
+        with patch.dict(os.environ, {"XDG_STATE_HOME": str(tmp_path)}):
+            configure_tui_logging(level="DEBUG")
+        try:
+            assert logging.getLogger("taskdog").level == logging.DEBUG
+        finally:
+            self._cleanup()


### PR DESCRIPTION
## What

Add file-based logging for the TUI and stop swallowing errors silently.

## Why

The TUI had **no logging configured**, so several broad `except` handlers swallowed errors with no trace. The worst was the catch-all in the reload worker (#976) — a real bug (`AttributeError`, etc.) would surface as an empty task list with no indication of the cause. This was flagged in the **Amazon Q review of #976**:

> The catch-all exception handler in `_reload_in_thread()` silently swallows all programming errors … This should log unexpected errors before returning empty data.

A Textual TUI owns stdout/stderr, so logs can't go there (it would corrupt the display). The fix is a log **file**.

## Change

- `XDGDirectories.get_state_home()` — new helper for `$XDG_STATE_HOME/taskdog` (the XDG-correct home for logs; `~/.local/state` default, `LOCALAPPDATA` on Windows).
- `taskdog.infrastructure.logging_config.configure_tui_logging()` — routes the `taskdog` / `taskdog_core` logger namespaces to a `RotatingFileHandler` at `<state>/tui.log`. **No stream handler** (would break the display). Idempotent. Level via `TASKDOG_LOG_LEVEL`.
- Called once on TUI startup (`tui_command`).
- Replaced silent swallows with `logger.exception(...)`:
  - `app._reload_in_thread` (the Amazon Q finding)
  - `task_ui_manager._fetch_task_data` (generic fetch error)
  - `task_ui_manager.recalculate_gantt` (was `except Exception: pass`)

## Test

- `get_state_home` (custom + default).
- `configure_tui_logging`: writes to the state-dir file, installs only a file handler (no stream), idempotent, respects level.
- `make check` + all packages' tests green (1097 UI + core/server/etc.).

## Notes

- Resolves the Amazon Q critical finding on #976.
- Other `except Exception as e:` handlers that already surface errors to the user (notifications) were left as-is; this PR targets the spots that hid failures entirely. They can adopt `logger.exception` incrementally now that the infra exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)