### PR TITLE
feat: backup/restore the SQLite store over the API (#999)

### DIFF
--- a/packages/taskdog-client/src/taskdog_client/backup_client.py
+++ b/packages/taskdog-client/src/taskdog_client/backup_client.py
@@ -40,6 +40,9 @@ class BackupClient:
             TaskNotFoundException / TaskValidationError / AuthenticationError /
             ServerError: Mapped from non-success HTTP responses.
         """
+        # Download to a temp file and atomically rename, so an interrupted
+        # download never leaves a corrupt partial snapshot at output_path.
+        tmp_path = output_path.with_name(output_path.name + ".part")
         try:
             with self._base.client.stream(
                 "GET", "/api/v1/backup", headers=self._base.auth_headers()
@@ -47,11 +50,16 @@ class BackupClient:
                 if not response.is_success:
                     response.read()
                     self._base._handle_error(response)
-                with output_path.open("wb") as out:
+                with tmp_path.open("wb") as out:
                     for chunk in response.iter_bytes(_CHUNK_SIZE):
                         out.write(chunk)
+            tmp_path.replace(output_path)
         except (httpx.ConnectError, httpx.TimeoutException, httpx.RequestError) as e:
+            tmp_path.unlink(missing_ok=True)
             raise ServerConnectionError(self._base.base_url, e) from e
+        except BaseException:
+            tmp_path.unlink(missing_ok=True)
+            raise
 
     def restore(self, file_path: Path) -> RestoreResultDTO:
         """Upload a `.db` snapshot to stage a restore.

--- a/packages/taskdog-client/src/taskdog_client/backup_client.py
+++ b/packages/taskdog-client/src/taskdog_client/backup_client.py
@@ -1,0 +1,75 @@
+"""Client for backup/restore endpoints."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx  # type: ignore[import-not-found]
+
+from taskdog_core.application.dto.restore_result import RestoreResultDTO
+from taskdog_core.domain.exceptions.task_exceptions import ServerConnectionError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from taskdog_client.base_client import BaseApiClient
+
+# Write the streamed snapshot in 1 MiB chunks.
+_CHUNK_SIZE = 1024 * 1024
+
+
+class BackupClient:
+    """Download physical database snapshots and upload them for restore."""
+
+    def __init__(self, base: BaseApiClient) -> None:
+        """Initialize with a shared base client.
+
+        Args:
+            base: Shared BaseApiClient instance.
+        """
+        self._base = base
+
+    def backup(self, output_path: Path) -> None:
+        """Download a database snapshot and save it to output_path.
+
+        Args:
+            output_path: Local path to write the `.db` snapshot to.
+
+        Raises:
+            ServerConnectionError: If the connection to the server fails.
+            TaskNotFoundException / TaskValidationError / AuthenticationError /
+            ServerError: Mapped from non-success HTTP responses.
+        """
+        try:
+            with self._base.client.stream(
+                "GET", "/api/v1/backup", headers=self._base.auth_headers()
+            ) as response:
+                if not response.is_success:
+                    response.read()
+                    self._base._handle_error(response)
+                with output_path.open("wb") as out:
+                    for chunk in response.iter_bytes(_CHUNK_SIZE):
+                        out.write(chunk)
+        except (httpx.ConnectError, httpx.TimeoutException, httpx.RequestError) as e:
+            raise ServerConnectionError(self._base.base_url, e) from e
+
+    def restore(self, file_path: Path) -> RestoreResultDTO:
+        """Upload a `.db` snapshot to stage a restore.
+
+        Args:
+            file_path: Local path to the `.db` snapshot to upload.
+
+        Returns:
+            RestoreResultDTO reporting the pending status.
+
+        Raises:
+            TaskValidationError: If the server rejects the upload (400).
+            ServerConnectionError: If the connection to the server fails.
+        """
+        with file_path.open("rb") as upload:
+            data = self._base._request_json(
+                "post",
+                "/api/v1/restore",
+                files={"file": (file_path.name, upload, "application/octet-stream")},
+            )
+        return RestoreResultDTO.model_validate(data)

--- a/packages/taskdog-client/src/taskdog_client/base_client.py
+++ b/packages/taskdog-client/src/taskdog_client/base_client.py
@@ -49,6 +49,19 @@ class BaseApiClient:
         self.client_id: str | None = None  # Set by WebSocket connection
         self.api_key = api_key
 
+    def auth_headers(self) -> dict[str, str]:
+        """Build the client/auth headers used on every request.
+
+        Returns:
+            Headers including X-Client-ID and X-Api-Key when set.
+        """
+        headers: dict[str, str] = {}
+        if self.client_id:
+            headers["X-Client-ID"] = self.client_id
+        if self.api_key:
+            headers["X-Api-Key"] = self.api_key
+        return headers
+
     def close(self) -> None:
         """Close the HTTP client."""
         self.client.close()
@@ -186,16 +199,7 @@ class BaseApiClient:
             Exception: For other errors
         """
         try:
-            headers = kwargs.get("headers", {})
-
-            # Add X-Client-ID header if client_id is set
-            if self.client_id:
-                headers["X-Client-ID"] = self.client_id
-
-            # Add X-Api-Key header if api_key is set
-            if self.api_key:
-                headers["X-Api-Key"] = self.api_key
-
+            headers = {**self.auth_headers(), **kwargs.get("headers", {})}
             if headers:
                 kwargs["headers"] = headers
 

--- a/packages/taskdog-client/src/taskdog_client/taskdog_api_client.py
+++ b/packages/taskdog-client/src/taskdog_client/taskdog_api_client.py
@@ -5,12 +5,14 @@ clients while maintaining a simple public API.
 """
 
 from datetime import date, datetime
+from pathlib import Path
 from typing import Any
 
 import httpx  # type: ignore[import-not-found]
 
 from taskdog_client.analytics_client import AnalyticsClient
 from taskdog_client.audit_client import AuditClient
+from taskdog_client.backup_client import BackupClient
 from taskdog_client.base_client import BaseApiClient
 from taskdog_client.bulk_client import BulkClient
 from taskdog_client.lifecycle_client import LifecycleClient
@@ -26,6 +28,7 @@ from taskdog_core.application.dto.bulk_operation_output import BulkOperationOutp
 from taskdog_core.application.dto.delete_tag_output import DeleteTagOutput
 from taskdog_core.application.dto.get_task_by_id_output import TaskByIdOutput
 from taskdog_core.application.dto.optimization_output import OptimizationOutput
+from taskdog_core.application.dto.restore_result import RestoreResultDTO
 from taskdog_core.application.dto.statistics_output import StatisticsOutput
 from taskdog_core.application.dto.tag_statistics_output import TagStatisticsOutput
 from taskdog_core.application.dto.task_detail_output import TaskDetailOutput
@@ -68,6 +71,7 @@ class TaskdogApiClient:
         self._notes = NotesClient(self._base)
         self._audit = AuditClient(self._base)
         self._bulk = BulkClient(self._base)
+        self._backup = BackupClient(self._base)
 
     @property
     def client(self) -> httpx.Client:
@@ -406,6 +410,16 @@ class TaskdogApiClient:
     def get_audit_log(self, log_id: int) -> AuditLogOutput:
         """Get a single audit log entry by ID."""
         return self._audit.get_audit_log(log_id)
+
+    # Backup/restore methods - delegate to BackupClient
+
+    def backup(self, output_path: Path) -> None:
+        """Download a physical database snapshot to output_path."""
+        return self._backup.backup(output_path)
+
+    def restore(self, file_path: Path) -> RestoreResultDTO:
+        """Upload a database snapshot to stage a restore (applied on restart)."""
+        return self._backup.restore(file_path)
 
     # Bulk operation methods - delegate to BulkClient
 

--- a/packages/taskdog-client/tests/test_backup_client.py
+++ b/packages/taskdog-client/tests/test_backup_client.py
@@ -34,6 +34,8 @@ class TestBackupClient:
         self.client.backup(out)
 
         assert out.read_bytes() == b"chunk-1chunk-2"
+        # The temp file is renamed away on success.
+        assert not (tmp_path / "backup.db.part").exists()
 
     def test_backup_maps_error_response(self, tmp_path: Path):
         """A non-success response is routed through the base error handler."""
@@ -50,6 +52,9 @@ class TestBackupClient:
         with pytest.raises(RuntimeError, match="boom"):
             self.client.backup(tmp_path / "backup.db")
         self.mock_base._handle_error.assert_called_once_with(response)
+        # No partial file and no corrupt output left behind on failure.
+        assert not (tmp_path / "backup.db.part").exists()
+        assert not (tmp_path / "backup.db").exists()
 
     def test_restore_uploads_file_and_returns_dto(self, tmp_path: Path):
         """restore posts a multipart upload and parses the pending result."""

--- a/packages/taskdog-client/tests/test_backup_client.py
+++ b/packages/taskdog-client/tests/test_backup_client.py
@@ -1,0 +1,70 @@
+"""Tests for BackupClient."""
+
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from taskdog_client.backup_client import BackupClient
+
+
+class TestBackupClient:
+    """Test cases for BackupClient."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Set up test fixtures."""
+        self.mock_base = Mock()
+        self.mock_base.auth_headers.return_value = {"X-Api-Key": "k"}
+        self.client = BackupClient(self.mock_base)
+
+    def test_backup_writes_streamed_chunks(self, tmp_path: Path):
+        """backup streams the response body to the output file."""
+        response = Mock()
+        response.is_success = True
+        response.iter_bytes.return_value = [b"chunk-1", b"chunk-2"]
+
+        @contextmanager
+        def fake_stream(*args, **kwargs):
+            yield response
+
+        self.mock_base.client.stream = fake_stream
+
+        out = tmp_path / "backup.db"
+        self.client.backup(out)
+
+        assert out.read_bytes() == b"chunk-1chunk-2"
+
+    def test_backup_maps_error_response(self, tmp_path: Path):
+        """A non-success response is routed through the base error handler."""
+        response = Mock()
+        response.is_success = False
+        self.mock_base._handle_error.side_effect = RuntimeError("boom")
+
+        @contextmanager
+        def fake_stream(*args, **kwargs):
+            yield response
+
+        self.mock_base.client.stream = fake_stream
+
+        with pytest.raises(RuntimeError, match="boom"):
+            self.client.backup(tmp_path / "backup.db")
+        self.mock_base._handle_error.assert_called_once_with(response)
+
+    def test_restore_uploads_file_and_returns_dto(self, tmp_path: Path):
+        """restore posts a multipart upload and parses the pending result."""
+        upload = tmp_path / "snapshot.db"
+        upload.write_bytes(b"sqlite-bytes")
+        self.mock_base._request_json.return_value = {
+            "status": "pending",
+            "message": "restart required",
+        }
+
+        result = self.client.restore(upload)
+
+        assert result.status == "pending"
+        assert result.message == "restart required"
+        method, url = self.mock_base._request_json.call_args.args
+        assert method == "post"
+        assert url == "/api/v1/restore"
+        assert "files" in self.mock_base._request_json.call_args.kwargs

--- a/packages/taskdog-core/src/taskdog_core/application/dto/restore_result.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/restore_result.py
@@ -1,0 +1,18 @@
+"""Output DTO for restore operations."""
+
+from pydantic import BaseModel
+
+
+class RestoreResultDTO(BaseModel):
+    """Result of staging a restore.
+
+    Restore is applied on the next server startup, so the response only reports
+    that the upload was accepted and a restart is required.
+
+    Attributes:
+        status: Restore lifecycle status (e.g. "pending").
+        message: Human-readable instruction (e.g. "restart required").
+    """
+
+    status: str
+    message: str

--- a/packages/taskdog-core/src/taskdog_core/controllers/backup_controller.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/backup_controller.py
@@ -1,0 +1,37 @@
+"""Controller for backup/restore operations."""
+
+from collections.abc import Iterator
+
+from taskdog_core.application.dto.restore_result import RestoreResultDTO
+from taskdog_core.domain.services.backup_store import IBackupStore
+
+
+class BackupController:
+    """Unified backup/restore operations over a storage-neutral port."""
+
+    def __init__(self, store: IBackupStore) -> None:
+        """Initialize the controller.
+
+        Args:
+            store: Backup store implementation (e.g. SqliteBackupStore).
+        """
+        self._store = store
+
+    def create_snapshot(self) -> Iterator[bytes]:
+        """Stream a consistent snapshot of the store as byte chunks."""
+        return self._store.create_snapshot()
+
+    def restore(self, data: Iterator[bytes]) -> RestoreResultDTO:
+        """Stage an uploaded snapshot to be applied on the next startup.
+
+        Args:
+            data: Iterator yielding the uploaded snapshot in chunks.
+
+        Returns:
+            RestoreResultDTO reporting the pending status.
+
+        Raises:
+            BackupValidationError: If the uploaded snapshot is invalid.
+        """
+        self._store.stage_restore(data)
+        return RestoreResultDTO(status="pending", message="restart required")

--- a/packages/taskdog-core/src/taskdog_core/domain/exceptions/backup_exceptions.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/exceptions/backup_exceptions.py
@@ -1,0 +1,13 @@
+"""Custom exceptions for backup/restore operations."""
+
+
+class BackupError(Exception):
+    """Base exception for all backup/restore errors."""
+
+
+class BackupValidationError(BackupError):
+    """Raised when an uploaded backup fails validation (e.g. integrity check)."""
+
+
+class BackupNotSupportedError(BackupError):
+    """Raised when backup/restore is requested for a non-file store (e.g. in-memory)."""

--- a/packages/taskdog-core/src/taskdog_core/domain/services/backup_store.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/services/backup_store.py
@@ -1,0 +1,49 @@
+"""Storage-neutral port for backup/restore of the data store."""
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterator
+
+
+class IBackupStore(ABC):
+    """Abstract interface for backing up and restoring the data store.
+
+    The port is storage-neutral: it exposes only chunk streams, never database
+    files, paths, or SQL. Storage specifics (SQLite, VACUUM INTO, file swaps)
+    live solely in the infrastructure implementation.
+    """
+
+    @abstractmethod
+    def create_snapshot(self) -> Iterator[bytes]:
+        """Produce a consistent snapshot of the store as a stream of byte chunks.
+
+        Returns:
+            Iterator yielding the snapshot content in chunks.
+
+        Raises:
+            BackupNotSupportedError: If the store cannot be snapshotted.
+        """
+
+    @abstractmethod
+    def stage_restore(self, data: Iterator[bytes]) -> None:
+        """Validate an uploaded snapshot and place it into staging.
+
+        The snapshot is applied on the next startup via apply_pending_restore;
+        it is not applied live.
+
+        Args:
+            data: Iterator yielding the uploaded snapshot in chunks.
+
+        Raises:
+            BackupValidationError: If the uploaded snapshot is not valid.
+            BackupNotSupportedError: If the store cannot be restored.
+        """
+
+    @abstractmethod
+    def apply_pending_restore(self) -> bool:
+        """Apply a previously staged snapshot, if any.
+
+        Intended to run at startup before the store is opened.
+
+        Returns:
+            True if a staged snapshot was applied, False if there was none.
+        """

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_backup_store.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_backup_store.py
@@ -1,0 +1,138 @@
+"""SQLite implementation of the backup/restore port."""
+
+import os
+import sqlite3
+import tempfile
+from collections.abc import Iterator
+from datetime import datetime
+from pathlib import Path
+
+from sqlalchemy.engine import make_url
+
+from taskdog_core.domain.exceptions.backup_exceptions import (
+    BackupNotSupportedError,
+    BackupValidationError,
+)
+from taskdog_core.domain.services.backup_store import IBackupStore
+
+# Stream the snapshot in 1 MiB chunks.
+_CHUNK_SIZE = 1024 * 1024
+
+
+class SqliteBackupStore(IBackupStore):
+    """Backup/restore a SQLite database file.
+
+    The only place in the codebase that knows about VACUUM INTO, integrity
+    checks, WAL sidecars, and the on-disk file swap.
+    """
+
+    def __init__(self, database_url: str) -> None:
+        """Initialize from a SQLAlchemy database URL.
+
+        Args:
+            database_url: e.g. "sqlite:////home/user/.local/share/taskdog/tasks.db".
+                In-memory databases have no file and are not supported.
+        """
+        database = make_url(database_url).database
+        # ":memory:", empty, or None all denote a non-file (in-memory) store.
+        self._db_path: Path | None = (
+            Path(database) if database and database != ":memory:" else None
+        )
+
+    @property
+    def _pending_path(self) -> Path:
+        assert self._db_path is not None
+        return self._db_path.with_name(self._db_path.name + ".pending-restore")
+
+    def _sidecar(self, suffix: str) -> Path:
+        assert self._db_path is not None
+        return self._db_path.with_name(self._db_path.name + suffix)
+
+    def _require_file_store(self) -> Path:
+        if self._db_path is None:
+            raise BackupNotSupportedError(
+                "Backup/restore is only supported for file-based SQLite databases."
+            )
+        return self._db_path
+
+    def create_snapshot(self) -> Iterator[bytes]:
+        """Stream a consistent, defragmented single-file snapshot.
+
+        ``VACUUM INTO`` yields a transactionally consistent copy with no WAL
+        sidecars. The temp file is always removed once streaming finishes.
+        """
+        db_path = self._require_file_store()
+
+        # VACUUM INTO requires the target not to exist, so reserve a name and
+        # delete the placeholder before handing it to SQLite.
+        fd, tmp_name = tempfile.mkstemp(suffix=".db", dir=db_path.parent)
+        os.close(fd)
+        tmp_path = Path(tmp_name)
+        tmp_path.unlink()
+
+        def _stream() -> Iterator[bytes]:
+            try:
+                conn = sqlite3.connect(db_path)
+                try:
+                    conn.execute("VACUUM main INTO ?", (str(tmp_path),))
+                finally:
+                    conn.close()
+
+                with tmp_path.open("rb") as snapshot:
+                    while chunk := snapshot.read(_CHUNK_SIZE):
+                        yield chunk
+            finally:
+                if tmp_path.exists():
+                    tmp_path.unlink()
+
+        return _stream()
+
+    def stage_restore(self, data: Iterator[bytes]) -> None:
+        """Write the upload to staging and validate it before accepting."""
+        db_path = self._require_file_store()
+        pending = self._pending_path
+
+        with pending.open("wb") as staged:
+            for chunk in data:
+                staged.write(chunk)
+
+        if not self._is_valid_sqlite(pending):
+            pending.unlink(missing_ok=True)
+            raise BackupValidationError(
+                "Uploaded file is not a valid SQLite database (integrity check failed)."
+            )
+
+        # Keep mypy/readers honest that db_path is the swap target at apply time.
+        assert db_path == self._db_path
+
+    @staticmethod
+    def _is_valid_sqlite(path: Path) -> bool:
+        try:
+            conn = sqlite3.connect(path)
+            try:
+                row = conn.execute("PRAGMA integrity_check").fetchone()
+            finally:
+                conn.close()
+        except sqlite3.DatabaseError:
+            return False
+        return row is not None and row[0] == "ok"
+
+    def apply_pending_restore(self) -> bool:
+        """Swap a staged snapshot onto the live DB. Safe to call at startup."""
+        if self._db_path is None:
+            return False
+        pending = self._pending_path
+        if not pending.exists():
+            return False
+
+        db_path = self._db_path
+        if db_path.exists():
+            ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+            db_path.replace(db_path.with_name(f"{db_path.name}.pre-restore-{ts}"))
+
+        # Drop stale WAL/SHM so the old journal cannot shadow the restored DB.
+        for suffix in ("-wal", "-shm"):
+            self._sidecar(suffix).unlink(missing_ok=True)
+
+        pending.replace(db_path)
+        return True

--- a/packages/taskdog-core/tests/infrastructure/persistence/database/test_sqlite_backup_store.py
+++ b/packages/taskdog-core/tests/infrastructure/persistence/database/test_sqlite_backup_store.py
@@ -1,0 +1,124 @@
+"""Tests for SqliteBackupStore (issue #999)."""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from taskdog_core.domain.exceptions.backup_exceptions import (
+    BackupNotSupportedError,
+    BackupValidationError,
+)
+from taskdog_core.infrastructure.persistence.database.sqlite_backup_store import (
+    SqliteBackupStore,
+)
+
+
+def _seed_db(path: Path, rows: list[str]) -> None:
+    """Create a SQLite db at path with a notes table holding the given rows."""
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("CREATE TABLE notes (body TEXT)")
+        conn.executemany("INSERT INTO notes (body) VALUES (?)", [(r,) for r in rows])
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _read_rows(path: Path) -> list[str]:
+    conn = sqlite3.connect(path)
+    try:
+        return [row[0] for row in conn.execute("SELECT body FROM notes ORDER BY body")]
+    finally:
+        conn.close()
+
+
+def _url(path: Path) -> str:
+    return f"sqlite:///{path}"
+
+
+class TestCreateSnapshot:
+    def test_snapshot_round_trips(self, tmp_path: Path) -> None:
+        db = tmp_path / "tasks.db"
+        _seed_db(db, ["alpha", "beta"])
+        store = SqliteBackupStore(_url(db))
+
+        snapshot = tmp_path / "snapshot.db"
+        with snapshot.open("wb") as out:
+            for chunk in store.create_snapshot():
+                out.write(chunk)
+
+        assert _read_rows(snapshot) == ["alpha", "beta"]
+
+    def test_snapshot_leaves_no_temp_files(self, tmp_path: Path) -> None:
+        db = tmp_path / "tasks.db"
+        _seed_db(db, ["x"])
+        store = SqliteBackupStore(_url(db))
+
+        list(store.create_snapshot())  # fully drain the stream
+
+        assert [p.name for p in tmp_path.iterdir()] == ["tasks.db"]
+
+    def test_in_memory_is_not_supported(self) -> None:
+        store = SqliteBackupStore("sqlite:///:memory:")
+        with pytest.raises(BackupNotSupportedError):
+            list(store.create_snapshot())
+
+
+class TestStageRestore:
+    def test_invalid_upload_rejected_and_cleaned_up(self, tmp_path: Path) -> None:
+        db = tmp_path / "tasks.db"
+        _seed_db(db, ["keep"])
+        store = SqliteBackupStore(_url(db))
+
+        with pytest.raises(BackupValidationError):
+            store.stage_restore(iter([b"this is not a sqlite database"]))
+
+        # The live DB is untouched and no staging file is left behind.
+        assert _read_rows(db) == ["keep"]
+        assert not (tmp_path / "tasks.db.pending-restore").exists()
+
+    def test_valid_upload_is_staged(self, tmp_path: Path) -> None:
+        db = tmp_path / "tasks.db"
+        _seed_db(db, ["old"])
+        other = tmp_path / "other.db"
+        _seed_db(other, ["new"])
+        store = SqliteBackupStore(_url(db))
+
+        store.stage_restore(iter([other.read_bytes()]))
+
+        # Staged, not yet applied.
+        assert (tmp_path / "tasks.db.pending-restore").exists()
+        assert _read_rows(db) == ["old"]
+
+
+class TestApplyPendingRestore:
+    def test_no_pending_returns_false(self, tmp_path: Path) -> None:
+        db = tmp_path / "tasks.db"
+        _seed_db(db, ["only"])
+        store = SqliteBackupStore(_url(db))
+
+        assert store.apply_pending_restore() is False
+
+    def test_pending_is_applied_with_wal_cleanup(self, tmp_path: Path) -> None:
+        db = tmp_path / "tasks.db"
+        _seed_db(db, ["old"])
+        # Stale WAL/SHM sidecars must be removed so they can't shadow the restore.
+        (tmp_path / "tasks.db-wal").write_bytes(b"stale-wal")
+        (tmp_path / "tasks.db-shm").write_bytes(b"stale-shm")
+
+        snapshot = tmp_path / "snapshot.db"
+        _seed_db(snapshot, ["restored"])
+        store = SqliteBackupStore(_url(db))
+        store.stage_restore(iter([snapshot.read_bytes()]))
+
+        assert store.apply_pending_restore() is True
+
+        assert _read_rows(db) == ["restored"]
+        assert not (tmp_path / "tasks.db.pending-restore").exists()
+        assert not (tmp_path / "tasks.db-wal").exists()
+        assert not (tmp_path / "tasks.db-shm").exists()
+        # Previous DB preserved as a pre-restore copy.
+        pre_restore = list(tmp_path.glob("tasks.db.pre-restore-*"))
+        assert len(pre_restore) == 1
+        assert _read_rows(pre_restore[0]) == ["old"]

--- a/packages/taskdog-server/pyproject.toml
+++ b/packages/taskdog-server/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.48.0",
     "pydantic>=2.10.0",
+    "python-multipart>=0.0.9",
 ]
 
 [project.optional-dependencies]

