### PR TITLE
perf(ui): off-thread gantt zoom/pan + real loading indicator on startup

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from textual.timer import Timer
 
     from taskdog.infrastructure.cli_config_manager import CliConfig
+    from taskdog.services.task_data_loader import TaskData
     from taskdog.tui.services.task_ui_manager import FetchParams, GanttFetchParams
     from taskdog.view_models.gantt_view_model import GanttViewModel
 
@@ -363,12 +364,10 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
             on_error=self._handle_api_error,
         )
 
-        # Load tasks after screen is fully mounted
-        def _load_tasks_if_ready() -> None:
-            if self.task_ui_manager:
-                self.task_ui_manager.load_tasks()
-
-        self.call_after_refresh(_load_tasks_if_ready)
+        # Load tasks after screen is fully mounted. Routed through the reload
+        # funnel so the initial fetch runs off the UI thread; the loading
+        # indicator set in MainScreen.on_mount is cleared when it completes.
+        self.call_after_refresh(self.request_reload)
         # Start auto-refresh timer for elapsed time updates
         self.set_interval(AUTO_REFRESH_INTERVAL_SECONDS, self._refresh_elapsed_time)
         # Start connection monitoring timer (check every 3 seconds)
@@ -563,7 +562,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
             task_data = mgr.fetch_with_params(params)
         except (ServerConnectionError, AuthenticationError, ServerError) as e:
             if not worker.is_cancelled:
-                self.call_from_thread(mgr.handle_api_error, e)
+                self.call_from_thread(self._finish_reload, mgr, None, e)
             return
         except Exception:
             # Unexpected (non-API) error — a real bug. Log it instead of
@@ -571,7 +570,25 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
             logger.exception("Unexpected error during task reload")
             task_data = mgr.empty_task_data()
         if not worker.is_cancelled:
-            self.call_from_thread(mgr.apply_task_data, task_data, True)
+            self.call_from_thread(self._finish_reload, mgr, task_data, None)
+
+    def _finish_reload(
+        self,
+        mgr: TaskUIManager,
+        task_data: "TaskData | None",
+        error: "ServerConnectionError | AuthenticationError | ServerError | None",
+    ) -> None:
+        """Apply reload result (or surface error), then drop the loading state."""
+        if error is not None:
+            mgr.handle_api_error(error)
+        elif task_data is not None:
+            mgr.apply_task_data(task_data, keep_scroll_position=True)
+        # Clear the startup loading indicator (no-op on later reloads).
+        if self.main_screen:
+            if self.main_screen.gantt_widget:
+                self.main_screen.gantt_widget.loading = False
+            if self.main_screen.task_table:
+                self.main_screen.task_table.loading = False
 
     # Event handlers for task operations
     def _handle_task_change_event(self, event: Any) -> None:

--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -14,7 +14,8 @@ if TYPE_CHECKING:
     from textual.timer import Timer
 
     from taskdog.infrastructure.cli_config_manager import CliConfig
-    from taskdog.tui.services.task_ui_manager import FetchParams
+    from taskdog.tui.services.task_ui_manager import FetchParams, GanttFetchParams
+    from taskdog.view_models.gantt_view_model import GanttViewModel
 
 from taskdog_client import WebSocketClient
 
@@ -26,6 +27,7 @@ from taskdog.tui.commands.factory import CommandFactory
 from taskdog.tui.constants.command_mapping import ACTION_TO_COMMAND_MAP
 from taskdog.tui.constants.ui_settings import (
     AUTO_REFRESH_INTERVAL_SECONDS,
+    GANTT_LOADING_DELAY_SECONDS,
     RELOAD_DEBOUNCE_SECONDS,
     SORT_KEY_LABELS,
 )
@@ -279,6 +281,9 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
 
         # Debounce timer for the single reload funnel (request_reload)
         self._reload_timer: Timer | None = None
+
+        # Delayed-loading-indicator timer for gantt zoom/pan
+        self._gantt_loading_timer: Timer | None = None
 
         # Initialize WebSocket client for real-time updates
         self.websocket_client = websocket_client
@@ -588,13 +593,77 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
     on_tasks_refreshed = _handle_task_change_event
 
     def on_gantt_resize_requested(self, event: GanttResizeRequested) -> None:
-        """Handle gantt resize event.
+        """Handle gantt resize/pan: recalculate gantt data off the UI thread.
 
