### PR TITLE
refactor(core): inject ITimeProvider into TaskQueryService

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
@@ -37,20 +37,16 @@ class TaskQueryService(QueryService):
     def __init__(
         self,
         repository: TaskRepository,
-        time_provider: ITimeProvider | None = None,
+        time_provider: ITimeProvider,
     ) -> None:
         """Initialize query service with repository.
 
         Args:
             repository: Task repository for data access
-            time_provider: Provider for current time. Defaults to SystemTimeProvider.
+            time_provider: Provider for current time, supplied by the caller.
         """
         super().__init__(repository)
         self.sorter = TaskSorter()
-        if time_provider is None:
-            from taskdog_core.infrastructure.time_provider import SystemTimeProvider
-
-            time_provider = SystemTimeProvider()
         self._time_provider = time_provider
 
     def get_filtered_tasks_as_dtos(

--- a/packages/taskdog-core/src/taskdog_core/controllers/query_controller.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/query_controller.py
@@ -25,6 +25,7 @@ from taskdog_core.application.use_cases.get_task_detail import GetTaskDetailUseC
 from taskdog_core.application.use_cases.list_tasks import ListTasksUseCase
 from taskdog_core.domain.repositories.notes_repository import NotesRepository
 from taskdog_core.domain.repositories.task_repository import TaskRepository
+from taskdog_core.domain.services.time_provider import ITimeProvider
 
 if TYPE_CHECKING:
     from taskdog_core.domain.services.holiday_checker import IHolidayChecker
@@ -48,16 +49,20 @@ class QueryController:
         self,
         repository: TaskRepository,
         notes_repository: NotesRepository | None,
+        time_provider: ITimeProvider,
     ):
         """Initialize the query controller.
 
         Args:
             repository: Task repository
             notes_repository: Notes repository (optional, required for get_task_detail)
+            time_provider: Provider for current time, supplied by the caller
         """
         self.repository = repository
         self.notes_repository = notes_repository
