### PR TITLE
refactor(tui): inject dependencies into EventHandlerRegistry instead of app reference

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -275,7 +275,12 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         self.command_factory = CommandFactory(self, self.context)
 
         # Initialize WebSocket handler for message processing
-        self.websocket_handler = WebSocketHandler(self)
+        self.websocket_handler = WebSocketHandler(
+            notify=self.notify,
+            reload_tasks=self.request_reload,
+            set_client_id=self.api_client.set_client_id,
+            get_client_id=lambda: self.api_client.client_id,
+        )
 
         # TaskUIManager will be initialized in on_mount (needs MainScreen)
         self.task_ui_manager: TaskUIManager | None = None

--- a/packages/taskdog-ui/src/taskdog/tui/services/event_handler_registry.py
+++ b/packages/taskdog-ui/src/taskdog/tui/services/event_handler_registry.py
@@ -5,10 +5,18 @@ to their appropriate handlers, replacing if-elif chains with a lookup table.
 """
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal, Protocol
 
-if TYPE_CHECKING:
-    from taskdog.tui.app import TaskdogTUI
+
+class NotifyFn(Protocol):
+    """Callable that surfaces a notification to the user."""
+
+    def __call__(
+        self,
+        message: str,
+        *,
+        severity: Literal["information", "warning", "error"] = ...,
+    ) -> None: ...
 
 
 class EventHandlerRegistry:
@@ -18,13 +26,26 @@ class EventHandlerRegistry:
     dispatch mechanism for incoming WebSocket messages.
     """
 
-    def __init__(self, app: "TaskdogTUI"):
+    def __init__(
+        self,
+        *,
+        notify: NotifyFn,
+        reload_tasks: Callable[[], None],
+        set_client_id: Callable[[str], None],
+        get_client_id: Callable[[], str | None],
+    ) -> None:
         """Initialize the event handler registry.
 
         Args:
-            app: The TaskdogTUI application instance
+            notify: Show a notification to the user.
+            reload_tasks: Trigger the app's debounced task-list reload.
+            set_client_id: Record this client's ID (from the connected event).
+            get_client_id: Read this client's current ID.
         """
-        self.app = app
+        self._notify = notify
+        self._reload_tasks = reload_tasks
+        self._set_client_id = set_client_id
+        self._get_client_id = get_client_id
         self._handlers: dict[str, Callable[[dict[str, Any]], None]] = {}
         self._register_handlers()
 
@@ -60,7 +81,7 @@ class EventHandlerRegistry:
         """
         client_id = message.get("client_id")
         if client_id:
-            self.app.api_client.set_client_id(client_id)
+            self._set_client_id(client_id)
 
     def _handle_task_event(
         self,
@@ -91,7 +112,7 @@ class EventHandlerRegistry:
             details=details,
             source_client_id=display_source,
         )
-        self.app.notify(msg, severity=severity)
+        self._notify(msg, severity=severity)
 
     def _handle_task_created(self, message: dict[str, Any]) -> None:
         """Handle task created event."""
@@ -136,7 +157,7 @@ class EventHandlerRegistry:
         msg = TUIMessageBuilder.schedule_optimized(
             algorithm, scheduled_count, failed_count
         )
-        self.app.notify(msg, severity="information")
+        self._notify(msg, severity="information")
 
     def _handle_bulk_operation_completed(self, message: dict[str, Any]) -> None:
         """Handle bulk operation completed event."""
@@ -147,13 +168,9 @@ class EventHandlerRegistry:
         total = success_count + failure_count
         msg = f"Bulk {operation}: {success_count}/{total} succeeded"
         if failure_count > 0:
-            self.app.notify(msg, severity="warning")
+            self._notify(msg, severity="warning")
         else:
-            self.app.notify(msg, severity="information")
-
-    def _reload_tasks(self) -> None:
-        """Reload tasks via the app's single debounced reload funnel."""
-        self.app.request_reload()
+            self._notify(msg, severity="information")
 
     def _get_display_source(self, message: dict[str, Any]) -> str | None:
         """Get display source (user name or client ID) if different from this client.
@@ -173,7 +190,7 @@ class EventHandlerRegistry:
         source_client_id = message.get("source_client_id")
         if (
             isinstance(source_client_id, str)
-            and source_client_id != self.app.api_client.client_id
+            and source_client_id != self._get_client_id()
         ):
             return source_client_id
         return None

--- a/packages/taskdog-ui/src/taskdog/tui/services/websocket_handler.py
+++ b/packages/taskdog-ui/src/taskdog/tui/services/websocket_handler.py
@@ -4,12 +4,13 @@ This module provides WebSocket message handling logic separated from
 the main app class for better separation of concerns.
 """
 