-        Delegates to TaskUIManager for recalculating gantt data
-        with the new date range.
+        The fetch runs in an exclusive thread worker so zooming/panning never
+        freezes the chart; a loading indicator is shown only if the fetch is
+        slow enough to notice.
 
         Args:
             event: GanttResizeRequested event containing display parameters
         """
-        if self.task_ui_manager:
-            self.task_ui_manager.recalculate_gantt(event.start_date, event.end_date)
+        mgr = self.task_ui_manager
+        if not mgr:
+            return
+        params = mgr.gather_gantt_params(event.start_date, event.end_date)
+        self._schedule_gantt_loading()
+        self.run_worker(
+            lambda: self._gantt_reload_in_thread(mgr, params),
+            group="gantt",
+            exclusive=True,
+            thread=True,
+        )
+
+    def _gantt_reload_in_thread(
+        self, mgr: TaskUIManager, params: "GanttFetchParams"
+    ) -> None:
+        """Worker body: fetch gantt in a thread, apply on the UI thread."""
+        worker = get_current_worker()
+        try:
+            gantt_view_model = mgr.fetch_gantt(params)
+        except (ServerConnectionError, AuthenticationError, ServerError) as e:
+            if not worker.is_cancelled:
+                self.call_from_thread(self._finish_gantt_reload, mgr, None, e)
+            return
+        except Exception:
+            logger.exception("Unexpected error recalculating gantt")
+            if not worker.is_cancelled:
+                self.call_from_thread(self._clear_gantt_loading)
+            return
+        if not worker.is_cancelled:
+            self.call_from_thread(
+                self._finish_gantt_reload, mgr, gantt_view_model, None
+            )
+
+    def _finish_gantt_reload(
+        self,
+        mgr: TaskUIManager,
+        gantt_view_model: "GanttViewModel | None",
+        error: "ServerConnectionError | AuthenticationError | ServerError | None",
+    ) -> None:
+        """Apply gantt result (or surface error), then drop the loading state."""
+        if error is not None:
+            mgr.handle_api_error(error)
+        else:
+            mgr.apply_gantt(gantt_view_model)
+        self._clear_gantt_loading()
+
+    def _schedule_gantt_loading(self) -> None:
+        """Arm a delayed loading indicator for the gantt (avoids flicker)."""
+        if self._gantt_loading_timer is not None:
+            self._gantt_loading_timer.stop()
+        self._gantt_loading_timer = self.set_timer(
+            GANTT_LOADING_DELAY_SECONDS, self._show_gantt_loading
+        )
+
+    def _show_gantt_loading(self) -> None:
+        self._gantt_loading_timer = None
+        if self.main_screen and self.main_screen.gantt_widget:
+            self.main_screen.gantt_widget.loading = True
+
+    def _clear_gantt_loading(self) -> None:
+        if self._gantt_loading_timer is not None:
+            self._gantt_loading_timer.stop()
+            self._gantt_loading_timer = None
+        if self.main_screen and self.main_screen.gantt_widget:
+            self.main_screen.gantt_widget.loading = False

--- a/packages/taskdog-ui/src/taskdog/tui/constants/ui_settings.py
+++ b/packages/taskdog-ui/src/taskdog/tui/constants/ui_settings.py
@@ -10,6 +10,7 @@ through CliConfig.input_defaults, not from this module.
 
 __all__ = [
     "AUTO_REFRESH_INTERVAL_SECONDS",
+    "GANTT_LOADING_DELAY_SECONDS",
     "MAX_HOURS_PER_DAY",
     "OPTIMIZATION_FAILURE_DETAIL_THRESHOLD",
     "RELOAD_DEBOUNCE_SECONDS",
@@ -27,6 +28,12 @@ RELOAD_DEBOUNCE_SECONDS = 0.1
 A single change can fire both a local refresh and its WebSocket echo (and
 batch operations fire many events); collapsing them within this window into
 one reload avoids redundant full reloads."""
+
+GANTT_LOADING_DELAY_SECONDS = 0.15
+"""Delay before showing the gantt loading indicator on zoom/pan.
+
+Fast fetches finish before this elapses, so the indicator only appears for
+fetches slow enough to be noticeable — avoiding flicker on quick refreshes."""
 
 # Time validation constants
 MAX_HOURS_PER_DAY = 24

