### PR TITLE
feat(tui): consolidate mode state into footer badges

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -445,6 +445,11 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         """Show the help screen with keybindings and usage instructions."""
         self.command_factory.execute("show_help")
 
+    def _refresh_mode_badges(self) -> None:
+        """Refresh the footer mode badges to reflect current toggle/sort state."""
+        if self.main_screen and self.main_screen.custom_footer:
+            self.main_screen.custom_footer.update_mode_badges(self.state)
+
     def set_sort_order(self, sort_key: str) -> None:
         """Set the sort order for Gantt chart and task list.
 
@@ -457,6 +462,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
 
         # Post TasksRefreshed event to trigger UI refresh with new sort order
         self.post_message(TasksRefreshed())
+        self._refresh_mode_badges()
 
         # Show notification message with current direction
         sort_label = SORT_KEY_LABELS.get(sort_key, sort_key)
@@ -480,6 +486,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
 
         # Reload tasks with new sort direction
         self.request_reload()
+        self._refresh_mode_badges()
 
         # Show notification with current direction
         direction = "descending" if self.state.sort_reverse else "ascending"
@@ -502,6 +509,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         enabled = self.state.toggle_gantt_filter()
         # Post to current screen so MainScreen's on_filter_changed handler receives it
         self.screen.post_message(FilterChanged(gantt_filter_toggled=True))
+        self._refresh_mode_badges()
         status = "enabled" if enabled else "disabled"
         self.notify(f"Gantt filter {status}")
 
@@ -516,6 +524,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         """
         self.state.show_archived = not self.state.show_archived
         self.request_reload()
+        self._refresh_mode_badges()
         status = "shown" if self.state.show_archived else "hidden"
         self.notify(f"Archived tasks {status}")
 

--- a/packages/taskdog-ui/src/taskdog/tui/styles/components.tcss
+++ b/packages/taskdog-ui/src/taskdog/tui/styles/components.tcss
@@ -47,6 +47,15 @@
     padding: 0 1;
 }
 
+#footer-mode-badges {
+    width: auto;
+    height: auto;
+    content-align: right middle;
+    padding: 0 1;
+    color: $accent;
+    text-style: bold;
+}
+
 #footer-connection-status {
     width: auto;
     height: auto;

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/custom_footer.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/custom_footer.py
@@ -10,21 +10,56 @@ from textual.message import Message
 from textual.reactive import reactive
 from textual.widgets import Input, Static
 
+from taskdog.tui.constants.ui_settings import SORT_KEY_LABELS
 from taskdog.tui.events import SearchQueryChanged
 from taskdog.tui.widgets.base_widget import TUIWidget
 
 if TYPE_CHECKING:
-    from taskdog.tui.state import ConnectionStatus
+    from taskdog.tui.state import ConnectionStatus, TUIState
 
 # Constants
 SEARCH_INPUT_ID = "footer-search-input"
+
+
+def format_mode_badges(
+    *,
+    gantt_filter_enabled: bool,
+    show_archived: bool,
+    sort_by: str,
+    sort_reverse: bool,
+) -> str:
+    """Render the persistent mode-state badges shown in the footer status row.
+
+    Boolean toggles appear only while active to reduce noise; the sort state is
+    always shown. Square brackets are avoided so the text never collides with
+    Textual content markup. This footer is the single home for the Gantt filter
+    state — the Gantt widget no longer renders its own filter indicator.
+
+    Args:
+        gantt_filter_enabled: Whether the search filter is applied to the Gantt.
+        show_archived: Whether archived tasks are included in the list.
+        sort_by: Current sort field key.
+        sort_reverse: Sort direction (True=descending).
+
+    Returns:
+        A ` · `-joined badge string, e.g. "gantt-filter · archived · ↓ Deadline".
+    """
+    parts: list[str] = []
+    if gantt_filter_enabled:
+        parts.append("gantt-filter")
+    if show_archived:
+        parts.append("archived")
+    arrow = "↓" if sort_reverse else "↑"
+    sort_label = SORT_KEY_LABELS.get(sort_by, sort_by)
+    parts.append(f"{arrow} {sort_label}")
+    return " · ".join(parts)
 
 
 class CustomFooter(Container, TUIWidget):
     """Custom footer with status bar and search input (Vim-style).
 
     Layout (2 rows):
-    - Row 1 (Status bar): Keybindings (left) + Connection status (right)
+    - Row 1 (Status bar): Keybindings (left) + Mode badges + Connection status (right)
     - Row 2 (Search bar): Filter chain + Search input + Result count
 
     Subscribes to ConnectionStatusManager for automatic updates via observer pattern.
@@ -63,12 +98,13 @@ class CustomFooter(Container, TUIWidget):
         Returns:
             Iterable of widgets to display
         """