-from typing import TYPE_CHECKING, Any
+from collections.abc import Callable
+from typing import Any
 
-from taskdog.tui.services.event_handler_registry import EventHandlerRegistry
-
-if TYPE_CHECKING:
-    from taskdog.tui.app import TaskdogTUI
+from taskdog.tui.services.event_handler_registry import (
+    EventHandlerRegistry,
+    NotifyFn,
+)
 
 
 class WebSocketHandler:
@@ -19,14 +20,28 @@ class WebSocketHandler:
     to the EventHandlerRegistry for dispatch.
     """
 
-    def __init__(self, app: "TaskdogTUI"):
+    def __init__(
+        self,
+        *,
+        notify: NotifyFn,
+        reload_tasks: Callable[[], None],
+        set_client_id: Callable[[str], None],
+        get_client_id: Callable[[], str | None],
+    ) -> None:
         """Initialize the WebSocket handler.
 
         Args:
-            app: The TaskdogTUI application instance
+            notify: Show a notification to the user.
+            reload_tasks: Trigger the app's debounced task-list reload.
+            set_client_id: Record this client's ID (from the connected event).
+            get_client_id: Read this client's current ID.
         """
-        self.app = app
-        self.registry = EventHandlerRegistry(app)
+        self.registry = EventHandlerRegistry(
+            notify=notify,
+            reload_tasks=reload_tasks,
+            set_client_id=set_client_id,
+            get_client_id=get_client_id,
+        )
 
     def handle_message(self, message: dict[str, Any]) -> None:
         """Handle incoming WebSocket messages.

--- a/packages/taskdog-ui/tests/tui/services/test_event_handler_registry.py
+++ b/packages/taskdog-ui/tests/tui/services/test_event_handler_registry.py
@@ -11,18 +11,20 @@ class TestEventHandlerRegistry:
     @pytest.fixture(autouse=True)
     def setup(self) -> None:
         """Set up test fixtures."""
-        self.mock_app = MagicMock()
-        self.mock_app.api_client = MagicMock()
-        self.mock_app.api_client.client_id = "test-client-id"
-        self.mock_app.task_ui_manager = MagicMock()
-        self.mock_app.notify = MagicMock()
-        # Set main_screen to None by default to avoid audit panel refresh
-        self.mock_app.main_screen = None
+        self.notify = MagicMock()
+        self.reload_tasks = MagicMock()
+        self.set_client_id = MagicMock()
+        self.get_client_id = MagicMock(return_value="test-client-id")
 
         # Import here to avoid circular import issues
         from taskdog.tui.services.event_handler_registry import EventHandlerRegistry
 
-        self.registry = EventHandlerRegistry(self.mock_app)
+        self.registry = EventHandlerRegistry(
+            notify=self.notify,
+            reload_tasks=self.reload_tasks,
+            set_client_id=self.set_client_id,
+            get_client_id=self.get_client_id,
+        )
 
     def test_handlers_registered(self) -> None:
         """Test that all expected handlers are registered."""
@@ -42,13 +44,13 @@ class TestEventHandlerRegistry:
         """Test that connected event sets client ID in API client."""
         message = {"type": "connected", "client_id": "new-client-id"}
         self.registry.dispatch(message)
-        self.mock_app.api_client.set_client_id.assert_called_once_with("new-client-id")
+        self.set_client_id.assert_called_once_with("new-client-id")
 
     def test_dispatch_connected_without_client_id(self) -> None:
         """Test that connected event without client_id doesn't fail."""
         message = {"type": "connected"}
         self.registry.dispatch(message)
-        self.mock_app.api_client.set_client_id.assert_not_called()
+        self.set_client_id.assert_not_called()
 
     def test_dispatch_task_created_reloads_tasks(self) -> None:
         """Test that task_created event triggers task reload."""
@@ -58,8 +60,8 @@ class TestEventHandlerRegistry:
             "task_name": "New Task",
         }
         self.registry.dispatch(message)
-        self.mock_app.request_reload.assert_called_once()
-        self.mock_app.notify.assert_called_once()
+        self.reload_tasks.assert_called_once()
+        self.notify.assert_called_once()
 
     def test_dispatch_task_updated_shows_fields(self) -> None:
         """Test that task_updated event shows updated fields."""
@@ -70,8 +72,8 @@ class TestEventHandlerRegistry:
             "updated_fields": ["priority", "deadline"],
         }
         self.registry.dispatch(message)
-        self.mock_app.request_reload.assert_called_once()
-        self.mock_app.notify.assert_called_once()
+        self.reload_tasks.assert_called_once()
+        self.notify.assert_called_once()
 
     def test_dispatch_task_deleted_shows_warning(self) -> None:
         """Test that task_deleted event shows warning notification."""