--- a/packages/taskdog-ui/src/taskdog/tui/screens/main_screen.py
+++ b/packages/taskdog-ui/src/taskdog/tui/screens/main_screen.py
@@ -85,13 +85,15 @@ class MainScreen(Screen[None]):
 
     def on_mount(self) -> None:
         """Called when screen is mounted."""
-        # Initialize gantt with empty message
+        # Show a loading indicator until the initial data load completes
+        # (cleared by the app once the first reload finishes).
         if self.gantt_widget:
-            self.gantt_widget.update("Loading gantt chart...")
+            self.gantt_widget.loading = True
 
         # Setup task table columns
         if self.task_table:
             self.task_table.setup_columns()  # type: ignore[no-untyped-call]
+            self.task_table.loading = True
             self.task_table.focus()
 
     def on_search_query_changed(self, event: SearchQueryChanged) -> None:

--- a/packages/taskdog-ui/src/taskdog/tui/services/task_ui_manager.py
+++ b/packages/taskdog-ui/src/taskdog/tui/services/task_ui_manager.py
@@ -38,6 +38,21 @@ class FetchParams:
     date_range: tuple[date, date]
 
 
+@dataclass(frozen=True)
+class GanttFetchParams:
+    """Parameters for a gantt-only fetch (zoom/pan), gathered on the UI thread.
+
+    Like FetchParams but scoped to the gantt recalculation: it carries the
+    explicit chart window instead of deriving it from the widget.
+    """
+
+    start_date: date
+    end_date: date
+    sort_by: str
+    reverse: bool
+    include_archived: bool
+
+
 class TaskUIManager:
     """Manages task data lifecycle for TUI.
 
@@ -236,62 +251,58 @@ class TaskUIManager:
         # Update Table widget (reads from TUIState.filtered_viewmodels)
         main_screen.refresh_tasks(keep_scroll_position=keep_scroll_position)
 
-    def recalculate_gantt(self, start_date: date, end_date: date) -> None:
-        """Recalculate gantt data for a new date range.
-
-        Called when gantt widget is resized and needs recalculation
-        with a different date range.
-
-        Args:
-            start_date: New start date for gantt range
-            end_date: New end date for gantt range
-        """
-        try:
-            gantt_view_model = self._fetch_gantt_for_range(start_date, end_date)
-            self._update_gantt_ui(gantt_view_model)
-        except (ServerConnectionError, AuthenticationError, ServerError) as e:
-            self.handle_api_error(e)
-        except Exception:
-            logger.exception("Unexpected error recalculating gantt")
-
-    def _fetch_gantt_for_range(
-        self, start_date: date, end_date: date
-    ) -> GanttViewModel | None:
-        """Fetch gantt data for specific date range.
+    def gather_gantt_params(self, start_date: date, end_date: date) -> GanttFetchParams:
+        """Collect gantt fetch inputs from UI/state. Must run on the UI thread.
 
         Args:
             start_date: Start date for gantt range
             end_date: End date for gantt range
 
         Returns:
-            GanttViewModel or None if no data
+            GanttFetchParams snapshot to hand to ``fetch_gantt``.
         """
-        # Get current sort state from gantt widget if available
         sort_by = self.state.sort_by
         main_screen = self._get_main_screen()
         if main_screen and main_screen.gantt_widget:
             sort_by = main_screen.gantt_widget.get_sort_by()
 
