### PR TITLE
fix(core): seed genetic/monte_carlo optimizers for reproducible schedules (#963)

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/constants/optimization.py
+++ b/packages/taskdog-core/src/taskdog_core/application/constants/optimization.py
@@ -17,6 +17,10 @@ MONTE_CARLO_NUM_SIMULATIONS = (
     50  # Number of random simulations to run (reduced from 100 for performance)
 )
 
+# Default seed for randomized strategies (genetic, monte_carlo) so identical
+# input yields an identical schedule unless an explicit seed is provided.
+DEFAULT_OPTIMIZATION_SEED = 0
+
 # Round Robin Parameters
 ROUND_ROBIN_MAX_ITERATIONS = 10000  # Safety limit to prevent infinite loops
 

--- a/packages/taskdog-core/src/taskdog_core/application/dto/optimize_params.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/optimize_params.py
@@ -22,12 +22,15 @@ class OptimizeParams:
         max_hours_per_day: Maximum work hours per day
         holiday_checker: Optional holiday checker for workday validation
         include_all_days: If True, schedule tasks on weekends and holidays too (default: False)
+        seed: Seed for randomized strategies (genetic, monte_carlo). None falls back
+            to a fixed default so identical input yields an identical schedule.
     """
 
     start_date: datetime
     max_hours_per_day: float
     holiday_checker: "IHolidayChecker | None" = None
     include_all_days: bool = False
+    seed: int | None = None
 
     def __post_init__(self) -> None:
         """Validate optimization parameters."""

--- a/packages/taskdog-core/src/taskdog_core/application/services/optimization/genetic_optimization_strategy.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/optimization/genetic_optimization_strategy.py
@@ -5,6 +5,7 @@ import random
 from datetime import date
 
 from taskdog_core.application.constants.optimization import (
+    DEFAULT_OPTIMIZATION_SEED,
     GENETIC_CROSSOVER_RATE,
     GENETIC_EARLY_TERMINATION_GENERATIONS,
     GENETIC_GENERATIONS,
@@ -60,6 +61,7 @@ class GeneticOptimizationStrategy(OptimizationStrategy):
         self._fitness_cache: dict[
             tuple[int | None, ...], tuple[float, dict[date, float], list[Task]]
         ] = {}
+        self._rng = random.Random()
 
     def optimize_tasks(
         self,
@@ -88,6 +90,11 @@ class GeneticOptimizationStrategy(OptimizationStrategy):
 
         # Clear fitness cache for new optimization run
         self._fitness_cache.clear()
+
+        # Seed a local RNG per run so identical input + seed is reproducible
+        self._rng.seed(
+            params.seed if params.seed is not None else DEFAULT_OPTIMIZATION_SEED
+        )
 
         # Run genetic algorithm to find best task order
         best_order = self._genetic_algorithm(
@@ -145,7 +152,7 @@ class GeneticOptimizationStrategy(OptimizationStrategy):
         """
         # Generate initial population
         population = [
-            random.sample(tasks, len(tasks)) for _ in range(self.POPULATION_SIZE)
+            self._rng.sample(tasks, len(tasks)) for _ in range(self.POPULATION_SIZE)
         ]
 
         # Track best fitness for early termination
@@ -188,17 +195,17 @@ class GeneticOptimizationStrategy(OptimizationStrategy):
 
             # Generate offspring
             while len(next_generation) < self.POPULATION_SIZE:
-                parent1 = random.choice(parents)
-                parent2 = random.choice(parents)
+                parent1 = self._rng.choice(parents)
+                parent2 = self._rng.choice(parents)
 
                 # Crossover
-                if random.random() < self.CROSSOVER_RATE:
+                if self._rng.random() < self.CROSSOVER_RATE:
                     child = self._crossover(parent1, parent2)
                 else:
                     child = copy.copy(parent1)
 
                 # Mutation
-                if random.random() < self.MUTATION_RATE:
+                if self._rng.random() < self.MUTATION_RATE:
                     child = self._mutate(child)
 
                 next_generation.append(child)
@@ -308,7 +315,7 @@ class GeneticOptimizationStrategy(OptimizationStrategy):
 
         for _ in range(len(population)):
             # Select random individuals for tournament
-            tournament_indices = random.sample(
+            tournament_indices = self._rng.sample(
                 range(len(population)), self.TOURNAMENT_SIZE
             )
             # Choose best from tournament
@@ -334,7 +341,7 @@ class GeneticOptimizationStrategy(OptimizationStrategy):
             return list(parent1)
 
         # Select two random crossover points
-        start, end = sorted(random.sample(range(size), 2))
+        start, end = sorted(self._rng.sample(range(size), 2))
 
         # Copy segment from parent1
         child: list[Task | None] = [None] * size
@@ -367,6 +374,6 @@ class GeneticOptimizationStrategy(OptimizationStrategy):
 
         mutated = copy.copy(individual)
         # Swap two random positions
-        idx1, idx2 = random.sample(range(len(mutated)), 2)
+        idx1, idx2 = self._rng.sample(range(len(mutated)), 2)
         mutated[idx1], mutated[idx2] = mutated[idx2], mutated[idx1]
         return mutated

--- a/packages/taskdog-core/src/taskdog_core/application/services/optimization/monte_carlo_optimization_strategy.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/optimization/monte_carlo_optimization_strategy.py
@@ -3,7 +3,10 @@
 import random
 from datetime import date
 
-from taskdog_core.application.constants.optimization import MONTE_CARLO_NUM_SIMULATIONS
+from taskdog_core.application.constants.optimization import (
+    DEFAULT_OPTIMIZATION_SEED,
+    MONTE_CARLO_NUM_SIMULATIONS,
+)
 from taskdog_core.application.dto.optimize_params import OptimizeParams
 from taskdog_core.application.dto.optimize_result import OptimizeResult
 from taskdog_core.application.services.optimization.greedy_optimization_strategy import (
@@ -44,6 +47,7 @@ class MonteCarloOptimizationStrategy(OptimizationStrategy):
             tuple[int | None, ...], float
         ] = {}  # Cache for evaluation results
         self._existing_allocations: dict[date, float] = {}
+        self._rng = random.Random()
 
     def optimize_tasks(
         self,
@@ -63,6 +67,11 @@ class MonteCarloOptimizationStrategy(OptimizationStrategy):
         """
         if not tasks:
             return OptimizeResult()
+
+        # Seed a local RNG per run so identical input + seed is reproducible
+        self._rng.seed(
+            params.seed if params.seed is not None else DEFAULT_OPTIMIZATION_SEED
+        )
 
         # Store existing allocations for use in evaluation
         self._existing_allocations = existing_allocations
@@ -118,7 +127,7 @@ class MonteCarloOptimizationStrategy(OptimizationStrategy):
 
         for _ in range(self.NUM_SIMULATIONS):
             # Generate random ordering
-            random_order = random.sample(schedulable_tasks, len(schedulable_tasks))
+            random_order = self._rng.sample(schedulable_tasks, len(schedulable_tasks))
 
             # Skip duplicate orderings
             ordering_key = tuple(

--- a/packages/taskdog-core/tests/application/services/optimization/test_optimization_determinism.py
+++ b/packages/taskdog-core/tests/application/services/optimization/test_optimization_determinism.py
@@ -1,0 +1,75 @@
+"""Determinism tests for randomized optimization strategies (issue #963)."""
+
+from datetime import datetime
+
+import pytest
+
+from taskdog_core.application.dto.optimize_params import OptimizeParams
+from taskdog_core.application.services.optimization.genetic_optimization_strategy import (
+    GeneticOptimizationStrategy,
+)
+from taskdog_core.application.services.optimization.monte_carlo_optimization_strategy import (
+    MonteCarloOptimizationStrategy,
+)
+from taskdog_core.domain.entities.task import Task
+
+
+def _make_tasks() -> list[Task]:
+    """Build several schedulable tasks with identical priority/duration.
+
+    Ties make the optimal ordering ambiguous, so the result depends on the RNG
+    draw — exactly the situation that exposes unseeded non-determinism.
+    """
+    deadline = datetime(2025, 11, 30, 18, 0, 0)
+    return [
+        Task(
+            name=f"Task {i}",
+            id=i,
+            priority=50,
+            estimated_duration=6.0,
+            deadline=deadline,
+        )
+        for i in range(1, 7)
+    ]
+
+
+def _params(seed: int | None) -> OptimizeParams:
+    return OptimizeParams(
+        start_date=datetime(2025, 10, 20, 9, 0, 0),
+        max_hours_per_day=6.0,
+        seed=seed,
+    )
+
+
+@pytest.mark.parametrize(
+    "strategy_cls",
+    [GeneticOptimizationStrategy, MonteCarloOptimizationStrategy],
+)
+class TestOptimizationDeterminism:
+    """Same input + same seed must yield an identical schedule."""
+
+    def test_same_seed_is_reproducible(self, strategy_cls):
+        order_a = [
+            t.id
+            for t in strategy_cls().optimize_tasks(_make_tasks(), {}, _params(42)).tasks
+        ]
+        order_b = [
+            t.id
+            for t in strategy_cls().optimize_tasks(_make_tasks(), {}, _params(42)).tasks
+        ]
+        assert order_a == order_b
+
+    def test_default_seed_is_reproducible(self, strategy_cls):
+        order_a = [
+            t.id
+            for t in strategy_cls()
+            .optimize_tasks(_make_tasks(), {}, _params(None))
+            .tasks
+        ]
+        order_b = [
+            t.id
+            for t in strategy_cls()
+            .optimize_tasks(_make_tasks(), {}, _params(None))
+            .tasks
+        ]
+        assert order_a == order_b


### PR DESCRIPTION
## Summary

The `genetic` and `monte_carlo` optimization strategies drew from the global `random` module without ever seeding it, so identical input produced a different schedule on every run. This is at odds with taskdog's "transparent, reproducible algorithms" goal and makes any test asserting on these strategies' output inherently flaky.

Closes #963.

## Changes

- Add `seed: int | None = None` to `OptimizeParams`.
- Add `DEFAULT_OPTIMIZATION_SEED = 0` constant.
- In both strategies, seed a local `random.Random` per run (no global RNG mutation) and route every `random.sample/choice/random(...)` through it. `seed=None` falls back to `DEFAULT_OPTIMIZATION_SEED`, so identical input → identical schedule by default; callers can pass an explicit seed to vary results.

Scope kept to core: threading `--seed` through the CLI/server/MCP is intentionally out of scope — the acceptance criterion is reproducible strategy output.

## Verification

- New `test_optimization_determinism.py`: same seed → identical schedule, and default (None) seed → reproducible, parametrized over both strategies.
- Confirmed the tests aren't vacuous: different seeds (1 vs 999) produce different orderings, so the RNG genuinely drives output.
- Full `taskdog-core` suite: 1109 passed. ruff + mypy clean. pre-push (make test, vulture) passed.