-        self.query_service: TaskQueryService = TaskQueryService(repository)
+        self.query_service: TaskQueryService = TaskQueryService(
+            repository, time_provider
+        )
 
     def list_tasks(
         self,

--- a/packages/taskdog-core/tests/application/queries/test_task_query_service.py
+++ b/packages/taskdog-core/tests/application/queries/test_task_query_service.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 import pytest
 
 from taskdog_core.application.queries.task_query_service import TaskQueryService
+from tests.helpers.time_provider import FakeTimeProvider
 
 
 class TestTaskQueryService:
@@ -14,7 +15,7 @@ class TestTaskQueryService:
     def setup(self, repository):
         """Initialize service for each test."""
         self.repository = repository
-        self.query_service = TaskQueryService(self.repository)
+        self.query_service = TaskQueryService(self.repository, FakeTimeProvider())
 
         # Calculate date strings for testing
         self.today = datetime.now().date()

--- a/packages/taskdog-core/tests/application/use_cases/test_get_gantt_data_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_get_gantt_data_use_case.py
@@ -8,6 +8,7 @@ from taskdog_core.application.dto.query_inputs import GetGanttDataInput
 from taskdog_core.application.queries.task_query_service import TaskQueryService
 from taskdog_core.application.use_cases.get_gantt_data import GetGanttDataUseCase
 from taskdog_core.domain.entities.task import TaskStatus
+from tests.helpers.time_provider import FakeTimeProvider
 
 
 class TestGetGanttDataUseCase:
@@ -17,7 +18,7 @@ class TestGetGanttDataUseCase:
     def setup(self, repository):
         """Initialize use case for each test."""
         self.repository = repository
-        self.query_service = TaskQueryService(self.repository)
+        self.query_service = TaskQueryService(self.repository, FakeTimeProvider())
         self.use_case = GetGanttDataUseCase(self.query_service)
 
     def test_execute_returns_gantt_output(self):

--- a/packages/taskdog-core/tests/application/use_cases/test_list_tasks_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_list_tasks_use_case.py
@@ -8,6 +8,7 @@ from taskdog_core.application.dto.query_inputs import ListTasksInput
 from taskdog_core.application.queries.task_query_service import TaskQueryService
 from taskdog_core.application.use_cases.list_tasks import ListTasksUseCase
 from taskdog_core.domain.entities.task import TaskStatus
+from tests.helpers.time_provider import FakeTimeProvider
 
 
 class TestListTasksUseCase:
@@ -17,7 +18,7 @@ class TestListTasksUseCase:
     def setup(self, repository):
         """Initialize use case for each test."""
         self.repository = repository
-        self.query_service = TaskQueryService(self.repository)
+        self.query_service = TaskQueryService(self.repository, FakeTimeProvider())
         self.use_case = ListTasksUseCase(self.repository, self.query_service)
 
     def test_execute_returns_all_tasks(self):

--- a/packages/taskdog-core/tests/controllers/test_query_controller.py
+++ b/packages/taskdog-core/tests/controllers/test_query_controller.py
@@ -10,6 +10,7 @@ from taskdog_core.application.dto.query_inputs import (
 )
 from taskdog_core.controllers.query_controller import QueryController
 from taskdog_core.domain.entities.task import TaskStatus
+from tests.helpers.time_provider import FakeTimeProvider
 
 
 class TestQueryController:
@@ -19,7 +20,7 @@ class TestQueryController:
     def setup(self, repository):
         """Initialize controller for each test."""
         self.repository = repository
-        self.controller = QueryController(self.repository, None)
+        self.controller = QueryController(self.repository, None, FakeTimeProvider())
 
     def test_list_tasks_returns_output_dto(self):
         """Test list_tasks returns TaskListOutput with correct structure."""

--- a/packages/taskdog-server/src/taskdog_server/api/dependencies.py
+++ b/packages/taskdog-server/src/taskdog_server/api/dependencies.py
@@ -92,7 +92,7 @@ def initialize_api_context(
     audit_log_repository = SqliteAuditLogRepository(db_url, engine=engine)
 
     # Initialize controllers
-    query_controller = QueryController(repository, notes_repository)
+    query_controller = QueryController(repository, notes_repository, time_provider)
     lifecycle_controller = TaskLifecycleController(repository, config)
     relationship_controller = TaskRelationshipController(repository, config)
     analytics_controller = TaskAnalyticsController(repository, config, holiday_checker)

--- a/packages/taskdog-server/tests/api/test_app.py
+++ b/packages/taskdog-server/tests/api/test_app.py
@@ -37,7 +37,7 @@ class TestApp:
 
         # Create controllers with mocked dependencies
         query_controller = QueryController(
-            self.mock_repository, self.mock_notes_repository
+            self.mock_repository, self.mock_notes_repository, SystemTimeProvider()
         )
         lifecycle_controller = TaskLifecycleController(
             self.mock_repository, self.mock_config

--- a/packages/taskdog-server/tests/conftest.py
+++ b/packages/taskdog-server/tests/conftest.py
@@ -203,7 +203,9 @@ def app(
 ):
     """FastAPI application with all routers (session-scoped)."""
     # Create controllers once (reused across all tests)
-    query_controller = QueryController(session_repository, session_notes_repository)
+    query_controller = QueryController(
+        session_repository, session_notes_repository, SystemTimeProvider()
+    )
     lifecycle_controller = TaskLifecycleController(session_repository, mock_config)
     relationship_controller = TaskRelationshipController(
         session_repository, mock_config


### PR DESCRIPTION
## Summary

`TaskQueryService` lives in the **application** layer but reached into the **infrastructure** layer to build a default `SystemTimeProvider`, inverting the Clean Architecture dependency direction (dependencies must point inward).

```python
# before — application/queries/task_query_service.py
if time_provider is None:
    from taskdog_core.infrastructure.time_provider import SystemTimeProvider
    time_provider = SystemTimeProvider()
```

## Change

- `TaskQueryService` now takes a **required** `ITimeProvider` (domain interface), supplied by the caller — no infrastructure import.
- `QueryController` receives `ITimeProvider` and threads it through (matching the existing `AuditLogController` pattern).
- Server composition root (`api/dependencies.py`) injects the `SystemTimeProvider` it already constructs.
- Tests updated to inject `FakeTimeProvider` / `SystemTimeProvider`.

## Verification

- `grep` confirms **no** `taskdog_core.infrastructure` import remains under `application/` (excluding docstrings).
- core suite: 1096 passed · server suite: 307 passed
- `ruff` + `mypy` clean

Closes #981