-        task_list_output = self.task_data_loader.api_client.list_tasks(
-            include_archived=self.state.show_archived,
+        return GanttFetchParams(
+            start_date=start_date,
+            end_date=end_date,
             sort_by=sort_by,
             reverse=self.state.sort_reverse,
+            include_archived=self.state.show_archived,
+        )
+
+    def fetch_gantt(self, params: GanttFetchParams) -> GanttViewModel | None:
+        """Fetch gantt data for the given params. Thread-safe; touches no UI.
+
+        Raises the underlying API exception on failure.
+
+        Args:
+            params: Snapshot from ``gather_gantt_params``.
+
+        Returns:
+            GanttViewModel, or None when there is no gantt data.
+        """
+        task_list_output = self.task_data_loader.api_client.list_tasks(
+            include_archived=params.include_archived,
+            sort_by=params.sort_by,
+            reverse=params.reverse,
             include_gantt=True,
-            gantt_start_date=start_date,
-            gantt_end_date=end_date,
+            gantt_start_date=params.start_date,
+            gantt_end_date=params.end_date,
         )
 
         if not task_list_output.gantt_data:
             return None
 
-        gantt_view_model = self.task_data_loader.gantt_presenter.present(
+        return self.task_data_loader.gantt_presenter.present(
             task_list_output.gantt_data
         )
 
-        return gantt_view_model
-
-    def _update_gantt_ui(self, gantt_view_model: GanttViewModel | None) -> None:
-        """Update gantt cache in State and tell widget to re-render.
+    def apply_gantt(self, gantt_view_model: GanttViewModel | None) -> None:
+        """Update gantt cache and re-render. Must run on the UI thread.
 
         Args:
             gantt_view_model: New gantt view model to display

--- a/packages/taskdog-ui/tests/tui/services/test_task_ui_manager.py
+++ b/packages/taskdog-ui/tests/tui/services/test_task_ui_manager.py
@@ -408,122 +408,57 @@ class TestRecalculateGantt:
             on_error=self.on_error,
         )
 
-    def test_recalculate_gantt_fetches_and_updates_widget(self):
-        """Test recalculate_gantt fetches data and updates widget."""
-        # Setup
-        gantt = create_gantt_viewmodel()
-        task_list_output = TaskListOutput(
-            tasks=[],
-            total_count=0,
-            filtered_count=0,
-            gantt_data=create_gantt_output(),
-        )
-        self.task_data_loader.api_client.list_tasks.return_value = task_list_output
-        self.task_data_loader.gantt_presenter.present.return_value = gantt
-
-        start_date = date(2024, 1, 1)
-        end_date = date(2024, 1, 31)
-
-        # Execute
-        self.manager.recalculate_gantt(start_date, end_date)
-
-        # Verify API was called with parameters from state/gantt_widget
-        self.task_data_loader.api_client.list_tasks.assert_called_once_with(
-            include_archived=False,  # from state.show_archived (default)
-            sort_by="deadline",  # from gantt_widget.get_sort_by()
-            reverse=self.state.sort_reverse,
-            include_gantt=True,
-            gantt_start_date=start_date,  # honored when archived not shown
-            gantt_end_date=end_date,
-        )
-
-        # Verify presenter was called
-        self.task_data_loader.gantt_presenter.present.assert_called_once()
-
-        # Verify State was updated and widget was told to render
-        assert self.state.gantt_cache == gantt
-        self.main_screen.gantt_widget.update_view_model_and_render.assert_called_once()
-
-    def test_recalculate_gantt_respects_show_archived_state(self):
-        """Test recalculate_gantt respects state.show_archived on zoom/pan.
-
-        When archived tasks are shown they must be included for the requested
-        (fixed-width) window; the requested start/end are honored verbatim
-        (the window is moved by panning, not auto-expanded).
-        """
-        # Setup - archived tasks are shown
+    def test_gather_gantt_params_snapshots_window_and_sort(self):
+        """gather_gantt_params captures the window plus sort/archive state."""
+        self.state.sort_reverse = True
         self.state.show_archived = True
         self.main_screen.gantt_widget.get_sort_by.return_value = "priority"
 
+        params = self.manager.gather_gantt_params(date(2024, 1, 1), date(2024, 1, 31))
+
+        assert params.start_date == date(2024, 1, 1)
+        assert params.end_date == date(2024, 1, 31)
+        assert params.sort_by == "priority"
+        assert params.reverse is True
+        assert params.include_archived is True
+
+    def test_fetch_gantt_raises_on_api_error(self):
+        """fetch_gantt propagates API errors (no UI-thread handling)."""
+        from taskdog.tui.services.task_ui_manager import GanttFetchParams
+
+        self.task_data_loader.api_client.list_tasks.side_effect = ServerError("boom")
+        params = GanttFetchParams(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 1, 31),
+            sort_by="id",
+            reverse=False,
+            include_archived=False,
+        )
+
+        with pytest.raises(ServerError):
+            self.manager.fetch_gantt(params)
+        self.on_error.assert_not_called()
+
+    def test_apply_gantt_updates_cache_and_renders(self):
+        """apply_gantt writes the gantt cache and re-renders the widget."""
         gantt = create_gantt_viewmodel()
