### PR TITLE
refactor(core): drop redundant note delete and dead notes_repository

### DIFF
--- a/packages/taskdog-core/README.md
+++ b/packages/taskdog-core/README.md
@@ -79,7 +79,7 @@ repository = SqliteTaskRepository("sqlite:///tasks.db")
 config = ConfigManager()
 
 # Create controller
-crud_controller = TaskCrudController(repository, notes_repository, config)
+crud_controller = TaskCrudController(repository, config)
 
 # Create a task
 from taskdog_core.application.dto.task_request import CreateTaskRequest

--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/remove_task.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/remove_task.py
@@ -3,28 +3,26 @@
 from taskdog_core.application.dto.base import SingleTaskInput
 from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 from taskdog_core.application.use_cases.base import UseCase
-from taskdog_core.domain.repositories.notes_repository import NotesRepository
 from taskdog_core.domain.repositories.task_repository import TaskRepository
 
 
 class RemoveTaskUseCase(UseCase[SingleTaskInput, TaskOperationOutput]):
     """Use case for removing tasks."""
 
-    def __init__(self, repository: TaskRepository, notes_repository: NotesRepository):
+    def __init__(self, repository: TaskRepository):
         """Initialize use case.
 
         Args:
             repository: Task repository for data access
-            notes_repository: Notes repository for notes cleanup
         """
         self.repository = repository
-        self.notes_repository = notes_repository
 
     def execute(self, input_dto: SingleTaskInput) -> TaskOperationOutput:
         """Execute task removal.
 
-        Deletes both the task and its associated notes file (if any).
-        Returns task information captured before deletion.
+        Deletes both the task and its associated notes (if any). Notes are
+        removed in the same transaction via the ``ON DELETE CASCADE`` foreign
+        key. Returns task information captured before deletion.
 
         Args:
             input_dto: Task removal input data

--- a/packages/taskdog-core/src/taskdog_core/controllers/task_crud_controller.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/task_crud_controller.py
@@ -23,7 +23,6 @@ from taskdog_core.application.use_cases.restore_task import RestoreTaskUseCase
 from taskdog_core.application.use_cases.update_task import UpdateTaskUseCase
 from taskdog_core.controllers.base_controller import BaseTaskController
 from taskdog_core.domain.entities.task import TaskStatus
-from taskdog_core.domain.repositories.notes_repository import NotesRepository
 from taskdog_core.domain.repositories.task_repository import TaskRepository
 from taskdog_core.domain.services.holiday_checker import IHolidayChecker
 from taskdog_core.shared.config_manager import Config
@@ -46,13 +45,11 @@ class TaskCrudController(BaseTaskController):
     Attributes:
         repository: Task repository (inherited from BaseTaskController)
         config: Application configuration (inherited from BaseTaskController)
-        notes_repository: Notes repository for managing task notes
     """
 
     def __init__(
         self,
         repository: TaskRepository,
-        notes_repository: NotesRepository,
         config: Config,
         holiday_checker: IHolidayChecker | None = None,
     ):
@@ -60,12 +57,10 @@ class TaskCrudController(BaseTaskController):
 
         Args:
             repository: Task repository
-            notes_repository: Notes repository
             config: Application configuration
             holiday_checker: Holiday checker for workload calculations (optional)
         """
         super().__init__(repository, config)
-        self.notes_repository = notes_repository
         self._holiday_checker = holiday_checker
 
     def create_task(
@@ -239,7 +234,7 @@ class TaskCrudController(BaseTaskController):
         """
         logger.info(f"Removing task permanently: task_id={task_id}")
 
-        use_case = RemoveTaskUseCase(self.repository, self.notes_repository)
+        use_case = RemoveTaskUseCase(self.repository)
         request = SingleTaskInput(task_id=task_id)
         result = use_case.execute(request)
 

--- a/packages/taskdog-core/src/taskdog_core/domain/repositories/notes_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/repositories/notes_repository.py
@@ -50,17 +50,6 @@ class NotesRepository(ABC):
         """
 
     @abstractmethod
-    def delete_notes(self, task_id: int) -> None:
-        """Delete notes for a task.
-
-        Args:
-            task_id: Task ID
-
-        Note:
-            Should not raise error if notes don't exist (idempotent operation)
-        """
-
-    @abstractmethod
     def get_task_ids_with_notes(self, task_ids: list[int]) -> set[int]:
         """Get task IDs that have notes from a list of task IDs.
 

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_notes_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_notes_repository.py
@@ -107,19 +107,6 @@ class SqliteNotesRepository(SqliteBaseRepository, NotesRepository):
                 session.add(note)
             session.commit()
 