@@ -81,10 +83,10 @@ class TestEventHandlerRegistry:
             "task_name": "Deleted Task",
         }
         self.registry.dispatch(message)
-        self.mock_app.request_reload.assert_called_once()
-        self.mock_app.notify.assert_called_once()
+        self.reload_tasks.assert_called_once()
+        self.notify.assert_called_once()
         # Verify warning severity
-        call_args = self.mock_app.notify.call_args
+        call_args = self.notify.call_args
         assert call_args.kwargs.get("severity") == "warning"
 
     def test_dispatch_task_status_changed_shows_transition(self) -> None:
@@ -97,8 +99,8 @@ class TestEventHandlerRegistry:
             "new_status": "IN_PROGRESS",
         }
         self.registry.dispatch(message)
-        self.mock_app.request_reload.assert_called_once()
-        self.mock_app.notify.assert_called_once()
+        self.reload_tasks.assert_called_once()
+        self.notify.assert_called_once()
 
     def test_dispatch_schedule_optimized(self) -> None:
         """Test that schedule_optimized event shows optimization result."""
@@ -109,22 +111,22 @@ class TestEventHandlerRegistry:
             "algorithm": "greedy",
         }
         self.registry.dispatch(message)
-        self.mock_app.request_reload.assert_called_once()
-        self.mock_app.notify.assert_called_once()
+        self.reload_tasks.assert_called_once()
+        self.notify.assert_called_once()
 
     def test_dispatch_unknown_event_type_ignored(self) -> None:
         """Test that unknown event types are silently ignored."""
         message = {"type": "unknown_event_type"}
         # Should not raise
         self.registry.dispatch(message)
-        self.mock_app.notify.assert_not_called()
+        self.notify.assert_not_called()
 
     def test_dispatch_without_type_ignored(self) -> None:
         """Test that messages without type are silently ignored."""
         message = {"data": "something"}
         # Should not raise
         self.registry.dispatch(message)
-        self.mock_app.notify.assert_not_called()
+        self.notify.assert_not_called()
 
     def test_source_client_id_hidden_when_same(self) -> None:
         """Test that source client ID is not shown when same as this client."""
@@ -132,7 +134,7 @@ class TestEventHandlerRegistry:
             "type": "task_created",
             "task_id": 1,
             "task_name": "Task",
-            "source_client_id": "test-client-id",  # Same as mock_app.api_client.client_id
+            "source_client_id": "test-client-id",  # Same as get_client_id() return
         }
         self.registry.dispatch(message)
         # The source should not be displayed in the notification
@@ -149,18 +151,6 @@ class TestEventHandlerRegistry:
         }
         result = self.registry._get_display_source(message)
         assert result == "other-client-id"
-
-    def test_no_task_ui_manager_does_not_fail(self) -> None:
-        """Test that events don't fail when task_ui_manager is None."""
-        self.mock_app.task_ui_manager = None
-        message = {
-            "type": "task_created",
-            "task_id": 1,
-            "task_name": "Task",
-        }
-        # Should not raise
-        self.registry.dispatch(message)
-        self.mock_app.notify.assert_called_once()
 
     def test_source_user_name_preferred_over_client_id(self) -> None:
         """Test that source_user_name is preferred over source_client_id."""
@@ -216,13 +206,13 @@ class TestEventHandlerRegistry:
         """Test that dispatch ignores non-string type values."""
         message = {"type": 123}  # Integer type
         self.registry.dispatch(message)
-        self.mock_app.notify.assert_not_called()
+        self.notify.assert_not_called()
 
     def test_schedule_optimized_uses_defaults(self) -> None:
         """Test schedule_optimized with missing fields uses defaults."""
         message = {"type": "schedule_optimized"}
         self.registry.dispatch(message)
-        self.mock_app.notify.assert_called_once()
+        self.notify.assert_called_once()
         # Should not raise and should show notification
 
     def test_task_updated_without_fields(self) -> None:
@@ -233,7 +223,7 @@ class TestEventHandlerRegistry:
             "task_name": "Updated Task",
         }
         self.registry.dispatch(message)
-        self.mock_app.notify.assert_called_once()
+        self.notify.assert_called_once()
 
     def test_task_status_changed_without_statuses(self) -> None:
         """Test task_status_changed with missing status fields."""
@@ -243,7 +233,7 @@ class TestEventHandlerRegistry:
             "task_name": "Task",
         }
         self.registry.dispatch(message)
-        self.mock_app.notify.assert_called_once()
+        self.notify.assert_called_once()
 
     def test_dispatch_bulk_operation_completed_all_success(self) -> None:
         """Test bulk_operation_completed with all tasks succeeding."""