-        # Row 1: Status bar (keybindings + connection status)
+        # Row 1: Status bar (keybindings + mode badges + connection status)
         with Horizontal(id="footer-status-row"):
             yield Static(
-                " [bold]j[/]/[bold]k[/] Navigate  [bold]Ctrl+J[/]/[bold]K[/] Focus  [bold]q[/] Quit  [bold]a[/] Add  [bold]s[/] Start  [bold]d[/] Done  [bold]x[/] Archive  [bold]?[/] Help  [bold]Ctrl+P[/] Palette",
+                " [bold]j[/]/[bold]k[/] Nav  [bold]a[/] Add  [bold]s[/] Start  [bold]d[/] Done  [bold]q[/] Quit  [bold]?[/] Help  [bold]Ctrl+P[/] Palette",
                 id="footer-keybindings",
             )
+            yield Static("", id="footer-mode-badges")
             yield Static("🔴 Offline", id="footer-connection-status")
 
         # Row 2: Search bar (container with filter chain, input, and result count)
@@ -92,6 +128,9 @@ class CustomFooter(Container, TUIWidget):
         self.is_api_connected = status.is_api_connected
         self.is_websocket_connected = status.is_websocket_connected
         self._update_connection_status()
+
+        # Initialize mode badges from current app state
+        self.update_mode_badges(self.tui_app.state)
 
     def on_unmount(self) -> None:
         """Called when widget is unmounted from the DOM."""
@@ -150,6 +189,22 @@ class CustomFooter(Container, TUIWidget):
         # Remove all status classes and add the current one
         status_widget.remove_class("status-online", "status-partial", "status-offline")
         status_widget.add_class(status_class)
+
+    def update_mode_badges(self, state: "TUIState") -> None:
+        """Refresh the persistent mode-state badges from app state.
+
+        Args:
+            state: Current TUI application state.
+        """
+        badges = self.query_one("#footer-mode-badges", Static)
+        badges.update(
+            format_mode_badges(
+                gantt_filter_enabled=state.gantt_filter_enabled,
+                show_archived=state.show_archived,
+                sort_by=state.sort_by,
+                sort_reverse=state.sort_reverse,
+            )
+        )
 
     # Search input methods
 

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/gantt_widget.py
@@ -164,7 +164,11 @@ class GanttWidget(Vertical, TUIWidget):
             self._show_error_message(e)
 
     def _update_title(self) -> None:
-        """Update title with date range, sort order, and filter status."""
+        """Update title with the date range only.
+
+        Sort and filter status are intentionally omitted here; the custom footer
+        is the single home for those mode badges.
+        """
         if not self._title_widget:
             return
 
@@ -174,20 +178,10 @@ class GanttWidget(Vertical, TUIWidget):
 
         start_date = gantt_view_model.start_date
         end_date = gantt_view_model.end_date
-        # Access sort state from tui_state
-        arrow = "↓" if self.tui_state.sort_reverse else "↑"
-
-        # Build filter indicator (always shown)
-        if self.tui_state.gantt_filter_enabled:
-            filter_indicator = " [green]🔍 Filter: ON[/green]"
-        else:
-            filter_indicator = " [dim]🔍 Filter: OFF[/dim]"
 
         title_text = (
             f"[bold $primary]Gantt Chart[/bold $primary] "
-            f"[dim]({start_date} to {end_date})[/dim] "
-            f"[dim]- sorted by: {self.tui_state.sort_by} {arrow}[/dim]"
-            f"{filter_indicator}"
+            f"[dim]({start_date} to {end_date})[/dim]"
         )
         self._title_widget.update(title_text)
 

