### PR TITLE
fix: wrap converter missing keys

### DIFF
--- a/packages/taskdog-client/src/taskdog_client/converters/exceptions.py
+++ b/packages/taskdog-client/src/taskdog_client/converters/exceptions.py
@@ -31,3 +31,15 @@ class ConversionError(TaskError):
         self.field = field
         self.value = value
         super().__init__(message)
+
+
+def require_key(data: dict[str, Any], key: str) -> Any:
+    """Return a required API response key or raise ConversionError."""
+    try:
+        return data[key]
+    except KeyError as e:
+        raise ConversionError(
+            f"Missing required key {key!r} in API response",
+            field=key,
+            value=data,
+        ) from e

--- a/packages/taskdog-client/src/taskdog_client/converters/gantt_converters.py
+++ b/packages/taskdog-client/src/taskdog_client/converters/gantt_converters.py
@@ -9,7 +9,7 @@ from taskdog_core.domain.entities.task import TaskStatus
 from taskdog_core.shared.utils.datetime_parser import parse_iso_date
 
 from .datetime_utils import _parse_date_dict, _parse_date_set, _parse_datetime_fields
-from .exceptions import ConversionError
+from .exceptions import ConversionError, require_key
 
 
 def _parse_date_range(data: dict[str, Any]) -> GanttDateRange:
@@ -25,14 +25,15 @@ def _parse_date_range(data: dict[str, Any]) -> GanttDateRange:
         ConversionError: If date parsing fails
     """
     try:
-        start_date = parse_iso_date(data["date_range"]["start_date"])
-        end_date = parse_iso_date(data["date_range"]["end_date"])
+        date_range = require_key(data, "date_range")
+        start_date = parse_iso_date(require_key(date_range, "start_date"))
+        end_date = parse_iso_date(require_key(date_range, "end_date"))
 
         if start_date is None or end_date is None:
             raise ConversionError(
                 "date_range start_date or end_date is missing",
                 field="date_range",
-                value=data["date_range"],
+                value=date_range,
             )
 
         return GanttDateRange(start_date=start_date, end_date=end_date)
@@ -54,7 +55,7 @@ def _parse_gantt_tasks(data: dict[str, Any]) -> list[GanttTaskDto]:
         List of GanttTaskDto
     """
     tasks = []
