### PR TITLE
fix(core): use ISO week keys for trends

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/services/task_statistics_calculator.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/task_statistics_calculator.py
@@ -395,7 +395,8 @@ class TaskStatisticsCalculator:
 
                 # Weekly trend (ISO week)
                 week_start = end_dt - timedelta(days=end_dt.weekday())
-                week_key = week_start.strftime("%Y-W%U")
+                iso_week = week_start.isocalendar()
+                week_key = f"{iso_week.year}-W{iso_week.week:02d}"
                 weekly_trend[week_key] += 1
 
                 # Monthly trend

--- a/packages/taskdog-core/tests/application/services/test_task_statistics_calculator.py
+++ b/packages/taskdog-core/tests/application/services/test_task_statistics_calculator.py
@@ -185,6 +185,23 @@ class TestTaskStatisticsCalculator:
         assert result.trend_stats.last_7_days_completed == 1
         assert result.trend_stats.last_30_days_completed == 2
 
+    def test_weekly_trend_uses_iso_week_year(self):
+        """Test weekly trend keys use ISO week-year at year boundaries."""
+        tasks = [
+            Task(
+                name="Year boundary task",
+                priority=10,
+                id=1,
+                actual_end=datetime(2024, 12, 30, 12, 0),
+                status=TaskStatus.COMPLETED,
+            ),
+        ]
+
+        result = self.calculator.calculate_all(tasks)
+
+        assert result.trend_stats is not None
+        assert result.trend_stats.weekly_completion_trend == {"2025-W01": 1}
+
     def test_filter_by_period_7d(self):
         """Test filtering tasks by 7-day period."""
         now = datetime.now()


### PR DESCRIPTION
## Summary

Fixes the weekly completion trend bucket key so it uses the ISO week-year from the Monday-aligned `week_start` instead of mixing calendar year with the Sunday-based `%U` week number.

The regression test covers the year-boundary case from the bug: a task completed on 2024-12-30 now keys as `2025-W01`.

Fixes #970.

## Verification

- `PYTHONPATH=packages/taskdog-core/src python - <<'PY' ...` behavior check for 2024-12-30 → `{'2025-W01': 1}`
- `python -m compileall -q packages/taskdog-core/src/taskdog_core/application/services/task_statistics_calculator.py packages/taskdog-core/tests/application/services/test_task_statistics_calculator.py`
- `ruff check packages/taskdog-core/src/taskdog_core/application/services/task_statistics_calculator.py packages/taskdog-core/tests/application/services/test_task_statistics_calculator.py`
- `ruff format --check packages/taskdog-core/src/taskdog_core/application/services/task_statistics_calculator.py packages/taskdog-core/tests/application/services/test_task_statistics_calculator.py`
- `git diff --check`

`uv run --package taskdog-core pytest packages/taskdog-core/tests/application/services/test_task_statistics_calculator.py` could not run locally because the sandbox could not resolve PyPI DNS while creating `.venv`.