--- a/packages/taskdog-server/src/taskdog_server/api/app.py
+++ b/packages/taskdog-server/src/taskdog_server/api/app.py
@@ -5,14 +5,21 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from taskdog_core.infrastructure.persistence.database.sqlite_backup_store import (
+    SqliteBackupStore,
+)
 from taskdog_core.shared.config_manager import ConfigManager
 from taskdog_server import __version__
-from taskdog_server.api.dependencies import initialize_api_context
+from taskdog_server.api.dependencies import (
+    initialize_api_context,
+    resolve_database_url,
+)
 from taskdog_server.api.error_handlers import register_exception_handlers
 from taskdog_server.api.middleware import LoggingMiddleware
 from taskdog_server.api.routers import (
     analytics_router,
     audit_router,
+    backup_router,
     bulk_router,
     lifecycle_router,
     notes_router,
@@ -45,6 +52,10 @@ def create_app() -> FastAPI:
         """
         # Startup: Configure logging first
         configure_logging()
+
+        # Apply a pending restore (if any) BEFORE the engine is created, so the
+        # restored DB is what Alembic then migrates forward.
+        SqliteBackupStore(resolve_database_url(config)).apply_pending_restore()
 
         # Initialize API context and store in app.state
         api_context = initialize_api_context(config)
@@ -85,6 +96,7 @@ def create_app() -> FastAPI:
     app.include_router(analytics_router, prefix="/api/v1", tags=["analytics"])
     app.include_router(tags_router, prefix="/api/v1/tags", tags=["tags"])
     app.include_router(audit_router, prefix="/api/v1/audit-logs", tags=["audit"])
+    app.include_router(backup_router, prefix="/api/v1", tags=["backup"])
     app.include_router(websocket_router, tags=["websocket"])
 
     @app.get("/")

--- a/packages/taskdog-server/src/taskdog_server/api/app.py
+++ b/packages/taskdog-server/src/taskdog_server/api/app.py
@@ -1,5 +1,6 @@
 """FastAPI application factory and configuration."""
 
+import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
@@ -54,8 +55,16 @@ def create_app() -> FastAPI:
         configure_logging()
 
         # Apply a pending restore (if any) BEFORE the engine is created, so the
-        # restored DB is what Alembic then migrates forward.
-        SqliteBackupStore(resolve_database_url(config)).apply_pending_restore()
+        # restored DB is what Alembic then migrates forward. A failed swap must
+        # not leave the server permanently unstartable: log and continue with
+        # the existing DB, leaving the pending file for a later retry.
+        try:
+            SqliteBackupStore(resolve_database_url(config)).apply_pending_restore()
+        except OSError:
+            logging.getLogger(__name__).exception(
+                "Failed to apply pending database restore; "
+                "starting with the existing database."
+            )
 
         # Initialize API context and store in app.state
         api_context = initialize_api_context(config)

--- a/packages/taskdog-server/src/taskdog_server/api/context.py
+++ b/packages/taskdog-server/src/taskdog_server/api/context.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from sqlalchemy.engine import Engine
 
 from taskdog_core.controllers.audit_log_controller import AuditLogController
+from taskdog_core.controllers.backup_controller import BackupController
 from taskdog_core.controllers.bulk_task_controller import BulkTaskController
 from taskdog_core.controllers.notes_controller import NotesController
 from taskdog_core.controllers.query_controller import QueryController
@@ -53,6 +54,7 @@ class ApiContext:
     audit_log_controller: AuditLogController
     notes_controller: NotesController
     bulk_controller: BulkTaskController
+    backup_controller: BackupController
     engine: Engine | None = field(default=None, repr=False)
 
     def close(self) -> None:

--- a/packages/taskdog-server/src/taskdog_server/api/dependencies.py
+++ b/packages/taskdog-server/src/taskdog_server/api/dependencies.py
@@ -8,6 +8,7 @@ from fastapi import BackgroundTasks, Depends, HTTPException, Request, WebSocket
 from fastapi.security import APIKeyHeader
 
 from taskdog_core.controllers.audit_log_controller import AuditLogController
+from taskdog_core.controllers.backup_controller import BackupController
 from taskdog_core.controllers.bulk_task_controller import BulkTaskController
 from taskdog_core.controllers.notes_controller import NotesController
 from taskdog_core.controllers.query_controller import QueryController
@@ -26,6 +27,9 @@ from taskdog_core.infrastructure.persistence.database.engine_factory import (
 from taskdog_core.infrastructure.persistence.database.sqlite_audit_log_repository import (
     SqliteAuditLogRepository,
 )
+from taskdog_core.infrastructure.persistence.database.sqlite_backup_store import (
+    SqliteBackupStore,
+)
 from taskdog_core.infrastructure.persistence.database.sqlite_notes_repository import (
     SqliteNotesRepository,
 )
@@ -40,6 +44,21 @@ from taskdog_server.websocket.connection_manager import ConnectionManager
 
 # API Key header definition
 api_key_header = APIKeyHeader(name="X-Api-Key", auto_error=False)
+
+
+def resolve_database_url(config: Config) -> str:
+    """Resolve the SQLite database URL from config, falling back to the XDG path.
+
+    Args:
+        config: Loaded application configuration.
+
+    Returns:
+        SQLAlchemy database URL.
+    """
+    if config.storage.database_url:
+        return config.storage.database_url
+    db_file = XDGDirectories.get_data_home() / "tasks.db"
+    return f"sqlite:///{db_file}"
 
 
 def initialize_api_context(
@@ -66,12 +85,7 @@ def initialize_api_context(
         time_provider = SystemTimeProvider()
 
     # Resolve database URL
-    if config.storage.database_url:
-        db_url = config.storage.database_url
-    else:
-        data_dir = XDGDirectories.get_data_home()
-        db_file = data_dir / "tasks.db"
-        db_url = f"sqlite:///{db_file}"
+    db_url = resolve_database_url(config)
 
     # Create a single shared engine for all repositories
     engine = create_sqlite_engine(db_url)
@@ -104,6 +118,9 @@ def initialize_api_context(
         lifecycle_controller, crud_controller, query_controller
     )
 
+    # Backup/restore controller over a storage-neutral port
+    backup_controller = BackupController(SqliteBackupStore(db_url))
+
     return ApiContext(
         repository=repository,
         config=config,
@@ -118,6 +135,7 @@ def initialize_api_context(
         audit_log_controller=audit_log_controller,
         notes_controller=notes_controller,
         bulk_controller=bulk_controller,
+        backup_controller=backup_controller,
         engine=engine,
     )
 
@@ -199,6 +217,11 @@ def get_bulk_controller(context: ApiContextDep) -> BulkTaskController:
     return context.bulk_controller
 
 
+def get_backup_controller(context: ApiContextDep) -> BackupController:
+    """Get backup controller from context."""
+    return context.backup_controller
+
+
 def get_connection_manager(request: Request) -> ConnectionManager:
     """Get the ConnectionManager instance from app.state for HTTP endpoints.
 
@@ -260,6 +283,7 @@ TimeProviderDep = Annotated[ITimeProvider, Depends(get_time_provider)]
 AuditLogControllerDep = Annotated[AuditLogController, Depends(get_audit_log_controller)]
 NotesControllerDep = Annotated[NotesController, Depends(get_notes_controller)]
 BulkTaskControllerDep = Annotated[BulkTaskController, Depends(get_bulk_controller)]
+BackupControllerDep = Annotated[BackupController, Depends(get_backup_controller)]
 ConnectionManagerDep = Annotated[ConnectionManager, Depends(get_connection_manager)]
 ConnectionManagerWsDep = Annotated[
     ConnectionManager, Depends(get_connection_manager_ws)

--- a/packages/taskdog-server/src/taskdog_server/api/error_handlers.py
+++ b/packages/taskdog-server/src/taskdog_server/api/error_handlers.py
@@ -8,6 +8,7 @@ try/except blocks.
 from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
 
+from taskdog_core.domain.exceptions.backup_exceptions import BackupValidationError
 from taskdog_core.domain.exceptions.tag_exceptions import TagNotFoundException
 from taskdog_core.domain.exceptions.task_exceptions import (
     TaskNotFoundException,
@@ -45,3 +46,4 @@ def register_exception_handlers(app: FastAPI) -> None:
     app.add_exception_handler(TaskNotFoundException, _not_found_handler)
     app.add_exception_handler(TagNotFoundException, _not_found_handler)
     app.add_exception_handler(TaskValidationError, _bad_request_handler)
+    app.add_exception_handler(BackupValidationError, _bad_request_handler)

--- a/packages/taskdog-server/src/taskdog_server/api/error_handlers.py
+++ b/packages/taskdog-server/src/taskdog_server/api/error_handlers.py
@@ -8,7 +8,10 @@ try/except blocks.
 from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
 
-from taskdog_core.domain.exceptions.backup_exceptions import BackupValidationError
+from taskdog_core.domain.exceptions.backup_exceptions import (
+    BackupNotSupportedError,
+    BackupValidationError,
+)
 from taskdog_core.domain.exceptions.tag_exceptions import TagNotFoundException
 from taskdog_core.domain.exceptions.task_exceptions import (
     TaskNotFoundException,
@@ -30,11 +33,19 @@ async def _bad_request_handler(_request: Request, exc: Exception) -> JSONRespons
     )
 
 
+async def _not_implemented_handler(_request: Request, exc: Exception) -> JSONResponse:
+    """Map unsupported-operation domain exceptions to 501 NOT_IMPLEMENTED."""
+    return JSONResponse(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED, content={"detail": str(exc)}
+    )
+
+
 def register_exception_handlers(app: FastAPI) -> None:
     """Register domain exception handlers on the FastAPI app.
 
     - TaskNotFoundException, TagNotFoundException -> 404 NOT_FOUND
-    - TaskValidationError (and subclasses) -> 400 BAD_REQUEST
+    - TaskValidationError (and subclasses), BackupValidationError -> 400 BAD_REQUEST
+    - BackupNotSupportedError -> 501 NOT_IMPLEMENTED
 
     Starlette resolves handlers by walking the exception's MRO, so registering
     TaskValidationError also covers TaskAlreadyFinishedError, TaskNotStartedError,
@@ -47,3 +58,4 @@ def register_exception_handlers(app: FastAPI) -> None:
     app.add_exception_handler(TagNotFoundException, _not_found_handler)
     app.add_exception_handler(TaskValidationError, _bad_request_handler)
     app.add_exception_handler(BackupValidationError, _bad_request_handler)
+    app.add_exception_handler(BackupNotSupportedError, _not_implemented_handler)

--- a/packages/taskdog-server/src/taskdog_server/api/routers/__init__.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/__init__.py
@@ -2,6 +2,7 @@
 
 from taskdog_server.api.routers.analytics import router as analytics_router
 from taskdog_server.api.routers.audit import router as audit_router
+from taskdog_server.api.routers.backup import router as backup_router
 from taskdog_server.api.routers.bulk import router as bulk_router
 from taskdog_server.api.routers.lifecycle import router as lifecycle_router
 from taskdog_server.api.routers.notes import router as notes_router
@@ -13,6 +14,7 @@ from taskdog_server.api.routers.websocket import router as websocket_router
 __all__ = [
     "analytics_router",
     "audit_router",
+    "backup_router",
     "bulk_router",
     "lifecycle_router",
     "notes_router",

--- a/packages/taskdog-server/src/taskdog_server/api/routers/backup.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/backup.py
@@ -1,0 +1,41 @@
+"""Backup/restore endpoints for the SQLite store."""
+
+from datetime import datetime
+from typing import Annotated
+
+from fastapi import APIRouter, File, UploadFile
+from fastapi.responses import StreamingResponse
+
+from taskdog_core.application.dto.restore_result import RestoreResultDTO
+from taskdog_server.api.dependencies import (
+    AuthenticatedClientDep,
+    BackupControllerDep,
+)
+
+router = APIRouter()
+
+
+@router.get("/backup")
+async def backup(
+    controller: BackupControllerDep,
+    _client_name: AuthenticatedClientDep,
+) -> StreamingResponse:
+    """Stream a consistent physical snapshot of the database as a `.db` file."""
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    filename = f"taskdog-backup-{timestamp}.db"
+    return StreamingResponse(
+        controller.create_snapshot(),
+        media_type="application/octet-stream",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.post("/restore", response_model=RestoreResultDTO)
+async def restore(
+    controller: BackupControllerDep,
+    _client_name: AuthenticatedClientDep,
+    file: Annotated[UploadFile, File()],
+) -> RestoreResultDTO:
+    """Stage an uploaded `.db` snapshot to be applied on the next server restart."""
+    data = await file.read()
+    return controller.restore(iter([data]))

--- a/packages/taskdog-server/src/taskdog_server/api/routers/backup.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/backup.py
@@ -1,5 +1,6 @@
 """Backup/restore endpoints for the SQLite store."""
 
+from collections.abc import Iterator
 from datetime import datetime
 from typing import Annotated
 
@@ -13,6 +14,9 @@ from taskdog_server.api.dependencies import (
 )
 
 router = APIRouter()
+
+# Read the spooled upload back off disk in 1 MiB chunks.
+_CHUNK_SIZE = 1024 * 1024
 
 
 @router.get("/backup")
@@ -37,5 +41,12 @@ async def restore(
     file: Annotated[UploadFile, File()],
 ) -> RestoreResultDTO:
     """Stage an uploaded `.db` snapshot to be applied on the next server restart."""
-    data = await file.read()
-    return controller.restore(iter([data]))
+
+    # Starlette already spooled the upload to a temp file, so read it back in
+    # bounded chunks instead of loading the whole DB into memory.
+    def _chunks() -> Iterator[bytes]:
+        file.file.seek(0)
+        while chunk := file.file.read(_CHUNK_SIZE):
+            yield chunk
+
+    return controller.restore(_chunks())

--- a/packages/taskdog-server/tests/api/test_app.py
+++ b/packages/taskdog-server/tests/api/test_app.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from taskdog_core.controllers.audit_log_controller import AuditLogController
+from taskdog_core.controllers.backup_controller import BackupController
 from taskdog_core.controllers.bulk_task_controller import BulkTaskController
 from taskdog_core.controllers.notes_controller import NotesController
 from taskdog_core.controllers.query_controller import QueryController
@@ -15,6 +16,9 @@ from taskdog_core.controllers.task_crud_controller import TaskCrudController
 from taskdog_core.controllers.task_lifecycle_controller import TaskLifecycleController
 from taskdog_core.controllers.task_relationship_controller import (
     TaskRelationshipController,
+)
+from taskdog_core.infrastructure.persistence.database.sqlite_backup_store import (
+    SqliteBackupStore,
 )
 from taskdog_core.infrastructure.time_provider import SystemTimeProvider
 from taskdog_server import __version__
@@ -74,6 +78,7 @@ class TestApp:
                 crud_controller=crud_controller,
                 query_controller=query_controller,
             ),
+            backup_controller=BackupController(SqliteBackupStore("sqlite:///:memory:")),
         )
 
         # Create app using create_app (lifespan will set its own context)

--- a/packages/taskdog-server/tests/api/test_backup_router.py
+++ b/packages/taskdog-server/tests/api/test_backup_router.py
@@ -98,3 +98,32 @@ class TestRestoreEndpoint:
         )
 
         assert response.status_code == 400
+
+
+class TestInMemoryStoreNotSupported:
+    """An in-memory store cannot be backed up/restored -> 501, not 500."""
+
+    @pytest.fixture
+    def client(self) -> TestClient:
+        app = FastAPI()
+        register_exception_handlers(app)
+
+        class _Ctx:
+            backup_controller = BackupController(
+                SqliteBackupStore("sqlite:///:memory:")
+            )
+
+        app.state.api_context = _Ctx()
+        app.state.server_config = ServerConfig(auth=AuthConfig(enabled=False))
+        app.include_router(backup_router, prefix="/api/v1", tags=["backup"])
+        return TestClient(app, raise_server_exceptions=False)
+
+    def test_backup_returns_501(self, client: TestClient) -> None:
+        assert client.get("/api/v1/backup").status_code == 501
+
+    def test_restore_returns_501(self, client: TestClient) -> None:
+        response = client.post(
+            "/api/v1/restore",
+            files={"file": ("x.db", b"data", "application/octet-stream")},
+        )
+        assert response.status_code == 501

--- a/packages/taskdog-server/tests/api/test_backup_router.py
+++ b/packages/taskdog-server/tests/api/test_backup_router.py
@@ -1,0 +1,100 @@
+"""Tests for the backup/restore endpoints (issue #999)."""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from taskdog_core.controllers.backup_controller import BackupController
+from taskdog_core.infrastructure.persistence.database.sqlite_backup_store import (
+    SqliteBackupStore,
+)
+from taskdog_server.api.error_handlers import register_exception_handlers
+from taskdog_server.api.routers import backup_router
+from taskdog_server.config.server_config_manager import AuthConfig, ServerConfig
+
+
+def _seed_db(path: Path, rows: list[str]) -> None:
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("CREATE TABLE notes (body TEXT)")
+        conn.executemany("INSERT INTO notes (body) VALUES (?)", [(r,) for r in rows])
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _read_rows(path: Path) -> list[str]:
+    conn = sqlite3.connect(path)
+    try:
+        return [row[0] for row in conn.execute("SELECT body FROM notes ORDER BY body")]
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    db = tmp_path / "tasks.db"
+    _seed_db(db, ["alpha", "beta"])
+    return db
+
+
+@pytest.fixture
+def client(db_path: Path) -> TestClient:
+    app = FastAPI()
+    register_exception_handlers(app)
+
+    class _Ctx:
+        backup_controller = BackupController(SqliteBackupStore(f"sqlite:///{db_path}"))
+
+    app.state.api_context = _Ctx()
+    app.state.server_config = ServerConfig(auth=AuthConfig(enabled=False))
+    app.include_router(backup_router, prefix="/api/v1", tags=["backup"])
+    return TestClient(app)
+
+
+class TestBackupEndpoint:
+    def test_backup_streams_a_valid_snapshot(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        response = client.get("/api/v1/backup")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "application/octet-stream"
+        assert "attachment" in response.headers["content-disposition"]
+        assert ".db" in response.headers["content-disposition"]
+
+        downloaded = tmp_path / "downloaded.db"
+        downloaded.write_bytes(response.content)
+        assert _read_rows(downloaded) == ["alpha", "beta"]
+
+
+class TestRestoreEndpoint:
+    def test_restore_stages_a_valid_upload(
+        self, client: TestClient, tmp_path: Path, db_path: Path
+    ) -> None:
+        snapshot = tmp_path / "snapshot.db"
+        _seed_db(snapshot, ["restored"])
+
+        response = client.post(
+            "/api/v1/restore",
+            files={
+                "file": ("backup.db", snapshot.read_bytes(), "application/octet-stream")
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "pending", "message": "restart required"}
+        # Staged, not yet applied.
+        assert db_path.with_name("tasks.db.pending-restore").exists()
+        assert _read_rows(db_path) == ["alpha", "beta"]
+
+    def test_restore_rejects_invalid_upload(self, client: TestClient) -> None:
+        response = client.post(
+            "/api/v1/restore",
+            files={"file": ("bad.db", b"not a database", "application/octet-stream")},
+        )
+
+        assert response.status_code == 400

--- a/packages/taskdog-server/tests/api/test_context.py
+++ b/packages/taskdog-server/tests/api/test_context.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock
 
 from taskdog_core.controllers.audit_log_controller import AuditLogController
+from taskdog_core.controllers.backup_controller import BackupController
 from taskdog_core.controllers.bulk_task_controller import BulkTaskController
 from taskdog_core.controllers.notes_controller import NotesController
 from taskdog_core.controllers.query_controller import QueryController
@@ -39,6 +40,7 @@ class TestApiContext:
         self.mock_audit_log_controller = Mock(spec=AuditLogController)
         self.mock_notes_controller = Mock(spec=NotesController)
         self.mock_bulk_controller = Mock(spec=BulkTaskController)
+        self.mock_backup_controller = Mock(spec=BackupController)
 
     def test_create_context_with_all_dependencies(self):
         """Test creating ApiContext with all dependencies."""
@@ -57,6 +59,7 @@ class TestApiContext:
             audit_log_controller=self.mock_audit_log_controller,
             notes_controller=self.mock_notes_controller,
             bulk_controller=self.mock_bulk_controller,
+            backup_controller=self.mock_backup_controller,
         )
 
         # Assert
@@ -89,6 +92,7 @@ class TestApiContext:
             audit_log_controller=self.mock_audit_log_controller,
             notes_controller=self.mock_notes_controller,
             bulk_controller=self.mock_bulk_controller,
+            backup_controller=self.mock_backup_controller,
         )
 
         # Assert
@@ -111,6 +115,7 @@ class TestApiContext:
             audit_log_controller=self.mock_audit_log_controller,
             notes_controller=self.mock_notes_controller,
             bulk_controller=self.mock_bulk_controller,
+            backup_controller=self.mock_backup_controller,
         )
 
         # Assert - verify all attributes are accessible
@@ -145,6 +150,7 @@ class TestApiContext:
             audit_log_controller=self.mock_audit_log_controller,
             notes_controller=self.mock_notes_controller,
             bulk_controller=self.mock_bulk_controller,
+            backup_controller=self.mock_backup_controller,
         )
 
         context2 = ApiContext(
@@ -161,6 +167,7 @@ class TestApiContext:
             audit_log_controller=self.mock_audit_log_controller,
             notes_controller=self.mock_notes_controller,
             bulk_controller=self.mock_bulk_controller,
+            backup_controller=self.mock_backup_controller,
         )
 
         # Assert
@@ -186,6 +193,7 @@ class TestApiContext:
             audit_log_controller=self.mock_audit_log_controller,
             notes_controller=self.mock_notes_controller,
             bulk_controller=self.mock_bulk_controller,
+            backup_controller=self.mock_backup_controller,
         )
 
         context2 = ApiContext(
@@ -202,6 +210,7 @@ class TestApiContext:
             audit_log_controller=self.mock_audit_log_controller,
             notes_controller=self.mock_notes_controller,
             bulk_controller=self.mock_bulk_controller,
+            backup_controller=self.mock_backup_controller,
         )
 
         # Assert
@@ -224,6 +233,7 @@ class TestApiContext:
             audit_log_controller=self.mock_audit_log_controller,
             notes_controller=self.mock_notes_controller,
             bulk_controller=self.mock_bulk_controller,
+            backup_controller=self.mock_backup_controller,
         )
 
         # Assert - verify all five controllers are present