-    def delete_notes(self, task_id: int) -> None:
-        """Delete notes for a task.
-
-        Args:
-            task_id: Task ID
-
-        Note:
-            Does not raise error if notes don't exist (idempotent operation)
-        """
-        with self.Session() as session:
-            session.execute(delete(NoteModel).where(NoteModel.task_id == task_id))
-            session.commit()
-
     def get_task_ids_with_notes(self, task_ids: list[int]) -> set[int]:
         """Get task IDs that have notes from a list of task IDs.
 

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_task_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_task_repository.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import delete as sa_delete
 from sqlalchemy import func, select
 
 from taskdog_core.domain.entities.task import Task, TaskStatus
@@ -23,7 +22,6 @@ from taskdog_core.infrastructure.persistence.database.base_repository import (
 )
 from taskdog_core.infrastructure.persistence.database.models import (
     DailyAllocationModel,
-    NoteModel,
     TagModel,
     TaskModel,
     TaskTagModel,
@@ -311,21 +309,16 @@ class SqliteTaskRepository(SqliteBaseRepository, TaskRepository):
             session.commit()
 
     def delete(self, task_id: int) -> None:
-        """Delete a task and its associated notes by ID.
+        """Delete a task by its ID.
 
-        Uses TaskDeleteBuilder to handle DELETE operation.
-        Notes are deleted in the same transaction as the task to ensure
-        atomicity (both succeed or both fail together).
+        Uses TaskDeleteBuilder to handle the DELETE operation. Associated
+        notes (and other child records like task_tags) are removed in the
+        same transaction by the ``ON DELETE CASCADE`` foreign keys.
 
         Args:
             task_id: The ID of the task to delete
         """
         with self.Session() as session:
-            # Delete associated notes first (idempotent — no-op if none exist)
-            session.execute(
-                sa_delete(NoteModel).where(NoteModel.task_id == task_id)
-            )
-            # Then delete the task (CASCADE handles related records like task_tags)
             delete_builder = TaskDeleteBuilder(session)
             delete_builder.delete_task(task_id)
             session.commit()

--- a/packages/taskdog-core/tests/application/use_cases/test_remove_task_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_remove_task_use_case.py
@@ -1,7 +1,5 @@
 """Tests for RemoveTaskUseCase."""
 
-from unittest.mock import MagicMock
-
 import pytest
 
 from taskdog_core.application.dto.base import SingleTaskInput
@@ -16,8 +14,7 @@ class TestRemoveTaskUseCase:
     def setup(self, repository):
         """Set up test fixtures."""
         self.repository = repository
-        self.notes_repository = MagicMock()
-        self.use_case = RemoveTaskUseCase(self.repository, self.notes_repository)
+        self.use_case = RemoveTaskUseCase(self.repository)
 
     def test_remove_task(self):
         """Test removing a task."""
@@ -28,11 +25,8 @@ class TestRemoveTaskUseCase:
         input_dto = SingleTaskInput(task_id=task.id)
         self.use_case.execute(input_dto)
 
-        # Verify task removed
+        # Verify task removed (associated notes cascade via FK)
         assert self.repository.get_by_id(task.id) is None
-
-        # Verify notes deletion was not called separately (handled by repository)
-        self.notes_repository.delete_notes.assert_not_called()
 
     def test_remove_nonexistent_task(self):
         """Test removing a task that doesn't exist."""

--- a/packages/taskdog-core/tests/controllers/test_task_crud_controller.py
+++ b/packages/taskdog-core/tests/controllers/test_task_crud_controller.py
@@ -15,11 +15,9 @@ class TestTaskCrudController:
     def setup(self, repository):
         """Set up test fixtures."""
         self.repository = repository
-        self.notes_repository = MagicMock()
         self.config = MagicMock()
         self.controller = TaskCrudController(
             repository=self.repository,
-            notes_repository=self.notes_repository,
             config=self.config,
         )
 
@@ -115,12 +113,9 @@ class TestTaskCrudController:
         # Act
         self.controller.remove_task(task.id)
 
-        # Assert - task should no longer exist
+        # Assert - task should no longer exist (associated notes cascade via FK)
         deleted_task = self.repository.get_by_id(task.id)
         assert deleted_task is None