@@ -255,9 +245,9 @@ class TestEventHandlerRegistry:
             "task_ids": [1, 2, 3],
         }
         self.registry.dispatch(message)
-        self.mock_app.request_reload.assert_called_once()
-        self.mock_app.notify.assert_called_once()
-        call_args = self.mock_app.notify.call_args
+        self.reload_tasks.assert_called_once()
+        self.notify.assert_called_once()
+        call_args = self.notify.call_args
         assert "3/3" in call_args[0][0]
         assert call_args.kwargs.get("severity") == "information"
 
@@ -271,9 +261,9 @@ class TestEventHandlerRegistry:
             "task_ids": [1, 2, 3],
         }
         self.registry.dispatch(message)
-        self.mock_app.request_reload.assert_called_once()
-        self.mock_app.notify.assert_called_once()
-        call_args = self.mock_app.notify.call_args
+        self.reload_tasks.assert_called_once()
+        self.notify.assert_called_once()
+        call_args = self.notify.call_args
         assert "2/3" in call_args[0][0]
         assert call_args.kwargs.get("severity") == "warning"
 
@@ -281,8 +271,8 @@ class TestEventHandlerRegistry:
         """Test bulk_operation_completed with missing fields uses defaults."""
         message = {"type": "bulk_operation_completed"}
         self.registry.dispatch(message)
-        self.mock_app.notify.assert_called_once()
-        call_args = self.mock_app.notify.call_args
+        self.notify.assert_called_once()
+        call_args = self.notify.call_args
         assert "0/0" in call_args[0][0]
         assert "unknown" in call_args[0][0]
 
@@ -294,7 +284,7 @@ class TestEventHandlerRegistry:
             "task_name": "Task",
         }
         self.registry.dispatch(message)
-        self.mock_app.request_reload.assert_called_once_with()
+        self.reload_tasks.assert_called_once_with()
 
 
 class TestWebSocketHandler:
@@ -303,19 +293,23 @@ class TestWebSocketHandler:
     @pytest.fixture(autouse=True)
     def setup(self) -> None:
         """Set up test fixtures."""
-        self.mock_app = MagicMock()
-        self.mock_app.api_client = MagicMock()
-        self.mock_app.api_client.client_id = "test-client-id"
-        self.mock_app.task_ui_manager = MagicMock()
-        self.mock_app.notify = MagicMock()
+        self.notify = MagicMock()
+        self.reload_tasks = MagicMock()
+        self.set_client_id = MagicMock()
+        self.get_client_id = MagicMock(return_value="test-client-id")
 
     def test_handle_message_delegates_to_registry(self) -> None:
         """Test that WebSocketHandler delegates to EventHandlerRegistry."""
         from taskdog.tui.services.websocket_handler import WebSocketHandler
 
-        handler = WebSocketHandler(self.mock_app)
+        handler = WebSocketHandler(
+            notify=self.notify,
+            reload_tasks=self.reload_tasks,
+            set_client_id=self.set_client_id,
+            get_client_id=self.get_client_id,
+        )
         message = {"type": "connected", "client_id": "new-client"}
 
         handler.handle_message(message)
 
-        self.mock_app.api_client.set_client_id.assert_called_once_with("new-client")
+        self.set_client_id.assert_called_once_with("new-client")


### PR DESCRIPTION
## Summary

Removes the tight coupling between `EventHandlerRegistry` / `WebSocketHandler` and the `TaskdogTUI` app class by injecting individual callables instead of the whole app instance. This aligns these services with the dependency-injection style already used by `TaskUIManager`.

Closes #772.

## Changes

- **`event_handler_registry.py`**: drop the `app` parameter; inject `notify`, `reload_tasks`, `set_client_id`, `get_client_id`. Add a `NotifyFn` Protocol for the notify signature. The `_reload_tasks` method is replaced by the injected callable of the same name.
- **`websocket_handler.py`**: accept the same four callables and forward them to the registry; no longer holds an `app` reference.
- **`app.py`**: wire the callables when constructing `WebSocketHandler` (`get_client_id` is `lambda: self.api_client.client_id`).
- **tests**: inject mock callables instead of `mock_app`; remove the obsolete `task_ui_manager is None` test (the registry no longer touches `task_ui_manager`).

## Deviation from the proposal

The proposed `schedule_fn` (for `call_later`) is **not** injected: the registry never calls `call_later`, so adding it would be dead weight.

## Verification

- `grep -r "self\.app" .../event_handler_registry.py` → 0 matches
- `grep -r "self\.app" .../websocket_handler.py` → 0 matches
- `make check` → passed (lint + typecheck + codespell + vulture)
- `make test-ui` → 1095 passed
