### PR TITLE
feat(tui): add Backup command to the command palette

### DIFF
--- a/packages/taskdog-ui/src/taskdog/formatters/date_time_formatter.py
+++ b/packages/taskdog-ui/src/taskdog/formatters/date_time_formatter.py
@@ -153,6 +153,15 @@ class DateTimeFormatter:
         return datetime.now().strftime("%Y%m%d")
 
     @staticmethod
+    def format_timestamp_for_filename() -> str:
+        """Format current timestamp for filename (YYYYMMDD-HHMMSS).
+
+        Returns:
+            Current timestamp formatted as YYYYMMDD-HHMMSS
+        """
+        return datetime.now().strftime("%Y%m%d-%H%M%S")
+
+    @staticmethod
     def format_datetime_for_export(dt: datetime | None) -> str:
         """Format datetime for export (CSV/Markdown).
 

--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -37,6 +37,7 @@ from taskdog.tui.events import FilterChanged, GanttResizeRequested, TasksRefresh
 from taskdog.tui.palette.providers import (
     ArchiveCommandProvider,
     AuditCommandProvider,
+    BackupCommandProvider,
     ExportCommandProvider,
     ExportFormatProvider,
     HelpCommandProvider,
@@ -206,6 +207,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         SortCommandProvider,
         OptimizeCommandProvider,
         ExportCommandProvider,
+        BackupCommandProvider,
         HelpCommandProvider,
     }
 
@@ -431,6 +433,13 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
                 placeholder="Select export format…",
             ),
         )
+
+    def run_backup(self) -> None:
+        """Back up the database to a file.
+
+        Called from the Command Palette via BackupCommandProvider.
+        """
+        self.command_factory.execute("backup")
 
     def search_help(self) -> None:
         """Show the help screen with keybindings and usage instructions."""

--- a/packages/taskdog-ui/src/taskdog/tui/commands/__init__.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/__init__.py
@@ -2,6 +2,7 @@
 
 from taskdog.tui.commands.add import AddCommand
 from taskdog.tui.commands.audit import AuditCommand
+from taskdog.tui.commands.backup import BackupCommand
 from taskdog.tui.commands.base import TUICommandBase
 from taskdog.tui.commands.cancel import CancelCommand
 from taskdog.tui.commands.done import DoneCommand
@@ -23,6 +24,7 @@ from taskdog.tui.commands.stats import StatsCommand
 COMMANDS: dict[str, type[TUICommandBase]] = {
     "add": AddCommand,
     "audit": AuditCommand,
+    "backup": BackupCommand,
     "cancel": CancelCommand,
     "done": DoneCommand,
     "edit": EditCommand,

--- a/packages/taskdog-ui/src/taskdog/tui/commands/backup.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/backup.py
@@ -1,0 +1,31 @@
+"""Backup command for TUI."""
+
+from pathlib import Path
+
+from taskdog.formatters.date_time_formatter import DateTimeFormatter
+from taskdog.tui.commands.base import TUICommandBase
+from taskdog_core.domain.exceptions.task_exceptions import ServerConnectionError
+
+
+class BackupCommand(TUICommandBase):
+    """Command to back up the database to a physical snapshot file.
+
+    Downloads a consistent `.db` snapshot from the server into ~/Downloads.
+    """
+
+    def execute(self) -> None:
+        """Execute the backup command."""
+        timestamp = DateTimeFormatter.format_timestamp_for_filename()
+        downloads_dir = Path.home() / "Downloads"
+        downloads_dir.mkdir(parents=True, exist_ok=True)
+        output_path = downloads_dir / f"taskdog-backup-{timestamp}.db"
+
+        try:
+            self.context.api_client.backup(output_path)
+            self.notify_success(f"Backup saved to {output_path}")
+        except ServerConnectionError as e:
+            self.notify_error(
+                f"Server connection failed: {e.original_error.__class__.__name__}", e
+            )
+        except Exception as e:
+            self.notify_error("Backup failed", e)

--- a/packages/taskdog-ui/src/taskdog/tui/palette/providers/__init__.py
+++ b/packages/taskdog-ui/src/taskdog/tui/palette/providers/__init__.py
@@ -2,6 +2,7 @@
 
 from taskdog.tui.palette.providers.archive_provider import ArchiveCommandProvider
 from taskdog.tui.palette.providers.audit_provider import AuditCommandProvider
+from taskdog.tui.palette.providers.backup_provider import BackupCommandProvider
 from taskdog.tui.palette.providers.base import BaseListProvider
 from taskdog.tui.palette.providers.export_providers import (
     EXPORT_FORMATS,
@@ -19,6 +20,7 @@ __all__ = [
     "EXPORT_FORMATS",
     "ArchiveCommandProvider",
     "AuditCommandProvider",
+    "BackupCommandProvider",
     "BaseListProvider",
     "ExportCommandProvider",
     "ExportFormatProvider",

--- a/packages/taskdog-ui/src/taskdog/tui/palette/providers/backup_provider.py
+++ b/packages/taskdog-ui/src/taskdog/tui/palette/providers/backup_provider.py
@@ -1,0 +1,13 @@
+"""Command provider for backup functionality."""
+
+from __future__ import annotations
+
+from taskdog.tui.palette.providers.base import SimpleSingleCommandProvider
+
+
+class BackupCommandProvider(SimpleSingleCommandProvider):
+    """Command provider for the 'Backup' command."""
+
+    COMMAND_NAME = "Backup"
+    COMMAND_HELP = "Back up the database to a file"
+    COMMAND_CALLBACK_NAME = "run_backup"

--- a/packages/taskdog-ui/tests/tui/commands/test_backup.py
+++ b/packages/taskdog-ui/tests/tui/commands/test_backup.py
@@ -1,0 +1,83 @@
+"""Tests for BackupCommand."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from taskdog.tui.commands.backup import BackupCommand
+from taskdog_core.domain.exceptions.task_exceptions import ServerConnectionError
+
+
+class TestBackupCommandExecute:
+    """Test cases for execute method."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self) -> None:
+        """Set up test fixtures."""
+        self.mock_app = MagicMock()
+        self.mock_context = MagicMock()
+
+    @patch("taskdog.tui.commands.backup.Path")
+    def test_downloads_backup_and_notifies_success(self, mock_path: MagicMock) -> None:
+        """Backup downloads to ~/Downloads and reports success."""
+        mock_home = MagicMock()
+        mock_downloads = MagicMock()
+        mock_output = MagicMock()
+        mock_path.home.return_value = mock_home
+        mock_home.__truediv__.return_value = mock_downloads
+        mock_downloads.__truediv__.return_value = mock_output
+
+        command = BackupCommand(self.mock_app, self.mock_context)
+        command.notify_success = MagicMock()
+
+        command.execute()
+
+        self.mock_context.api_client.backup.assert_called_once_with(mock_output)
+        mock_downloads.mkdir.assert_called_once_with(parents=True, exist_ok=True)
+        command.notify_success.assert_called_once()
+
+    @patch("taskdog.tui.commands.backup.Path")
+    def test_filename_uses_backup_prefix_and_db_suffix(
+        self, mock_path: MagicMock
+    ) -> None:
+        """The download filename follows taskdog-backup-<ts>.db."""
+        mock_home = MagicMock()
+        mock_downloads = MagicMock()
+        mock_path.home.return_value = mock_home
+        mock_home.__truediv__.return_value = mock_downloads
+
+        command = BackupCommand(self.mock_app, self.mock_context)
+        command.notify_success = MagicMock()
+
+        command.execute()
+
+        filename = mock_downloads.__truediv__.call_args[0][0]
+        assert filename.startswith("taskdog-backup-")
+        assert filename.endswith(".db")
+
+    def test_handles_server_connection_error(self) -> None:
+        """Server connection errors are reported via notify_error."""
+        original_error = ConnectionError("Connection refused")
+        self.mock_context.api_client.backup.side_effect = ServerConnectionError(
+            "http://localhost:8000", original_error
+        )
+
+        command = BackupCommand(self.mock_app, self.mock_context)
+        command.notify_error = MagicMock()
+
+        command.execute()
+
+        command.notify_error.assert_called_once()
+        assert "server connection" in command.notify_error.call_args[0][0].lower()
+
+    def test_handles_generic_exception(self) -> None:
+        """Generic errors are reported via notify_error."""
+        self.mock_context.api_client.backup.side_effect = RuntimeError("boom")
+
+        command = BackupCommand(self.mock_app, self.mock_context)
+        command.notify_error = MagicMock()
+
+        command.execute()
+
+        command.notify_error.assert_called_once()
+        assert "backup failed" in command.notify_error.call_args[0][0].lower()

--- a/scripts/vulture_whitelist.py
+++ b/scripts/vulture_whitelist.py
@@ -3,6 +3,7 @@ estimation  # unused variable (packages/taskdog-server/src/taskdog_server/api/mo
 trends  # unused variable (packages/taskdog-server/src/taskdog_server/api/models/responses.py:270)
 _.format_commands  # Click override called via duck-typing (packages/taskdog-ui/src/taskdog/cli_main.py:138)
 _.show_audit_logs  # unused method (packages/taskdog-ui/src/taskdog/tui/app.py:478)
+_.run_backup  # palette callback via getattr (packages/taskdog-ui/src/taskdog/tui/app.py)
 _.toggle_archive  # palette callback via getattr (packages/taskdog-ui/src/taskdog/tui/app.py)
 _.loading  # Textual Widget reactive (packages/taskdog-ui/src/taskdog/tui/app.py)
 SelectionProvider  # unused import (packages/taskdog-ui/src/taskdog/tui/context.py:12)


### PR DESCRIPTION
## Summary

Surface the database backup (added in #999) from the TUI. A **Backup** entry in the command palette downloads a physical `.db` snapshot to `~/Downloads/taskdog-backup-<timestamp>.db` and notifies with the full path.

## Design

Mirrors the existing **Export** command structure:
- `tui/commands/backup.py` — `BackupCommand(TUICommandBase)`; `execute()` builds the `~/Downloads` path and calls `api_client.backup(path)`, with the same `ServerConnectionError` / generic-error notification handling as Export.
- `tui/palette/providers/backup_provider.py` — `BackupCommandProvider(SimpleSingleCommandProvider)` (single-stage, same mechanism as Audit), callback `run_backup`.
- `app.py` — registers the provider and adds `run_backup()` → `command_factory.execute("backup")`.
- `DateTimeFormatter.format_timestamp_for_filename()` — `YYYYMMDD-HHMMSS` (second precision so multiple backups/day don't collide), matching the CLI/server backup filename.

**Scope:** backup only. Restore stays in the CLI (`restore-db`) — it is destructive and only applies on server restart, which is awkward to drive from a live TUI.

## Verification

- New `test_backup.py`: success path (downloads to `~/Downloads`, `mkdir` Downloads, notifies), filename is `taskdog-backup-*.db`, and both error paths notify.
- Wiring integration check: provider callback `run_backup` resolves on the app → `command_factory.execute("backup")` → `BackupCommand.execute` → `api_client.backup(~/Downloads/...db)`. (Palette surfacing uses the same `SimpleSingleCommandProvider` mechanism as the working Export/Audit entries.)
- Full UI suite 1053 passed; ruff + mypy clean; pre-push (make test, vulture) green.