### PR TITLE
fix(ui): capture taskdog_client logs in TUI log file

### DIFF
--- a/packages/taskdog-ui/src/taskdog/infrastructure/logging_config.py
+++ b/packages/taskdog-ui/src/taskdog/infrastructure/logging_config.py
@@ -18,7 +18,9 @@ _BACKUP_COUNT = 3
 _LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
 # Logger namespaces whose records should reach the TUI log file.
-_TARGET_LOGGERS = ("taskdog", "taskdog_core")
+# `taskdog_client` is a separate root (not a child of `taskdog`), so it must be
+# listed explicitly or the WebSocket client's records would be dropped.
+_TARGET_LOGGERS = ("taskdog", "taskdog_core", "taskdog_client")
 
 
 def configure_tui_logging(level: str | None = None) -> Path:

--- a/packages/taskdog-ui/tests/infrastructure/test_logging_config.py
+++ b/packages/taskdog-ui/tests/infrastructure/test_logging_config.py
@@ -15,7 +15,7 @@ class TestConfigureTuiLogging:
     """configure_tui_logging routes taskdog logs to a state-dir file."""
 
     def _cleanup(self) -> None:
-        for name in ("taskdog", "taskdog_core"):
+        for name in ("taskdog", "taskdog_core", "taskdog_client"):
             log = logging.getLogger(name)
             for h in [h for h in log.handlers if getattr(h, "_taskdog_tui", False)]:
                 log.removeHandler(h)
@@ -32,6 +32,19 @@ class TestConfigureTuiLogging:
 
             assert log_file.exists()
             assert "boom" in log_file.read_text(encoding="utf-8")
+        finally:
+            self._cleanup()
+
+    def test_captures_taskdog_client_records(self, tmp_path):
+        """WebSocket client logs (taskdog_client.*) must reach the file."""
+        with patch.dict(os.environ, {"XDG_STATE_HOME": str(tmp_path)}):
+            log_file = configure_tui_logging()
+        try:
+            logging.getLogger("taskdog_client.websocket").info("ws connected")
+            for h in logging.getLogger("taskdog_client").handlers:
+                h.flush()
+
+            assert "ws connected" in log_file.read_text(encoding="utf-8")
         finally:
             self._cleanup()
 


### PR DESCRIPTION
## Summary

The TUI file logger (`tui.log`) silently dropped all `taskdog_client` log records, including the WebSocket client's connect / reconnect / client-id messages.

`configure_tui_logging()` only attached its handler to the `taskdog` and `taskdog_core` namespaces. `taskdog_client` is a **separate logger root** (not a child of `taskdog`), so its records never reached the file handler and were lost — making real-time-sync / connection issues hard to diagnose from the log.

## Change

- Add `taskdog_client` to `_TARGET_LOGGERS`.
- Test: assert `taskdog_client.*` records reach the log file; extend `_cleanup` to cover the new namespace.

## Verification

- `pytest tests/infrastructure/test_logging_config.py` — 5 passed (incl. new case)
- `ruff check` / `ruff format --check` / `mypy` clean

Closes #979