-    for task in data["tasks"]:
+    for task in require_key(data, "tasks"):
         dt_fields = _parse_datetime_fields(
             task,
             ["planned_start", "planned_end", "actual_start", "actual_end", "deadline"],
@@ -62,16 +63,17 @@ def _parse_gantt_tasks(data: dict[str, Any]) -> list[GanttTaskDto]:
 
         tasks.append(
             GanttTaskDto(
-                id=task["id"],
-                name=task["name"],
-                status=TaskStatus[task["status"].upper()],
+                id=require_key(task, "id"),
+                name=require_key(task, "name"),
+                status=TaskStatus[require_key(task, "status").upper()],
                 estimated_duration=task.get("estimated_duration"),
                 planned_start=dt_fields["planned_start"],
                 planned_end=dt_fields["planned_end"],
                 actual_start=dt_fields["actual_start"],
                 actual_end=dt_fields["actual_end"],
                 deadline=dt_fields["deadline"],
-                is_finished=task["status"].upper() in ["COMPLETED", "CANCELED"],
+                is_finished=require_key(task, "status").upper()
+                in ["COMPLETED", "CANCELED"],
             )
         )
     return tasks
@@ -93,7 +95,7 @@ def _parse_task_daily_hours(
     """
     try:
         result: dict[int, dict[date, float]] = {}
-        for task_id, daily_hours in data["task_daily_hours"].items():
+        for task_id, daily_hours in require_key(data, "task_daily_hours").items():
             result[int(task_id)] = _parse_date_dict(
                 {"daily_hours": daily_hours}, "daily_hours"
             )

--- a/packages/taskdog-client/src/taskdog_client/converters/optimization_converters.py
+++ b/packages/taskdog-client/src/taskdog_client/converters/optimization_converters.py
@@ -16,7 +16,7 @@ from taskdog_core.application.dto.optimization_summary import OptimizationSummar
 from taskdog_core.application.dto.task_dto import TaskSummaryDto
 from taskdog_core.shared.utils.datetime_parser import parse_iso_date
 
-from .exceptions import ConversionError
+from .exceptions import ConversionError, require_key
 
 
 def _parse_optimization_summary(
@@ -36,8 +36,8 @@ def _parse_optimization_summary(
     """
     # Calculate days span from start_date and end_date
     try:
-        start_date = parse_iso_date(summary_data["start_date"])
-        end_date = parse_iso_date(summary_data["end_date"])
+        start_date = parse_iso_date(require_key(summary_data, "start_date"))
+        end_date = parse_iso_date(require_key(summary_data, "end_date"))
 
         if start_date is None or end_date is None:
             raise ConversionError(
@@ -56,13 +56,14 @@ def _parse_optimization_summary(
 
     # Create TaskSummaryDto objects for unscheduled tasks from failures
     unscheduled_tasks = [
-        TaskSummaryDto(id=f["task_id"], name=f["task_name"]) for f in failures
+        TaskSummaryDto(id=require_key(f, "task_id"), name=require_key(f, "task_name"))
+        for f in failures
     ]
 
     return OptimizationSummary(
-        new_count=summary_data["scheduled_tasks"],
+        new_count=require_key(summary_data, "scheduled_tasks"),
         rescheduled_count=0,  # API doesn't distinguish between new and rescheduled
-        total_hours=summary_data["total_hours"],
+        total_hours=require_key(summary_data, "total_hours"),
         deadline_conflicts=0,  # Not provided by API
         days_span=days_span,
         unscheduled_tasks=unscheduled_tasks,
@@ -83,8 +84,11 @@ def _parse_scheduling_failures(
     """
     return [
         SchedulingFailure(
-            task=TaskSummaryDto(id=f["task_id"], name=f["task_name"]),
-            reason=f["reason"],
+            task=TaskSummaryDto(
+                id=require_key(f, "task_id"),
+                name=require_key(f, "task_name"),
+            ),
+            reason=require_key(f, "reason"),
         )
         for f in failures_data
     ]
@@ -116,12 +120,14 @@ def convert_to_optimization_output(data: dict[str, Any]) -> OptimizationOutput:
     Returns:
         OptimizationOutput with all optimization results
     """
-    summary = _parse_optimization_summary(data["summary"], data["failures"])
-    failures = _parse_scheduling_failures(data["failures"])
+    summary_data = require_key(data, "summary")
+    failures_data = require_key(data, "failures")
+    summary = _parse_optimization_summary(summary_data, failures_data)
+    failures = _parse_scheduling_failures(failures_data)
 
     # Note: API response doesn't include successful_tasks details
     # We'll create minimal TaskSummaryDto objects
-    successful_count = data["summary"]["scheduled_tasks"]
+    successful_count = require_key(summary_data, "scheduled_tasks")
     successful_tasks = [
         TaskSummaryDto(id=i, name=f"Task {i}") for i in range(successful_count)
     ]

--- a/packages/taskdog-client/src/taskdog_client/converters/task_converters.py
+++ b/packages/taskdog-client/src/taskdog_client/converters/task_converters.py
@@ -11,7 +11,7 @@ from taskdog_core.application.dto.task_list_output import TaskListOutput
 from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 from taskdog_core.application.dto.update_task_output import TaskUpdateOutput
 
-from .exceptions import ConversionError
+from .exceptions import ConversionError, require_key
 from .gantt_converters import convert_to_gantt_output
 
 
@@ -100,7 +100,7 @@ def convert_to_task_list_output(data: dict[str, Any]) -> TaskListOutput:
     Returns:
         TaskListOutput with task list and metadata
     """
-    tasks = [_model_validate(TaskRowDto, task) for task in data["tasks"]]
+    tasks = [_model_validate(TaskRowDto, task) for task in require_key(data, "tasks")]
 
     # Convert gantt data if present (separate reshaping converter)
     gantt_data = None
@@ -109,8 +109,8 @@ def convert_to_task_list_output(data: dict[str, Any]) -> TaskListOutput:
 
     return TaskListOutput(
         tasks=tasks,
-        total_count=data["total_count"],
-        filtered_count=data["filtered_count"],
+        total_count=require_key(data, "total_count"),
+        filtered_count=require_key(data, "filtered_count"),
         gantt_data=gantt_data,
     )
 

--- a/packages/taskdog-client/tests/test_converters.py
+++ b/packages/taskdog-client/tests/test_converters.py
@@ -397,6 +397,49 @@ class TestConverters:
 class TestConverterErrorHandling:
     """Test cases for error handling in converters (Phase 3 refactoring)."""
 
+    @pytest.mark.parametrize(
+        ("converter", "data", "field"),
+        [
+            (
+                convert_to_task_list_output,
+                {"total_count": 0, "filtered_count": 0},
+                "tasks",
+            ),
+            (
+                convert_to_optimization_output,
+                {
+                    "summary": {
+                        "scheduled_tasks": 1,
+                        "total_hours": 1.0,
+                        "start_date": "2025-01-01",
+                        "end_date": "2025-01-01",
+                    }
+                },
+                "failures",
+            ),
+            (
+                convert_to_gantt_output,
+                {
+                    "date_range": {
+                        "start_date": "2025-01-01",
+                        "end_date": "2025-01-31",
+                    },
+                    "tasks": [],
+                    "daily_workload": {},
+                    "holidays": [],
+                },
+                "task_daily_hours",
+            ),
+        ],
+    )
+    def test_missing_response_keys_raise_conversion_error(self, converter, data, field):
+        """Test that hand-written converters wrap missing keys."""
+        with pytest.raises(ConversionError) as exc_info:
+            converter(data)
+
+        assert exc_info.value.field == field
+        assert isinstance(exc_info.value.__cause__, KeyError)
+
     def test_invalid_datetime_format_raises_conversion_error(self):
         """Test that invalid datetime format raises ConversionError."""
         data = {


### PR DESCRIPTION
## Summary
- add a shared `require_key()` helper for API response converters
- wrap missing keys in task list, optimization, and gantt converters as `ConversionError`
- add regression coverage that verifies malformed responses no longer leak raw `KeyError`

## Validation
- `PYTHONPATH=src ../../.venv/bin/python -m pytest tests/ --cov=taskdog_client --cov-report=term-missing:skip-covered --cov-fail-under=80` from `packages/taskdog-client`
- `PATH="$PWD/.venv/bin:$PATH" make lint-client`
- `PATH="$PWD/.venv/bin:$PATH" make typecheck-client`

Closes #967