--- a/packages/taskdog-ui/tests/tui/widgets/test_custom_footer.py
+++ b/packages/taskdog-ui/tests/tui/widgets/test_custom_footer.py
@@ -1,0 +1,71 @@
+"""Tests for CustomFooter mode-badge formatting."""
+
+from taskdog.tui.widgets.custom_footer import format_mode_badges
+
+
+class TestFormatModeBadges:
+    """format_mode_badges renders the persistent toggle-state badges."""
+
+    def test_sort_always_shown_ascending(self) -> None:
+        result = format_mode_badges(
+            gantt_filter_enabled=False,
+            show_archived=False,
+            sort_by="deadline",
+            sort_reverse=False,
+        )
+        assert result == "↑ Deadline"
+
+    def test_sort_descending_arrow(self) -> None:
+        result = format_mode_badges(
+            gantt_filter_enabled=False,
+            show_archived=False,
+            sort_by="deadline",
+            sort_reverse=True,
+        )
+        assert result == "↓ Deadline"
+
+    def test_unknown_sort_key_falls_back_to_key(self) -> None:
+        result = format_mode_badges(
+            gantt_filter_enabled=False,
+            show_archived=False,
+            sort_by="custom",
+            sort_reverse=False,
+        )
+        assert result == "↑ custom"
+
+    def test_gantt_filter_badge_only_when_enabled(self) -> None:
+        result = format_mode_badges(
+            gantt_filter_enabled=True,
+            show_archived=False,
+            sort_by="priority",
+            sort_reverse=False,
+        )
+        assert result == "gantt-filter · ↑ Priority"
+
+    def test_archive_badge_only_when_shown(self) -> None:
+        result = format_mode_badges(
+            gantt_filter_enabled=False,
+            show_archived=True,
+            sort_by="priority",
+            sort_reverse=False,
+        )
+        assert result == "archived · ↑ Priority"
+
+    def test_both_toggles_ordered_filter_then_archive_then_sort(self) -> None:
+        result = format_mode_badges(
+            gantt_filter_enabled=True,
+            show_archived=True,
+            sort_by="id",
+            sort_reverse=True,
+        )
+        assert result == "gantt-filter · archived · ↓ ID"
+
+    def test_no_square_brackets_to_avoid_markup_collision(self) -> None:
+        result = format_mode_badges(
+            gantt_filter_enabled=True,
+            show_archived=True,
+            sort_by="deadline",
+            sort_reverse=False,
+        )
+        assert "[" not in result
+        assert "]" not in result


### PR DESCRIPTION
## Summary

TUI mode state was scattered: connection status lived persistently in the footer, while gantt-filter / archive / sort toggles only flashed as transient `notify()` toasts and the Gantt title carried its own filter and sort indicators. There was no single place to see the current mode at a glance.

This consolidates all of it into the footer status row.

## Changes

- **Footer mode badges**: new `#footer-mode-badges` Static placed before the connection status, showing `gantt-filter` (when on) · `archived` (when on) · `↑/↓ <sort>` (always). Boolean toggles appear only while active to reduce noise. Refreshed from the toggle/sort actions via `_refresh_mode_badges()`.
- **Gantt title**: removed the now-duplicated `🔍 Filter: ON/OFF` and `sorted by: …` indicators; the title is just `Gantt Chart (date to date)`. The footer is now the single home for these mode badges.
- **Keybinding hints**: trimmed the footer's left-hand hint string (dropped `Ctrl+J/K Focus` and `x Archive`, discoverable via `?` Help / `Ctrl+P` Palette) to make room for the badges. The keybindings cell keeps `width: 1fr` so it shrinks first on narrow terminals, protecting the badges and connection status from overflow.

## Tests

- New `format_mode_badges` pure function with unit tests in `tests/tui/widgets/test_custom_footer.py`.
- All package suites pass locally (core 1116, client 223, server 324, ui 1060).

🤖 Generated with [Claude Code](https://claude.com/claude-code)