-
-        # Assert - notes deletion should be handled by repository, not called separately
-        self.notes_repository.delete_notes.assert_not_called()
 
     def test_controller_inherits_from_base_controller(self):
         """Test that controller has repository and config from base class."""
@@ -132,14 +127,12 @@ class TestTaskCrudController:
     def test_holiday_checker_injected(self, repository):
         """Test that HolidayChecker is properly injected via DI."""
         # Arrange
-        notes_repository = MagicMock()
         config = MagicMock()
         holiday_checker = MagicMock()
 
         # Act
         controller = TaskCrudController(
             repository=repository,
-            notes_repository=notes_repository,
             config=config,
             holiday_checker=holiday_checker,
         )
@@ -150,13 +143,11 @@ class TestTaskCrudController:
     def test_holiday_checker_defaults_to_none(self, repository):
         """Test that HolidayChecker is None when not provided."""
         # Arrange
-        notes_repository = MagicMock()
         config = MagicMock()
 
         # Act
         controller = TaskCrudController(
             repository=repository,
-            notes_repository=notes_repository,
             config=config,
         )
 

--- a/packages/taskdog-core/tests/fixtures/repositories.py
+++ b/packages/taskdog-core/tests/fixtures/repositories.py
@@ -229,11 +229,6 @@ class InMemoryNotesRepository:
         """Write notes for task."""
         self._notes[task_id] = content
 
-    def delete_notes(self, task_id: int) -> None:
-        """Delete notes for task."""
-        if task_id in self._notes:
-            del self._notes[task_id]
-
     def get_task_ids_with_notes(self, task_ids: list[int]) -> set[int]:
         """Get task IDs that have notes from a list of task IDs."""
         return {task_id for task_id in task_ids if self.has_notes(task_id)}

--- a/packages/taskdog-core/tests/infrastructure/persistence/database/test_sqlite_notes_repository.py
+++ b/packages/taskdog-core/tests/infrastructure/persistence/database/test_sqlite_notes_repository.py
@@ -155,26 +155,6 @@ class TestSqliteNotesRepository:
 
         assert repository.read_notes(1) == content
 
-    def test_delete_notes_removes_existing_note(
-        self, repository: SqliteNotesRepository, create_task: Callable[[int], None]
-    ):
-        """Test delete_notes removes existing note."""
-        create_task(1)
-        repository.write_notes(1, "Test content")
-        assert repository.has_notes(1) is True
-
-        repository.delete_notes(1)
-
-        assert repository.has_notes(1) is False
-        assert repository.read_notes(1) is None
-
-    def test_delete_notes_is_idempotent(self, repository: SqliteNotesRepository):
-        """Test delete_notes doesn't raise when note doesn't exist."""
-        # Should not raise any exception
-        repository.delete_notes(999)
-
-        assert repository.has_notes(999) is False
-
     def test_get_task_ids_with_notes_returns_empty_set_for_empty_list(
         self, repository: SqliteNotesRepository
     ):

--- a/packages/taskdog-core/tests/infrastructure/persistence/database/test_sqlite_task_repository.py
+++ b/packages/taskdog-core/tests/infrastructure/persistence/database/test_sqlite_task_repository.py
@@ -807,6 +807,46 @@ class TestSqliteTaskRepository:
             records = session.scalars(stmt).all()
             assert len(records) == 0
 
