### PR TITLE
fix(core): validate optimization day limit

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/dto/optimize_params.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/optimize_params.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from taskdog_core.domain.exceptions.task_exceptions import TaskValidationError
+
 if TYPE_CHECKING:
     from taskdog_core.domain.services.holiday_checker import IHolidayChecker
 
@@ -26,3 +28,11 @@ class OptimizeParams:
     max_hours_per_day: float
     holiday_checker: "IHolidayChecker | None" = None
     include_all_days: bool = False
+
+    def __post_init__(self) -> None:
+        """Validate optimization parameters."""
+        if self.max_hours_per_day <= 0:
+            raise TaskValidationError(
+                f"Max hours per day must be greater than 0 "
+                f"(got {self.max_hours_per_day})"
+            )

--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/optimize_schedule.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/optimize_schedule.py
@@ -66,6 +66,14 @@ class OptimizeScheduleUseCase(UseCase[OptimizeScheduleInput, OptimizationOutput]
             NoSchedulableTasksError: If no tasks can be scheduled
             Exception: If optimization fails
         """
+        # Create and validate OptimizeParams from input_dto before any strategy work.
+        params = OptimizeParams(
+            start_date=input_dto.start_date,
+            max_hours_per_day=input_dto.max_hours_per_day,
+            holiday_checker=self.holiday_checker,
+            include_all_days=input_dto.include_all_days,
+        )
+
         # Get all tasks and backup their states before optimization
         all_tasks = self.repository.get_all()
         task_states_before: dict[int, datetime | None] = {
@@ -123,14 +131,6 @@ class OptimizeScheduleUseCase(UseCase[OptimizeScheduleInput, OptimizationOutput]
 
         # Get optimization strategy
         strategy = StrategyFactory.create(input_dto.algorithm_name)
-
-        # Create OptimizeParams from input_dto
-        params = OptimizeParams(
-            start_date=input_dto.start_date,
-            max_hours_per_day=input_dto.max_hours_per_day,
-            holiday_checker=self.holiday_checker,
-            include_all_days=input_dto.include_all_days,
-        )
 
         # Run optimization
         # Strategy responsibility: how to optimize

--- a/packages/taskdog-core/tests/application/dto/test_optimize_params.py
+++ b/packages/taskdog-core/tests/application/dto/test_optimize_params.py
@@ -1,0 +1,42 @@
+"""Tests for OptimizeParams DTO."""
+
+from datetime import datetime
+
+import pytest
+
+from taskdog_core.application.dto.optimize_params import OptimizeParams
+from taskdog_core.domain.exceptions.task_exceptions import TaskValidationError
+
+
+class TestOptimizeParams:
+    """Test suite for OptimizeParams DTO."""
+
+    def test_create_with_valid_fields(self) -> None:
+        """Test creating DTO with valid fields."""
+        start_date = datetime(2025, 1, 1, 9, 0)
+
+        dto = OptimizeParams(
+            start_date=start_date,
+            max_hours_per_day=8.0,
+        )
+
+        assert dto.start_date == start_date
+        assert dto.max_hours_per_day == 8.0
+        assert dto.holiday_checker is None
+        assert dto.include_all_days is False
+
+    @pytest.mark.parametrize("max_hours_per_day", [0.0, -1.0])
+    def test_rejects_non_positive_max_hours_per_day(
+        self, max_hours_per_day: float
+    ) -> None:
+        """Test non-positive max_hours_per_day raises domain validation error."""
+        with pytest.raises(TaskValidationError) as exc_info:
+            OptimizeParams(
+                start_date=datetime(2025, 1, 1, 9, 0),
+                max_hours_per_day=max_hours_per_day,
+            )
+
+        assert (
+            f"Max hours per day must be greater than 0 (got {max_hours_per_day})"
+            == str(exc_info.value)
+        )

--- a/packages/taskdog-core/tests/application/use_cases/test_optimize_schedule_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_optimize_schedule_use_case.py
@@ -9,11 +9,13 @@ from taskdog_core.application.use_cases.create_task import CreateTaskUseCase
 from taskdog_core.application.use_cases.optimize_schedule import (
     OptimizeScheduleInput,
     OptimizeScheduleUseCase,
+    StrategyFactory,
 )
 from taskdog_core.domain.entities.task import TaskStatus
 from taskdog_core.domain.exceptions.task_exceptions import (
     NoSchedulableTasksError,
     TaskNotFoundException,
+    TaskValidationError,
 )
 
 
@@ -59,6 +61,33 @@ class TestOptimizeScheduleUseCase:
         # Verify daily_allocations
         assert task.daily_allocations is not None
         assert task.daily_allocations[date(2025, 10, 15)] == 4.0
+
+    @pytest.mark.parametrize("algorithm_name", ["greedy", "backward"])
+    @pytest.mark.parametrize("max_hours_per_day", [0.0, -1.0])
+    def test_optimize_rejects_non_positive_max_hours_before_strategy(
+        self, algorithm_name, max_hours_per_day, monkeypatch
+    ):
+        """Test invalid max_hours_per_day raises before any strategy is created."""
+
+        def fail_if_strategy_is_created(*args, **kwargs):
+            raise AssertionError("Strategy should not be created for invalid params")
+
+        monkeypatch.setattr(StrategyFactory, "create", fail_if_strategy_is_created)
+
+        optimize_input = OptimizeScheduleInput(
+            start_date=datetime(2025, 10, 15, 18, 0, 0),
+            max_hours_per_day=max_hours_per_day,
+            force_override=False,
+            algorithm_name=algorithm_name,
+        )
+
+        with pytest.raises(TaskValidationError) as exc_info:
+            self.optimize_use_case.execute(optimize_input)
+
+        assert (
+            f"Max hours per day must be greater than 0 (got {max_hours_per_day})"
+            == str(exc_info.value)
+        )
 
     def test_optimize_multiple_tasks_same_day(self):
         """Test optimizing multiple tasks that fit in one day."""


### PR DESCRIPTION
## Summary

Fixes #966 by validating optimization parameters before scheduling begins. `OptimizeParams` now rejects `max_hours_per_day <= 0` with `TaskValidationError`, and `OptimizeScheduleUseCase` builds those params before repository reads or strategy creation so invalid input fails fast instead of reaching the greedy/backward loops.

Added focused tests for direct `OptimizeParams` construction and use-case execution with both `greedy` and `backward` algorithms.

## Verification

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=src pytest tests/application/dto/test_optimize_params.py tests/application/use_cases/test_optimize_schedule_use_case.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=src pytest tests/application/services/optimization/test_greedy_optimization_strategy.py tests/application/services/optimization/test_backward_optimization_strategy.py`
- `ruff check src/taskdog_core/application/dto/optimize_params.py src/taskdog_core/application/use_cases/optimize_schedule.py tests/application/dto/test_optimize_params.py tests/application/use_cases/test_optimize_schedule_use_case.py`
- `ruff format --check src/taskdog_core/application/dto/optimize_params.py src/taskdog_core/application/use_cases/optimize_schedule.py tests/application/dto/test_optimize_params.py tests/application/use_cases/test_optimize_schedule_use_case.py`
- `git diff --check`

Full `packages/taskdog-core` test collection in this local environment needs `sqlalchemy`; the focused core tests above do not touch that dependency and pass locally.