-        task_list_output = TaskListOutput(
-            tasks=[],
-            total_count=0,
-            filtered_count=0,
-            gantt_data=create_gantt_output(),
-        )
-        self.task_data_loader.api_client.list_tasks.return_value = task_list_output
-        self.task_data_loader.gantt_presenter.present.return_value = gantt
 
-        # Execute
-        self.manager.recalculate_gantt(date(2024, 1, 1), date(2024, 1, 31))
+        self.manager.apply_gantt(gantt)
 
-        # Verify API was called with archived included and the exact window
-        call_kwargs = self.task_data_loader.api_client.list_tasks.call_args[1]
-        assert call_kwargs["include_archived"] is True  # Respects state.show_archived
-        assert call_kwargs["gantt_start_date"] == date(2024, 1, 1)  # Honored verbatim
-        assert call_kwargs["gantt_end_date"] == date(2024, 1, 31)
-        assert call_kwargs["sort_by"] == "priority"  # Respects gantt_widget sort
-
-    def test_recalculate_gantt_handles_connection_error(self):
-        """Test recalculate_gantt calls error callback on failure."""
-        # Setup
-        original_error = ConnectionError("Connection refused")
-        self.task_data_loader.api_client.list_tasks.side_effect = ServerConnectionError(
-            base_url="http://localhost:8000",
-            original_error=original_error,
+        assert self.state.gantt_cache == gantt
+        self.main_screen.gantt_widget.update_view_model_and_render.assert_called_once_with(
+            keep_scroll_position=True
         )
 
-        # Execute
-        self.manager.recalculate_gantt(date(2024, 1, 1), date(2024, 1, 31))
-
-        # Verify error callback was called with the error
-        self.on_error.assert_called_once()
-        error_arg = self.on_error.call_args[0][0]
-        assert isinstance(error_arg, ServerConnectionError)
-
-        # Verify widget was NOT updated
+    def test_apply_gantt_ignores_none(self):
+        """apply_gantt is a no-op when there is no gantt data."""
+        self.manager.apply_gantt(None)
         self.main_screen.gantt_widget.update_view_model_and_render.assert_not_called()
 
-    def test_recalculate_gantt_without_main_screen(self):
-        """Test recalculate_gantt handles missing main_screen gracefully."""
-        # Setup - no main_screen
-        manager = TaskUIManager(
-            state=self.state,
-            task_data_loader=self.task_data_loader,
-            main_screen_provider=lambda: None,
-            on_error=self.on_error,
-        )
+    def test_fetch_gantt_returns_none_without_gantt_data(self):
+        """fetch_gantt returns None (and skips the presenter) on empty data."""
+        from taskdog.tui.services.task_ui_manager import GanttFetchParams
 
-        gantt = create_gantt_viewmodel()
-        task_list_output = TaskListOutput(
-            tasks=[],
-            total_count=0,
-            filtered_count=0,
-            gantt_data=create_gantt_output(),
-        )
-        self.task_data_loader.api_client.list_tasks.return_value = task_list_output
-        self.task_data_loader.gantt_presenter.present.return_value = gantt
-
-        # Execute - should not raise
-        manager.recalculate_gantt(date(2024, 1, 1), date(2024, 1, 31))
-
-        # Verify no error was raised and API was still called
-        self.task_data_loader.api_client.list_tasks.assert_called_once()
-
-    def test_recalculate_gantt_without_gantt_data(self):
-        """Test recalculate_gantt handles None gantt_data gracefully."""
-        # Setup - no gantt_data in response
         task_list_output = TaskListOutput(
             tasks=[],
             total_count=0,
@@ -531,15 +466,18 @@ class TestRecalculateGantt:
             gantt_data=None,
         )
         self.task_data_loader.api_client.list_tasks.return_value = task_list_output
+        params = GanttFetchParams(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 1, 31),
+            sort_by="id",
+            reverse=False,
+            include_archived=False,
+        )
 
-        # Execute - should not raise
-        self.manager.recalculate_gantt(date(2024, 1, 1), date(2024, 1, 31))
+        result = self.manager.fetch_gantt(params)
 
-        # Verify presenter was NOT called
+        assert result is None
         self.task_data_loader.gantt_presenter.present.assert_not_called()
-
-        # Verify widget was NOT updated
-        self.main_screen.gantt_widget.update_view_model_and_render.assert_not_called()
 
 
 class TestErrorHandling:
@@ -594,31 +532,6 @@ class TestErrorHandling:
         self.on_error.assert_called_once()
         assert isinstance(self.on_error.call_args[0][0], ServerError)
         assert result.all_tasks == []
-
-    def test_recalculate_gantt_handles_authentication_error(self):
-        """Test recalculate_gantt calls error callback with AuthenticationError."""
-        self.task_data_loader.api_client.list_tasks.side_effect = AuthenticationError(
-            message="Unauthorized",
-        )
-
-        self.manager.recalculate_gantt(date(2024, 1, 1), date(2024, 1, 31))
-
-        self.on_error.assert_called_once()
-        assert isinstance(self.on_error.call_args[0][0], AuthenticationError)
-        self.main_screen.gantt_widget.update_view_model_and_render.assert_not_called()
-
-    def test_recalculate_gantt_handles_server_error(self):
-        """Test recalculate_gantt calls error callback with ServerError."""
-        self.task_data_loader.api_client.list_tasks.side_effect = ServerError(
-            status_code=500,
-            message="Internal Server Error",
-        )
-
-        self.manager.recalculate_gantt(date(2024, 1, 1), date(2024, 1, 31))
-
-        self.on_error.assert_called_once()
-        assert isinstance(self.on_error.call_args[0][0], ServerError)
-        self.main_screen.gantt_widget.update_view_model_and_render.assert_not_called()
 
 
 class TestCreateEmptyTaskData:

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -4,6 +4,7 @@ trends  # unused variable (packages/taskdog-server/src/taskdog_server/api/models
 _.format_commands  # Click override called via duck-typing (packages/taskdog-ui/src/taskdog/cli_main.py:138)
 _.show_audit_logs  # unused method (packages/taskdog-ui/src/taskdog/tui/app.py:478)
 _.toggle_archive  # palette callback via getattr (packages/taskdog-ui/src/taskdog/tui/app.py)
+_.loading  # Textual Widget reactive (packages/taskdog-ui/src/taskdog/tui/app.py)
 SelectionProvider  # unused import (packages/taskdog-ui/src/taskdog/tui/context.py:12)
 SelectionProvider  # unused class (packages/taskdog-ui/src/taskdog/tui/selection.py:9)
 last_update  # unused variable (packages/taskdog-ui/src/taskdog/tui/state/connection_status.py:19)


### PR DESCRIPTION
## What

1. Run gantt zoom/pan recalculation off the UI thread (same worker split as the task reload).
2. Show a real Textual loading indicator during the initial load, replacing the static `"Loading gantt chart..."` text — and make the initial load non-blocking.

## Why

- Gantt zoom/pan still fetched **synchronously**, so panning into a heavier past range froze the chart.
- The loading indicator I first added for zoom/pan almost never appears: local fetches finish before its delay. Meanwhile startup showed a **static text placeholder**, not the animated indicator, and the initial load **blocked the UI thread**. So no real loading indicator was ever visible — the actual point raised in review/testing.

## Change

**Gantt worker split** (mirrors the reload seams):
- `gather_gantt_params()` (UI thread) / `fetch_gantt()` (any thread, raises) / `apply_gantt()` (UI thread)
- `on_gantt_resize_requested` runs the fetch in an exclusive `"gantt"` worker; a delayed indicator shows only if that fetch is slow.
- The now-unused synchronous `recalculate_gantt()` is removed (covered by seam tests).

**Real startup indicator**:
- `MainScreen.on_mount` sets `gantt_widget.loading` / `task_table.loading` (the animated `Widget.loading` indicator) instead of placeholder text.
- The initial load is routed through the off-thread reload funnel (`request_reload`), so startup doesn't block.
- The reload worker clears the loading state when it finishes (idempotent on later reloads), so the indicator disappears once the first data arrives.

## Test

- New gantt seam tests: `gather_gantt_params`, `fetch_gantt` (raises / returns None on empty), `apply_gantt`.
- `make check` (lint / typecheck / spell / deadcode) + full UI suite (1095 tests) green.
- `_.loading` added to the vulture whitelist (Textual reactive, not statically visible).

## Not verified

Threaded worker + `Widget.loading` rendering need manual TUI verification:
- **startup**: animated indicator on gantt + table until first data, then clears
- **pan/zoom**: no freeze; indicator appears only on genuinely slow fetches

🤖 Generated with [Claude Code](https://claude.com/claude-code)