+    def test_delete_task_cascades_to_notes(self):
+        """Test deleting task also deletes its note (CASCADE).
+
+        The explicit note deletion was removed in favor of the ON DELETE
+        CASCADE foreign key; this guards that the database still cleans up
+        notes when a task is deleted.
+        """
+        from sqlalchemy import select
+
+        from taskdog_core.infrastructure.persistence.database.models import NoteModel
+
+        task = Task(id=1, name="Delete Test", priority=1)
+        self.repository.save(task)
+
+        # Attach a note directly to the task
+        now = datetime(2025, 1, 15, 12, 0, 0)
+        with self.repository.Session() as session:
+            session.add(
+                NoteModel(
+                    task_id=1,
+                    content="some notes",
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+            session.commit()
+
+        # Verify note exists
+        with self.repository.Session() as session:
+            stmt = select(NoteModel).where(NoteModel.task_id == 1)
+            assert len(session.scalars(stmt).all()) == 1
+
+        # Delete task
+        self.repository.delete(1)
+
+        # Verify note is also deleted (CASCADE)
+        with self.repository.Session() as session:
+            stmt = select(NoteModel).where(NoteModel.task_id == 1)
+            assert len(session.scalars(stmt).all()) == 0
+
     # ====================================================================
     # SQL Aggregation Tests for Daily Workload (get_daily_workload_totals)
     # ====================================================================

--- a/packages/taskdog-server/src/taskdog_server/api/dependencies.py
+++ b/packages/taskdog-server/src/taskdog_server/api/dependencies.py
@@ -96,9 +96,7 @@ def initialize_api_context(
     lifecycle_controller = TaskLifecycleController(repository, config)
     relationship_controller = TaskRelationshipController(repository, config)
     analytics_controller = TaskAnalyticsController(repository, config, holiday_checker)
-    crud_controller = TaskCrudController(
-        repository, notes_repository, config, holiday_checker
-    )
+    crud_controller = TaskCrudController(repository, config, holiday_checker)
     audit_log_controller = AuditLogController(audit_log_repository, time_provider)
     notes_controller = NotesController(repository, notes_repository)
 

--- a/packages/taskdog-server/tests/api/test_app.py
+++ b/packages/taskdog-server/tests/api/test_app.py
@@ -50,7 +50,6 @@ class TestApp:
         )
         crud_controller = TaskCrudController(
             self.mock_repository,
-            self.mock_notes_repository,
             self.mock_config,
         )
 

--- a/packages/taskdog-server/tests/conftest.py
+++ b/packages/taskdog-server/tests/conftest.py
@@ -213,9 +213,7 @@ def app(
     analytics_controller = TaskAnalyticsController(
         session_repository, mock_config, None
     )
-    crud_controller = TaskCrudController(
-        session_repository, session_notes_repository, mock_config
-    )
+    crud_controller = TaskCrudController(session_repository, mock_config)
     audit_log_controller = AuditLogController(
         session_audit_log_repository, SystemTimeProvider()
     )


### PR DESCRIPTION
## Description

Cleanup follow-up to #972. That PR made task removal atomic by moving note cleanup into `SqliteTaskRepository.delete()`, but left two pieces of dead code behind. This removes them.

## Related Issue

Closes #985

## Type of Change

- [x] Refactoring (no functional changes)

## Changes Made

- **Drop the redundant explicit note delete.** `SqliteTaskRepository.delete()` ran an explicit `DELETE FROM notes` before deleting the task. This is redundant: the `notes` FK is declared `ON DELETE CASCADE` (migration `004_add_notes_table.py` + `NoteModel`) and `PRAGMA foreign_keys=ON` is set per connection (`engine_factory.py`), so the database already removes notes when the task row is deleted. Removed the statement and its now-unused `sa_delete` / `NoteModel` imports.
- **Drop the dead `notes_repository` injection.** `RemoveTaskUseCase` still received and stored a `notes_repository` it never used (since #972), threaded down from `TaskCrudController` and the server DI wiring. Removed the parameter from both and updated `dependencies.py` and the core README example.
- **Remove the now-orphaned `NotesRepository.delete_notes()`.** With no production caller left, the abstract method and its SQLite implementation are dead. Removed both (the user-facing "clear notes" path uses `write_notes(id, "")`, a separate code path, and is unaffected).
- **Add a regression test** (`test_delete_task_cascades_to_notes`) asserting task deletion cascades to its note, locking in the FK behavior the refactor now relies on.

## Testing

### Test Environment

- OS: WSL2 (Ubuntu) on Windows 11
- Python version: 3.13.13
- UV version: latest

### Tests Performed

- [x] Unit tests pass (`make test`)
- [x] Added new tests for new features

`make check` (lint + typecheck + spell + deadcode) clean across all packages. `make test-core` → 1102 passed (94.02% cov); `make test-server` → 307 passed (89.79% cov).

## Code Quality Checklist

- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] Code is formatted (`make format`)
- [x] No new warnings introduced
- [x] Code follows project conventions

## Documentation

- [x] Updated README.md (if needed) — updated the `TaskCrudController` example in `packages/taskdog-core/README.md`
- [ ] Updated CLAUDE.md (if architecture changed) — N/A
- [ ] Updated CHANGELOG.md — N/A, internal-only refactor with no user-facing change

## Package Affected

- [x] taskdog-core
- [x] taskdog-server

## Breaking Changes

- [ ] This PR includes breaking changes

None. `NotesRepository.delete_notes()` had no production callers; the public API (CLI, REST endpoints, TUI) and DB behavior are unchanged.

## Checklist

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