@@ -260,6 +270,7 @@ class TestApiContext:
             audit_log_controller=self.mock_audit_log_controller,
             notes_controller=self.mock_notes_controller,
             bulk_controller=self.mock_bulk_controller,
+            backup_controller=self.mock_backup_controller,
         )
 
         assert context.time_provider is time_provider

--- a/packages/taskdog-server/tests/conftest.py
+++ b/packages/taskdog-server/tests/conftest.py
@@ -36,6 +36,9 @@ from fixtures.repositories import InMemoryTaskRepository  # noqa: E402
 from taskdog_core.controllers.audit_log_controller import (  # noqa: E402
     AuditLogController,
 )
+from taskdog_core.controllers.backup_controller import (  # noqa: E402
+    BackupController,
+)
 from taskdog_core.controllers.bulk_task_controller import (  # noqa: E402
     BulkTaskController,
 )
@@ -55,6 +58,9 @@ from taskdog_core.controllers.task_relationship_controller import (  # noqa: E40
 )
 from taskdog_core.infrastructure.persistence.database.sqlite_audit_log_repository import (  # noqa: E402
     SqliteAuditLogRepository,
+)
+from taskdog_core.infrastructure.persistence.database.sqlite_backup_store import (  # noqa: E402
+    SqliteBackupStore,
 )
 from taskdog_core.infrastructure.time_provider import SystemTimeProvider  # noqa: E402
 
