### PR TITLE
refactor(server): consolidate audit log boilerplate in API routers

### DIFF
--- a/packages/taskdog-server/src/taskdog_server/api/audit_helpers.py
+++ b/packages/taskdog-server/src/taskdog_server/api/audit_helpers.py
@@ -1,0 +1,82 @@
+"""Shared helpers for audit logging in API routers.
+
+Consolidates the audit-log boilerplate that was repeated across routers:
+value serialization, capturing pre-change task state, diffing changed fields,
+and the task-resource ``log_operation`` call.
+"""
+
+from datetime import date, datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from taskdog_core.controllers.audit_log_controller import AuditLogController
+    from taskdog_core.controllers.query_controller import QueryController
+
+
+def serialize_audit_value(val: object) -> object:
+    """Serialize a value for JSON-safe audit logging."""
+    if hasattr(val, "value"):
+        val = val.value
+    if isinstance(val, datetime):
+        val = val.isoformat()
+    if isinstance(val, dict):
+        val = {
+            k.isoformat() if isinstance(k, (date, datetime)) else k: (
+                v.isoformat() if isinstance(v, (date, datetime)) else v
+            )
+            for k, v in val.items()
+        }
+    return val
+
+
+def capture_old_task(query_controller: "QueryController", task_id: int) -> Any:
+    """Fetch a task's pre-change state for the audit trail.
+
+    Returns the task detail DTO, or ``None`` if it cannot be retrieved, so the
+    caller can still log the operation without old values.
+    """
+    try:
+        output = query_controller.get_task_by_id(task_id)
+        return output.task if output else None
+    except Exception:
+        return None
+
+
+def diff_task_fields(
+    old_task: Any, new_task: Any, fields: list[str]
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Build serialized old/new value dicts for the given fields.
+
+    Skips fields absent on either side. Returns ``(None, None)`` when there is
+    nothing to record (no old task, or no matching fields).
+    """
+    old_values: dict[str, Any] = {}
+    new_values: dict[str, Any] = {}
+    if old_task is not None:
+        for field in fields:
+            if hasattr(old_task, field) and hasattr(new_task, field):
+                old_values[field] = serialize_audit_value(getattr(old_task, field))
+                new_values[field] = serialize_audit_value(getattr(new_task, field))
+    return old_values or None, new_values or None
+
+
+def log_task_operation(
+    audit_controller: "AuditLogController",
+    *,
+    operation: str,
+    task: Any,
+    client_name: str | None,
+    old_values: dict[str, Any] | None = None,
+    new_values: dict[str, Any] | None = None,
+) -> None:
+    """Log a successful ``task``-resource operation with task id/name defaults."""
+    audit_controller.log_operation(
+        operation=operation,
+        resource_type="task",
+        resource_id=task.id,
+        resource_name=task.name,
+        client_name=client_name,
+        old_values=old_values,
+        new_values=new_values,
+        success=True,
+    )

--- a/packages/taskdog-server/src/taskdog_server/api/routers/lifecycle.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/lifecycle.py
@@ -1,9 +1,15 @@
 """Task lifecycle endpoints (status changes with time tracking)."""
 
 from dataclasses import dataclass
+from typing import Any
 
 from fastapi import APIRouter
 
+from taskdog_server.api.audit_helpers import (
+    capture_old_task,
+    log_task_operation,
+    serialize_audit_value,
+)
 from taskdog_server.api.dependencies import (
     AuditLogControllerDep,
     AuthenticatedClientDep,
@@ -55,16 +61,13 @@ def _create_lifecycle_endpoint(op: LifecycleOperation) -> None:
             result.task, result.old_status.value, client_name
         )
 
-        # Audit log
-        audit_controller.log_operation(
+        log_task_operation(
+            audit_controller,
             operation=f"{op.name}_task",
-            resource_type="task",
-            resource_id=task_id,
-            resource_name=result.task.name,
+            task=result.task,
             client_name=client_name,
             old_values={"status": result.old_status.value},
             new_values={"status": result.task.status.value},
-            success=True,
         )
 
         return TaskOperationResponse.from_dto(result.task)
@@ -105,11 +108,7 @@ async def fix_actual_times(
         HTTPException: 404 if task not found, 400 if validation fails
     """
     # Get old values before update for audit trail
-    try:
-        old_task_output = query_controller.get_task_by_id(task_id)
-        old_task = old_task_output.task if old_task_output else None
-    except Exception:
-        old_task = None
+    old_task = capture_old_task(query_controller, task_id)
 
     # Determine values to pass (Ellipsis = keep current)
     actual_start = (
@@ -143,38 +142,24 @@ async def fix_actual_times(
         result, ["actual_start", "actual_end", "actual_duration"], client_name
     )
 
-    # Audit log with old values
-    old_values: dict[str, str | None] = {}
-    if old_task:
-        old_values["actual_start"] = (
-            old_task.actual_start.isoformat() if old_task.actual_start else None
-        )
-        old_values["actual_end"] = (
-            old_task.actual_end.isoformat() if old_task.actual_end else None
-        )
-        old_values["actual_duration"] = (
-            str(old_task.actual_duration)
-            if old_task.actual_duration is not None
-            else None
-        )
+    # Audit log with old/new values; actual_duration stays a string to preserve
+    # the existing log format, datetimes go through the shared serializer.
+    def _actual_values(task: Any) -> dict[str, Any]:
+        return {
+            "actual_start": serialize_audit_value(task.actual_start),
+            "actual_end": serialize_audit_value(task.actual_end),
+            "actual_duration": str(task.actual_duration)
+            if task.actual_duration is not None
+            else None,
+        }
 
-    audit_controller.log_operation(
+    log_task_operation(
+        audit_controller,
         operation="fix_actual_times",
-        resource_type="task",
-        resource_id=task_id,
-        resource_name=result.name,
+        task=result,
         client_name=client_name,
-        old_values=old_values or None,
-        new_values={
-            "actual_start": result.actual_start.isoformat()
-            if result.actual_start
-            else None,
-            "actual_end": result.actual_end.isoformat() if result.actual_end else None,
-            "actual_duration": str(result.actual_duration)
-            if result.actual_duration is not None
-            else None,
-        },
-        success=True,
+        old_values=_actual_values(old_task) if old_task else None,
+        new_values=_actual_values(result),
     )
 
     return TaskOperationResponse.from_dto(result)

--- a/packages/taskdog-server/src/taskdog_server/api/routers/relationships.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/relationships.py
@@ -2,6 +2,7 @@
 
 from fastapi import APIRouter
 
+from taskdog_server.api.audit_helpers import log_task_operation
 from taskdog_server.api.dependencies import (
     AuditLogControllerDep,
     AuthenticatedClientDep,
@@ -47,15 +48,12 @@ async def add_dependency(
     # Broadcast WebSocket event in background
     broadcaster.task_updated(result, ["depends_on"], client_name)
 
-    # Audit log
-    audit_controller.log_operation(
+    log_task_operation(
+        audit_controller,
         operation="add_dependency",
-        resource_type="task",
-        resource_id=task_id,
-        resource_name=result.name,
+        task=result,
         client_name=client_name,
         new_values={"added_dependency": request.depends_on_id},
-        success=True,
     )
 
     return TaskOperationResponse.from_dto(result)
@@ -93,15 +91,12 @@ async def remove_dependency(
     # Broadcast WebSocket event in background
     broadcaster.task_updated(result, ["depends_on"], client_name)
 
-    # Audit log
-    audit_controller.log_operation(
+    log_task_operation(
+        audit_controller,
         operation="remove_dependency",
-        resource_type="task",
-        resource_id=task_id,
-        resource_name=result.name,
+        task=result,
         client_name=client_name,
         old_values={"removed_dependency": depends_on_id},
-        success=True,
     )
 
     return TaskOperationResponse.from_dto(result)
@@ -137,15 +132,12 @@ async def set_task_tags(
     # Broadcast WebSocket event in background
     broadcaster.task_updated(result, ["tags"], client_name)
 
-    # Audit log
-    audit_controller.log_operation(
+    log_task_operation(
+        audit_controller,
         operation="set_tags",
-        resource_type="task",
-        resource_id=task_id,
-        resource_name=result.name,
+        task=result,
         client_name=client_name,
         new_values={"tags": list(result.tags)},
-        success=True,
     )
 
     return TaskOperationResponse.from_dto(result)

--- a/packages/taskdog-server/src/taskdog_server/api/routers/tasks.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/tasks.py
@@ -1,11 +1,15 @@
 """CRUD endpoints for task management."""
 
-from datetime import date, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Query, status
 
 from taskdog_core.application.dto.query_inputs import ListTasksInput
+from taskdog_server.api.audit_helpers import (
+    capture_old_task,
+    diff_task_fields,
+    log_task_operation,
+)
 from taskdog_server.api.converters import (
     convert_to_task_detail_response,
     convert_to_task_list_response,
@@ -29,22 +33,6 @@ from taskdog_server.api.models.responses import (
 from taskdog_server.api.utils import parse_iso_date
 
 router = APIRouter()
-
-
-def _serialize_audit_value(val: object) -> object:
-    """Serialize a value for JSON-safe audit logging."""
-    if hasattr(val, "value"):
-        val = val.value
-    if isinstance(val, datetime):
-        val = val.isoformat()
-    if isinstance(val, dict):
-        val = {
-            k.isoformat() if isinstance(k, (date, datetime)) else k: (
-                v.isoformat() if isinstance(v, (date, datetime)) else v
-            )
-            for k, v in val.items()
-        }
-    return val
 
 
 @router.post(
@@ -86,19 +74,16 @@ async def create_task(
     # Broadcast WebSocket event in background
     broadcaster.task_created(result, client_name)
 
-    # Audit log
-    audit_controller.log_operation(
+    log_task_operation(
+        audit_controller,
         operation="create_task",
-        resource_type="task",
-        resource_id=result.id,
-        resource_name=result.name,
+        task=result,
         client_name=client_name,
         new_values={
             "name": result.name,
             "priority": result.priority,
             "status": result.status.value,
         },
-        success=True,
     )
 
     return TaskOperationResponse.from_dto(result)
@@ -228,14 +213,9 @@ async def update_task(
     Raises:
         HTTPException: 404 if task not found, 400 if validation fails
     """
-    # Get old values before update for audit trail
-    # Handle potential errors gracefully - if we can't get old values,
-    # proceed with update but log without old values
-    try:
-        old_task_output = query_controller.get_task_by_id(task_id)
-        old_task = old_task_output.task if old_task_output else None
-    except Exception:
-        old_task = None
+    # Get old values before update for audit trail; if unavailable, the update
+    # still proceeds and is logged without old values.
+    old_task = capture_old_task(query_controller, task_id)
 
     result = controller.update_task(
         task_id=task_id,
@@ -253,24 +233,16 @@ async def update_task(
     # Broadcast WebSocket event in background
     broadcaster.task_updated(result.task, result.updated_fields, client_name)
 
-    # Audit log with old/new values for updated fields
-    old_values = {}
-    new_values = {}
-    if old_task:
-        for field in result.updated_fields:
-            if hasattr(old_task, field) and hasattr(result.task, field):
-                old_values[field] = _serialize_audit_value(getattr(old_task, field))
-                new_values[field] = _serialize_audit_value(getattr(result.task, field))
-
-    audit_controller.log_operation(
+    old_values, new_values = diff_task_fields(
+        old_task, result.task, result.updated_fields
+    )
+    log_task_operation(
+        audit_controller,
         operation="update_task",
-        resource_type="task",
-        resource_id=task_id,
-        resource_name=result.task.name,
+        task=result.task,
         client_name=client_name,
-        old_values=old_values or None,
-        new_values=new_values or None,
-        success=True,
+        old_values=old_values,
+        new_values=new_values,
     )
 
     return convert_to_update_task_response(result)
@@ -304,16 +276,13 @@ async def archive_task(
     # Broadcast WebSocket event in background
     broadcaster.task_updated(result, ["is_archived"], client_name)
 
-    # Audit log
-    audit_controller.log_operation(
+    log_task_operation(
+        audit_controller,
         operation="archive_task",
-        resource_type="task",
-        resource_id=task_id,
-        resource_name=result.name,
+        task=result,
         client_name=client_name,
         old_values={"is_archived": False},
         new_values={"is_archived": True},
-        success=True,
     )
 
     return TaskOperationResponse.from_dto(result)
@@ -347,16 +316,13 @@ async def restore_task(
     # Broadcast WebSocket event in background
     broadcaster.task_updated(result, ["is_archived"], client_name)
 
-    # Audit log
-    audit_controller.log_operation(
+    log_task_operation(
+        audit_controller,
         operation="restore_task",
-        resource_type="task",
-        resource_id=task_id,
-        resource_name=result.name,
+        task=result,
         client_name=client_name,
         old_values={"is_archived": True},
         new_values={"is_archived": False},
-        success=True,
     )
 
     return TaskOperationResponse.from_dto(result)
@@ -390,14 +356,11 @@ async def delete_task(
     # Broadcast WebSocket event in background
     broadcaster.task_deleted(task_id, result.name, client_name)
 
-    # Audit log
-    audit_controller.log_operation(
+    log_task_operation(
+        audit_controller,
         operation="delete_task",
-        resource_type="task",
-        resource_id=task_id,
-        resource_name=result.name,
+        task=result,
         client_name=client_name,
-        success=True,
     )
 
     return TaskOperationResponse.from_dto(result)

--- a/packages/taskdog-server/tests/api/test_audit_helpers.py
+++ b/packages/taskdog-server/tests/api/test_audit_helpers.py
@@ -1,0 +1,105 @@
+"""Tests for shared audit logging helpers."""
+
+from datetime import date, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from taskdog_core.domain.entities.task import TaskStatus
+from taskdog_server.api.audit_helpers import (
+    capture_old_task,
+    diff_task_fields,
+    log_task_operation,
+    serialize_audit_value,
+)
+
+
+class TestSerializeAuditValue:
+    def test_enum_uses_value(self):
+        assert serialize_audit_value(TaskStatus.IN_PROGRESS) == "IN_PROGRESS"
+
+    def test_datetime_uses_isoformat(self):
+        dt = datetime(2026, 1, 2, 18, 0, 0)
+        assert serialize_audit_value(dt) == dt.isoformat()
+
+    def test_dict_keys_and_values_serialized(self):
+        d = {date(2026, 1, 2): 3.0}
+        assert serialize_audit_value(d) == {"2026-01-02": 3.0}
+
+    def test_primitive_passthrough(self):
+        assert serialize_audit_value(5) == 5
+        assert serialize_audit_value("x") == "x"
+        assert serialize_audit_value(None) is None
+
+
+class TestCaptureOldTask:
+    def test_returns_task_when_present(self):
+        task = SimpleNamespace(id=1, name="t")
+        qc = MagicMock()
+        qc.get_task_by_id.return_value = SimpleNamespace(task=task)
+        assert capture_old_task(qc, 1) is task
+
+    def test_returns_none_when_output_task_is_none(self):
+        qc = MagicMock()
+        qc.get_task_by_id.return_value = SimpleNamespace(task=None)
+        assert capture_old_task(qc, 1) is None
+
+    def test_returns_none_on_exception(self):
+        qc = MagicMock()
+        qc.get_task_by_id.side_effect = RuntimeError("boom")
+        assert capture_old_task(qc, 1) is None
+
+
+class TestDiffTaskFields:
+    def test_serializes_old_and_new_for_changed_fields(self):
+        old = SimpleNamespace(name="old", priority=1)
+        new = SimpleNamespace(name="new", priority=2)
+        old_values, new_values = diff_task_fields(old, new, ["name", "priority"])
+        assert old_values == {"name": "old", "priority": 1}
+        assert new_values == {"name": "new", "priority": 2}
+
+    def test_skips_missing_attributes(self):
+        old = SimpleNamespace(name="old")
+        new = SimpleNamespace(name="new")
+        old_values, new_values = diff_task_fields(old, new, ["name", "ghost"])
+        assert old_values == {"name": "old"}
+        assert new_values == {"name": "new"}
+
+    def test_serializes_enum_and_datetime(self):
+        dt = datetime(2026, 1, 2, 18, 0, 0)
+        old = SimpleNamespace(status=TaskStatus.PENDING, planned_start=None)
+        new = SimpleNamespace(status=TaskStatus.IN_PROGRESS, planned_start=dt)
+        old_values, new_values = diff_task_fields(old, new, ["status", "planned_start"])
+        assert old_values == {"status": "PENDING", "planned_start": None}
+        assert new_values == {"status": "IN_PROGRESS", "planned_start": dt.isoformat()}
+
+    def test_returns_none_for_empty_result(self):
+        old = SimpleNamespace()
+        new = SimpleNamespace()
+        assert diff_task_fields(old, new, []) == (None, None)
+
+    def test_returns_none_when_old_is_none(self):
+        new = SimpleNamespace(name="new")
+        assert diff_task_fields(None, new, ["name"]) == (None, None)
+
+
+class TestLogTaskOperation:
+    def test_defaults_task_resource_fields(self):
+        audit = MagicMock()
+        task = SimpleNamespace(id=7, name="Task 7")
+        log_task_operation(
+            audit,
+            operation="create_task",
+            task=task,
+            client_name="cli",
+            new_values={"name": "Task 7"},
+        )
+        audit.log_operation.assert_called_once_with(
+            operation="create_task",
+            resource_type="task",
+            resource_id=7,
+            resource_name="Task 7",
+            client_name="cli",
+            old_values=None,
+            new_values={"name": "Task 7"},
+            success=True,
+        )


### PR DESCRIPTION
## Summary

Extracts the audit-log boilerplate that was hand-rolled across the tasks,
lifecycle, and relationships routers into a shared `api/audit_helpers.py`.

New pure helpers:
- `serialize_audit_value` — the former file-local `_serialize_audit_value` in `tasks.py`, now public and reusable
- `capture_old_task` — unifies the duplicated double-fetch + broad `try/except` for pre-change values
- `diff_task_fields` — the `updated_fields` getattr/serialize loop
- `log_task_operation` — defaults `resource_type="task"`, `success=True`, and the task id/name, removing the repeated arguments

Applied to 11 endpoints (tasks: create/update/archive/restore/delete; lifecycle: 5 status ops + fix_actual; relationships: add/remove dependency, set_tags). Router code shrinks by ~60 lines net.

## Scope decisions
- `notes.py` / `bulk.py` keep direct `log_operation` calls: they source `resource_name` differently (`task_name`, or `r.task` may be `None`) and have no serialize/old-value needs, so bending the helper to fit them wasn't worth it.
- `tags.py` (`resource_type="tag"`) and `analytics.py` optimize (`"schedule"`) are out of scope — they log non-task resources.

## Behavior
Unchanged. Verified by the existing audit integration tests. `fix_actual_times` keeps recording `actual_duration` as a string to preserve the current log format; datetimes now go through the shared serializer.

## Verification
- taskdog-core: 1105 passed
- taskdog-server: 319 passed (306 existing + 13 new helper tests)
- mypy: success; ruff check + format: clean

Closes #864