### PR TITLE
fix(core): include existing round-robin allocations

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/services/optimization/round_robin_optimization_strategy.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/optimization/round_robin_optimization_strategy.py
@@ -82,7 +82,7 @@ class RoundRobinOptimizationStrategy(OptimizationStrategy):
         task_daily_allocations: dict[int, dict[date, float]] = {
             task.id: {} for task in schedulable_tasks if task.id is not None
         }
-        daily_allocations: dict[date, float] = {}
+        daily_allocations: dict[date, float] = dict(existing_allocations)
 
         # Track start and end dates for each task
         task_start_dates: dict[int, datetime] = {}
@@ -230,7 +230,9 @@ class RoundRobinOptimizationStrategy(OptimizationStrategy):
                     task_start_dates[task_id] = current_date
                 task_end_dates[task_id] = current_date
 
-            daily_allocations[date_obj] = daily_total
+            daily_allocations[date_obj] = (
+                daily_allocations.get(date_obj, 0.0) + daily_total
+            )
 
             # Move to next day
             current_date += timedelta(days=1)

--- a/packages/taskdog-core/tests/application/services/optimization/test_round_robin_optimization_strategy.py
+++ b/packages/taskdog-core/tests/application/services/optimization/test_round_robin_optimization_strategy.py
@@ -2,6 +2,7 @@
 
 from datetime import date, datetime
 
+from taskdog_core.domain.entities.task import TaskStatus
 from tests.application.services.optimization.optimization_strategy_test_base import (
     BaseOptimizationStrategyTest,
 )
@@ -177,6 +178,49 @@ class TestRoundRobinOptimizationStrategy(BaseOptimizationStrategyTest):
             abs(updated_task.daily_allocations.get(date(2025, 10, 21), 0.0) - 6.0)
             < 1e-5
         )
+
+    def test_round_robin_result_includes_existing_allocations(self):
+        """Test result totals include fixed/in-progress allocations plus new hours."""
+        fixed_task = self.create_task(
+            "Fixed Task",
+            estimated_duration=3.0,
+            deadline=datetime(2025, 10, 31, 18, 0, 0),
+            is_fixed=True,
+        )
+        fixed_task.planned_start = datetime(2025, 10, 20, 9, 0, 0)
+        fixed_task.planned_end = datetime(2025, 10, 20, 12, 0, 0)
+        fixed_task.daily_allocations = {date(2025, 10, 20): 3.0}
+        self.repository.save(fixed_task)
+
+        in_progress_task = self.create_task(
+            "In Progress Task",
+            estimated_duration=1.0,
+            deadline=datetime(2025, 10, 31, 18, 0, 0),
+        )
+        in_progress_task.status = TaskStatus.IN_PROGRESS
+        in_progress_task.planned_start = datetime(2025, 10, 20, 12, 0, 0)
+        in_progress_task.planned_end = datetime(2025, 10, 20, 13, 0, 0)
+        in_progress_task.daily_allocations = {date(2025, 10, 20): 1.0}
+        self.repository.save(in_progress_task)
+
+        regular_task = self.create_task(
+            "Regular Task",
+            estimated_duration=2.0,
+            deadline=datetime(2025, 10, 31, 18, 0, 0),
+        )
+
+        result = self.optimize_schedule(
+            start_date=datetime(2025, 10, 20, 9, 0, 0),
+            max_hours_per_day=6.0,
+            force_override=True,
+        )
+
+        assert len(result.successful_tasks) == 1
+        assert result.daily_allocations[date(2025, 10, 20)] == 6.0
+
+        updated_regular = self.repository.get_by_id(regular_task.id)
+        assert updated_regular is not None
+        assert updated_regular.daily_allocations == {date(2025, 10, 20): 2.0}
 
     def test_round_robin_adjusts_allocation_as_tasks_complete(self):
         """Test that round-robin adjusts allocation as tasks complete."""


### PR DESCRIPTION
Fixes #965.

## Summary
Round-robin scheduling already subtracts fixed and in-progress work when deciding how many hours are available on a day, but the returned `result.daily_allocations` started from an empty map. That meant the API response reported only the newly scheduled hours and omitted protected pre-existing workload.

This seeds the round-robin result totals from `existing_allocations`, then accumulates newly scheduled round-robin hours into those same daily totals. Per-task `daily_allocations` for newly scheduled tasks remain unchanged.

The regression test covers fixed plus `IN_PROGRESS` allocations on the same day as a newly scheduled task: the result total includes all 6 hours, while the scheduled task still records only its own 2-hour allocation.

Verification:
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=src pytest tests/application/services/optimization/test_round_robin_optimization_strategy.py`
- `ruff check --config ../../pyproject.toml src/taskdog_core/application/services/optimization/round_robin_optimization_strategy.py tests/application/services/optimization/test_round_robin_optimization_strategy.py`
- `git diff --check`