@@ -221,6 +227,7 @@ def app(
     bulk_controller = BulkTaskController(
         lifecycle_controller, crud_controller, query_controller
     )
+    backup_controller = BackupController(SqliteBackupStore("sqlite:///:memory:"))
 
     # Create API context once
     api_context = ApiContext(
@@ -237,6 +244,7 @@ def app(
         audit_log_controller=audit_log_controller,
         notes_controller=notes_controller,
         bulk_controller=bulk_controller,
+        backup_controller=backup_controller,
     )
 
     # Create FastAPI app once with all routers

--- a/packages/taskdog-ui/src/taskdog/cli/commands/backup.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/backup.py
@@ -1,0 +1,51 @@
+"""Backup command - Download a physical snapshot of the database."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
+
+
+@click.command(
+    name="backup",
+    help="Back up the database to a physical .db snapshot.",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(dir_okay=False),
+    help="Output file path (default: ./taskdog-backup-YYYYMMDD-HHMMSS.db).",
+)
+@click.pass_context
+def backup_command(ctx: click.Context, output: str | None) -> None:
+    """Download a consistent physical snapshot of the server database.
+
+    Unlike `export` (logical JSON/CSV), this is a full physical snapshot
+    intended for real recovery.
+
+    Examples:
+        taskdog backup                       # save to ./taskdog-backup-<ts>.db
+        taskdog backup -o /backups/tasks.db  # save to a specific path
+    """
+    ctx_obj: CliContext = ctx.obj
+    console_writer = ctx_obj.console_writer
+    api_client = ctx_obj.api_client
+
+    if output:
+        path = Path(output)
+    else:
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        path = Path.cwd() / f"taskdog-backup-{timestamp}.db"
+
+    try:
+        api_client.backup(path)
+        console_writer.success(f"Backup saved to {path}")
+    except Exception as e:
+        console_writer.error("backing up database", e)
+        raise click.Abort() from e

--- a/packages/taskdog-ui/src/taskdog/cli/commands/restore_db.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/restore_db.py
@@ -1,0 +1,57 @@
+"""Restore-db command - Upload a database snapshot to be applied on restart."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from taskdog.cli.context import CliContext
+
+
+@click.command(
+    name="restore-db",
+    help="Restore the database from a physical .db snapshot (applied on restart).",
+)
+@click.argument(
+    "file_path",
+    type=click.Path(exists=True, dir_okay=False),
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    help="Skip the confirmation prompt.",
+)
+@click.pass_context
+def restore_db_command(ctx: click.Context, file_path: str, yes: bool) -> None:
+    """Upload a `.db` snapshot to replace the server database.
+
+    This is destructive: the snapshot is staged now and replaces the live
+    database the next time the server starts. Restart the server to apply.
+
+    Examples:
+        taskdog restore-db ./taskdog-backup-20250101-120000.db
+        taskdog restore-db backup.db --yes
+    """
+    ctx_obj: CliContext = ctx.obj
+    console_writer = ctx_obj.console_writer
+    api_client = ctx_obj.api_client
+
+    if not yes and not click.confirm(
+        f"This will replace the server database with '{file_path}' on the next "
+        "server restart. Continue?"
+    ):
+        console_writer.info("Restore canceled.")
+        return
+
+    try:
+        result = api_client.restore(Path(file_path))
+        console_writer.success(
+            f"Restore staged ({result.status}). Restart the server to apply."
+        )
+    except Exception as e:
+        console_writer.error("restoring database", e)
+        raise click.Abort() from e

--- a/packages/taskdog-ui/src/taskdog/cli_main.py
+++ b/packages/taskdog-ui/src/taskdog/cli_main.py
@@ -26,6 +26,10 @@ LAZY_SUBCOMMANDS: dict[str, tuple[str, str]] = {
         "taskdog.cli.commands.audit_logs.audit_logs_command",
         "Display operation history (audit logs).",
     ),
+    "backup": (
+        "taskdog.cli.commands.backup.backup_command",
+        "Back up the database to a physical .db snapshot.",
+    ),
     "cancel": (
         "taskdog.cli.commands.cancel.cancel_command",
         "Mark task(s) as canceled.",
@@ -63,6 +67,10 @@ LAZY_SUBCOMMANDS: dict[str, tuple[str, str]] = {
     "restore": (
         "taskdog.cli.commands.restore.restore_command",
         "Restore archived task(s).",
+    ),
+    "restore-db": (
+        "taskdog.cli.commands.restore_db.restore_db_command",
+        "Restore the database from a physical .db snapshot (applied on restart).",
     ),
     "rm": (
         "taskdog.cli.commands.rm.rm_command",

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_backup_command.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_backup_command.py
@@ -1,0 +1,102 @@
+"""Tests for backup and restore-db commands."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from taskdog.cli.commands.backup import backup_command
+from taskdog.cli.commands.restore_db import restore_db_command
+
+
+class TestBackupCommand:
+    """Test cases for the backup command."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.runner = CliRunner()
+        self.console_writer = MagicMock()
+        self.api_client = MagicMock()
+        self.cli_context = MagicMock()
+        self.cli_context.console_writer = self.console_writer
+        self.cli_context.api_client = self.api_client
+
+    def test_backup_with_explicit_output(self):
+        with self.runner.isolated_filesystem():
+            result = self.runner.invoke(
+                backup_command, ["-o", "out.db"], obj=self.cli_context
+            )
+
+        assert result.exit_code == 0
+        (path,) = self.api_client.backup.call_args.args
+        assert path == Path("out.db")
+        self.console_writer.success.assert_called_once()
+
+    def test_backup_defaults_to_timestamped_cwd_file(self):
+        with self.runner.isolated_filesystem():
+            result = self.runner.invoke(backup_command, [], obj=self.cli_context)
+
+        assert result.exit_code == 0
+        (path,) = self.api_client.backup.call_args.args
+        assert path.name.startswith("taskdog-backup-")
+        assert path.suffix == ".db"
+
+    def test_backup_reports_error(self):
+        self.api_client.backup.side_effect = RuntimeError("nope")
+
+        with self.runner.isolated_filesystem():
+            result = self.runner.invoke(
+                backup_command, ["-o", "out.db"], obj=self.cli_context
+            )
+
+        assert result.exit_code != 0
+        self.console_writer.error.assert_called_once()
+
+
+class TestRestoreDbCommand:
+    """Test cases for the restore-db command."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.runner = CliRunner()
+        self.console_writer = MagicMock()
+        self.api_client = MagicMock()
+        self.api_client.restore.return_value = MagicMock(
+            status="pending", message="restart required"
+        )
+        self.cli_context = MagicMock()
+        self.cli_context.console_writer = self.console_writer
+        self.cli_context.api_client = self.api_client
+
+    def test_restore_requires_confirmation(self):
+        with self.runner.isolated_filesystem():
+            Path("snap.db").write_bytes(b"db")
+            result = self.runner.invoke(
+                restore_db_command, ["snap.db"], obj=self.cli_context, input="n\n"
+            )
+
+        assert result.exit_code == 0
+        self.api_client.restore.assert_not_called()
+        self.console_writer.info.assert_called_once()
+
+    def test_restore_with_yes_skips_prompt(self):
+        with self.runner.isolated_filesystem():
+            Path("snap.db").write_bytes(b"db")
+            result = self.runner.invoke(
+                restore_db_command, ["snap.db", "--yes"], obj=self.cli_context
+            )
+
+        assert result.exit_code == 0
+        (path,) = self.api_client.restore.call_args.args
+        assert path == Path("snap.db")
+        self.console_writer.success.assert_called_once()
+
+    def test_restore_missing_file_errors(self):
+        with self.runner.isolated_filesystem():
+            result = self.runner.invoke(
+                restore_db_command, ["missing.db", "--yes"], obj=self.cli_context
+            )
+
+        assert result.exit_code != 0
+        self.api_client.restore.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -1452,6 +1452,7 @@ source = { editable = "packages/taskdog-server" }
 dependencies = [
     { name = "fastapi" },
     { name = "pydantic" },
+    { name = "python-multipart" },
     { name = "taskdog-core" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -1475,6 +1476,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
+    { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "taskdog-core", editable = "packages/taskdog-core" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.48.0" },


### PR DESCRIPTION
## Summary

Add a **physical** backup/restore feature for the SQLite store, exposed over the HTTP API so it works with remote-server setups and keeps the "only the server touches data" rule. This is distinct from the existing logical `export` (JSON/CSV): backup is a full physical snapshot (audit log, notes, dependencies, tags) intended for real recovery.

Closes #999.

## Design (mirrors the existing repository port/impl split)

- **`domain/services/backup_store.py`** — `IBackupStore(ABC)`, storage-neutral: `create_snapshot() -> Iterator[bytes]`, `stage_restore(data)`, `apply_pending_restore() -> bool`. No `.db`, paths, or SQL leak into domain/application.
- **`infrastructure/.../sqlite_backup_store.py`** — `SqliteBackupStore`, the only place that knows SQLite: `VACUUM INTO` for a consistent defragmented single-file snapshot, `PRAGMA integrity_check` on upload, and a startup file swap (move current DB to `*.pre-restore-<ts>`, delete stale `-wal`/`-shm`, rename pending onto `tasks.db`).
- **`controllers/backup_controller.py`** — `BackupController(store)`; `RestoreResultDTO`; `BackupError` hierarchy.

## Endpoints

- `GET /api/v1/backup` → `StreamingResponse`, `Content-Disposition: attachment; filename="taskdog-backup-<ts>.db"`.
- `POST /api/v1/restore` → multipart `.db` upload → integrity check (**400** on failure) → staged as `<db>.pending-restore` → `{"status": "pending", "message": "restart required"}`.
- Both honor the existing API-key auth.
- `apply_pending_restore()` runs in the FastAPI lifespan **before** the engine is created, so Alembic migrates a restored (possibly older) backup forward.

## Client & CLI

- `TaskdogApiClient.backup(path)` (streaming download) / `restore(path)` (multipart upload); `BaseApiClient.auth_headers()` extracted so streaming/multipart reuse auth.
- `taskdog backup [-o PATH]` — default `./taskdog-backup-YYYYMMDD-HHMMSS.db`.
- `taskdog restore-db PATH` — confirmation prompt (`--yes` to skip), instructs a restart on success.

### ⚠️ Naming note
The issue proposed `taskdog restore PATH`, but `restore` already exists and means **un-archive task(s)**. To avoid breaking it, the DB-restore command is named **`restore-db`**. Happy to rename if you'd prefer a `db` command group instead.

### Open question (from the issue)
Default `-o` location: chose **cwd + timestamped name** (`./taskdog-backup-<ts>.db`).

## Tests

- core: `SqliteBackupStore` snapshot round-trip, no-temp-leak, in-memory unsupported, restore staging + integrity rejection, `apply_pending_restore` incl. WAL/SHM cleanup and pre-restore copy.
- server: both endpoints + 400 on integrity failure.
- client + CLI: mocked (download chunks, error mapping, multipart upload, confirmation / `--yes` / missing-file).

## Verification

- Full suites: core 1116, client 223, server 322, ui 1049 — all pass. ruff + mypy clean across all four packages. pre-push (`make test`, vulture) passed.
- **End-to-end against a running server**: created a task → `backup` → added a second task → `restore-db --yes` → restarted the server → only the first task remained; `*.pre-restore-*` copy preserved, WAL/SHM regenerated cleanly.

## Out of scope (v1)

- MCP (operational action, not task management).