### PR TITLE
fix(ui): exit non-zero on CLI command failure (#960)

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/dto/bulk_operation_output.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/bulk_operation_output.py
@@ -22,3 +22,13 @@ class BulkOperationOutput:
     """Output DTO for bulk task operations."""
 
     results: list[BulkTaskResultOutput]
+
+    @property
+    def failure_count(self) -> int:
+        """Number of results that did not succeed."""
+        return sum(1 for result in self.results if not result.success)
+
+    @property
+    def has_failures(self) -> bool:
+        """True if any result in the batch failed."""
+        return self.failure_count > 0

--- a/packages/taskdog-core/tests/application/dto/test_bulk_operation_output.py
+++ b/packages/taskdog-core/tests/application/dto/test_bulk_operation_output.py
@@ -1,0 +1,38 @@
+"""Tests for BulkOperationOutput failure accounting."""
+
+from taskdog_core.application.dto.bulk_operation_output import (
+    BulkOperationOutput,
+    BulkTaskResultOutput,
+)
+
+
+def _result(task_id: int, success: bool) -> BulkTaskResultOutput:
+    return BulkTaskResultOutput(
+        task_id=task_id,
+        success=success,
+        task=None,
+        error=None if success else "boom",
+    )
+
+
+def test_no_failures_when_all_succeed():
+    output = BulkOperationOutput(results=[_result(1, True), _result(2, True)])
+
+    assert output.failure_count == 0
+    assert output.has_failures is False
+
+
+def test_counts_each_failed_result():
+    output = BulkOperationOutput(
+        results=[_result(1, True), _result(2, False), _result(3, False)]
+    )
+
+    assert output.failure_count == 2
+    assert output.has_failures is True
+
+
+def test_empty_batch_has_no_failures():
+    output = BulkOperationOutput(results=[])
+
+    assert output.failure_count == 0
+    assert output.has_failures is False

--- a/packages/taskdog-ui/src/taskdog/cli/commands/cancel.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/cancel.py
@@ -27,3 +27,6 @@ def cancel_command(ctx: click.Context, task_ids: tuple[int, ...]) -> None:
             console_writer.validation_error(result.error)
         if len(task_ids) > 1:
             console_writer.empty_line()
+
+    if results.has_failures:
+        raise click.exceptions.Exit(1)

--- a/packages/taskdog-ui/src/taskdog/cli/commands/done.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/done.py
@@ -28,3 +28,6 @@ def done_command(ctx: click.Context, task_ids: tuple[int, ...]) -> None:
             console_writer.validation_error(result.error)
         if len(task_ids) > 1:
             console_writer.empty_line()
+
+    if results.has_failures:
+        raise click.exceptions.Exit(1)

--- a/packages/taskdog-ui/src/taskdog/cli/commands/pause.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/pause.py
@@ -34,3 +34,6 @@ def pause_command(ctx: click.Context, task_ids: tuple[int, ...]) -> None:
             console_writer.validation_error(result.error)
         if len(task_ids) > 1:
             console_writer.empty_line()
+
+    if results.has_failures:
+        raise click.exceptions.Exit(1)

--- a/packages/taskdog-ui/src/taskdog/cli/commands/reopen.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/reopen.py
@@ -38,3 +38,6 @@ def reopen_command(ctx: click.Context, task_ids: tuple[int, ...]) -> None:
             console_writer.validation_error(result.error)
         if len(task_ids) > 1:
             console_writer.empty_line()
+
+    if results.has_failures:
+        raise click.exceptions.Exit(1)

--- a/packages/taskdog-ui/src/taskdog/cli/commands/restore.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/restore.py
@@ -27,3 +27,6 @@ def restore_command(ctx: click.Context, task_ids: tuple[int, ...]) -> None:
             console_writer.validation_error(result.error)
         if len(task_ids) > 1:
             console_writer.empty_line()
+
+    if results.has_failures:
+        raise click.exceptions.Exit(1)

--- a/packages/taskdog-ui/src/taskdog/cli/commands/rm.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/rm.py
@@ -8,6 +8,37 @@ import click
 
 if TYPE_CHECKING:
     from taskdog.cli.context import CliContext
+    from taskdog.console.console_writer import ConsoleWriter
+    from taskdog_core.application.dto.bulk_operation_output import BulkOperationOutput
+
+
+def _report_hard_delete(
+    console_writer: ConsoleWriter, results: BulkOperationOutput, count: int
+) -> None:
+    for result in results.results:
+        if result.success:
+            console_writer.success(
+                f"Permanently deleted task with ID: {result.task_id}"
+            )
+        elif result.error is not None:
+            console_writer.validation_error(result.error)
+        if count > 1:
+            console_writer.empty_line()
+
+
+def _report_archive(
+    console_writer: ConsoleWriter, results: BulkOperationOutput, count: int
+) -> None:
+    for result in results.results:
+        if result.success and result.task is not None:
+            console_writer.task_success("Archived (status preserved)", result.task)
+            console_writer.info(
+                f"Use 'taskdog restore {result.task_id}' to restore this task."
+            )
+        elif result.error is not None:
+            console_writer.validation_error(result.error)
+        if count > 1:
+            console_writer.empty_line()
 
 
 @click.command(
@@ -33,24 +64,10 @@ def rm_command(ctx: click.Context, task_ids: tuple[int, ...], hard: bool) -> Non
 
     if hard:
         results = ctx_obj.api_client.bulk_delete(list(task_ids))
-        for result in results.results:
-            if result.success:
-                console_writer.success(
-                    f"Permanently deleted task with ID: {result.task_id}"
-                )
-            elif result.error is not None:
-                console_writer.validation_error(result.error)
-            if len(task_ids) > 1:
-                console_writer.empty_line()
+        _report_hard_delete(console_writer, results, len(task_ids))
     else:
         results = ctx_obj.api_client.bulk_archive(list(task_ids))
-        for result in results.results:
-            if result.success and result.task is not None:
-                console_writer.task_success("Archived (status preserved)", result.task)
-                console_writer.info(
-                    f"Use 'taskdog restore {result.task_id}' to restore this task."
-                )
-            elif result.error is not None:
-                console_writer.validation_error(result.error)
-            if len(task_ids) > 1:
-                console_writer.empty_line()
+        _report_archive(console_writer, results, len(task_ids))
+
+    if results.has_failures:
+        raise click.exceptions.Exit(1)

--- a/packages/taskdog-ui/src/taskdog/cli/commands/start.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/start.py
@@ -30,3 +30,6 @@ def start_command(ctx: click.Context, task_ids: tuple[int, ...]) -> None:
             console_writer.validation_error(result.error)
         if len(task_ids) > 1:
             console_writer.empty_line()
+
+    if results.has_failures:
+        raise click.exceptions.Exit(1)

--- a/packages/taskdog-ui/src/taskdog/cli/error_handler.py
+++ b/packages/taskdog-ui/src/taskdog/cli/error_handler.py
@@ -48,10 +48,15 @@ def handle_task_errors[F: Callable[..., Any]](action_name: str) -> Callable[[F],
                 return func(*args, **kwargs)
             except TaskNotFoundException as e:
                 console_writer.validation_error(str(e))
+                raise click.exceptions.Exit(1) from e
             except (ServerConnectionError, AuthenticationError, ServerError) as e:
                 console_writer.validation_error(str(e))
+                raise click.exceptions.Exit(1) from e
+            except (click.exceptions.Exit, click.exceptions.Abort):
+                raise
             except Exception as e:
                 console_writer.error(action_name, e)
+                raise click.exceptions.Exit(1) from e
 
         return cast("F", wrapper)
 
@@ -88,8 +93,12 @@ def handle_command_errors[F: Callable[..., Any]](action_name: str) -> Callable[[
                 return func(*args, **kwargs)
             except (ServerConnectionError, AuthenticationError, ServerError) as e:
                 console_writer.validation_error(str(e))
+                raise click.exceptions.Exit(1) from e
+            except (click.exceptions.Exit, click.exceptions.Abort):
+                raise
             except Exception as e:
                 console_writer.error(action_name, e)
+                raise click.exceptions.Exit(1) from e
 
         return cast("F", wrapper)
 

--- a/packages/taskdog-ui/tests/presentation/cli/commands/bulk_command_test_base.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/bulk_command_test_base.py
@@ -125,7 +125,7 @@ class BaseBulkCommandTest:
 
         result = self.runner.invoke(self.command_func, ["999"], obj=self.cli_context)
 
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.validation_error.assert_called_once_with(
             "Task with ID 999 not found"
         )
@@ -143,7 +143,7 @@ class BaseBulkCommandTest:
             self.command_func, ["1", "999"], obj=self.cli_context
         )
 
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.task_success.assert_called_once()
         self.console_writer.validation_error.assert_called_once()
         assert self.console_writer.empty_line.call_count == 2

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_add_command.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_add_command.py
@@ -223,7 +223,7 @@ class TestAddCommand:
         result = self.runner.invoke(add_command, ["Test Task"], obj=self.cli_context)
 
         # Verify
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.validation_error.assert_called_once()
 
     def test_general_exception(self):
@@ -236,7 +236,7 @@ class TestAddCommand:
         result = self.runner.invoke(add_command, ["Test Task"], obj=self.cli_context)
 
         # Verify
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.error.assert_called_once_with("adding task", error)
 
     def test_missing_name(self):

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_dep_add_command.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_dep_add_command.py
@@ -47,7 +47,7 @@ class TestAddDependencyCommand:
         result = self.runner.invoke(add_command, ["999", "3"], obj=self.cli_context)
 
         # Verify
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.validation_error.assert_called_once()
 
     def test_general_exception(self):
@@ -60,7 +60,7 @@ class TestAddDependencyCommand:
         result = self.runner.invoke(add_command, ["5", "3"], obj=self.cli_context)
 
         # Verify
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.error.assert_called_once_with("adding dependency", error)
 
     def test_missing_task_id(self):

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_dep_remove_command.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_dep_remove_command.py
@@ -47,7 +47,7 @@ class TestRemoveDependencyCommand:
         result = self.runner.invoke(remove_command, ["999", "3"], obj=self.cli_context)
 
         # Verify
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.validation_error.assert_called_once()
 
     def test_general_exception(self):
@@ -60,7 +60,7 @@ class TestRemoveDependencyCommand:
         result = self.runner.invoke(remove_command, ["5", "3"], obj=self.cli_context)
 
         # Verify
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.error.assert_called_once_with("removing dependency", error)
 
     def test_missing_task_id(self):

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_fix_times_command.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_fix_times_command.py
@@ -193,7 +193,7 @@ class TestFixActualCommand:
             obj=self.cli_context,
         )
 
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.validation_error.assert_called_once()
 
     def test_general_exception(self):
@@ -207,7 +207,7 @@ class TestFixActualCommand:
             obj=self.cli_context,
         )
 
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.error.assert_called_once_with("fixing actual times", error)
 
     def test_missing_task_id(self):

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_gantt_command.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_gantt_command.py
@@ -156,7 +156,7 @@ class TestGanttCommand:
         result = self.runner.invoke(gantt_command, [], obj=self.cli_context)
 
         # Verify
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.error.assert_called_once_with(
             "displaying Gantt chart", error
         )

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_list_command.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_list_command.py
@@ -159,5 +159,5 @@ class TestTableCommand:
         result = self.runner.invoke(list_command, [], obj=self.cli_context)
 
         # Verify
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.error.assert_called_once_with("displaying tasks", error)

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_note.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_note.py
@@ -359,7 +359,7 @@ class TestNoteCommand:
         )
 
         # Verify - handle_task_errors catches TaskNotFoundException
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.validation_error.assert_called_once()
 
     def test_file_read_oserror(self):

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_optimize_command.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_optimize_command.py
@@ -229,7 +229,7 @@ class TestOptimizeCommand:
         )
 
         # Verify
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.error.assert_called_once_with("optimizing schedules", error)
 
     def test_missing_algorithm_fails(self):

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_rm_command.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_rm_command.py
@@ -106,7 +106,7 @@ class TestRmCommand:
 
         result = self.runner.invoke(rm_command, ["999"], obj=self.cli_context)
 
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.validation_error.assert_called_once()
 
     def test_task_not_found_hard_delete(self):
@@ -119,7 +119,7 @@ class TestRmCommand:
 
         result = self.runner.invoke(rm_command, ["999", "--hard"], obj=self.cli_context)
 
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.validation_error.assert_called_once()
 
     def test_archive_restore_hint(self):

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_show_command.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_show_command.py
@@ -66,7 +66,7 @@ class TestShowCommand:
         result = self.runner.invoke(show_command, ["999"], obj=self.cli_context)
 
         # Verify
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.validation_error.assert_called_once()
 
     def test_general_exception(self):
@@ -79,7 +79,7 @@ class TestShowCommand:
         result = self.runner.invoke(show_command, ["1"], obj=self.cli_context)
 
         # Verify
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.error.assert_called_once_with("showing task", error)
 
     def test_missing_task_id(self):

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_stats_command.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_stats_command.py
@@ -114,7 +114,7 @@ class TestStatsCommand:
         result = self.runner.invoke(stats_command, [], obj=self.cli_context)
 
         # Verify
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.error.assert_called_once_with(
             "calculating statistics", error
         )

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_tag_command.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_tag_command.py
@@ -86,7 +86,7 @@ class TestTagListCommand(_TagCommandFixture):
 
         result = self.runner.invoke(list_command, ["999"], obj=self.cli_context)
 
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.validation_error.assert_called_once()
 
     def test_general_exception(self):
@@ -96,7 +96,7 @@ class TestTagListCommand(_TagCommandFixture):
 
         result = self.runner.invoke(list_command, [], obj=self.cli_context)
 
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.error.assert_called_once_with("listing tags", error)
 
 
@@ -139,7 +139,7 @@ class TestTagSetCommand(_TagCommandFixture):
 
         result = self.runner.invoke(set_command, ["999", "work"], obj=self.cli_context)
 
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.validation_error.assert_called_once()
 
 
@@ -196,7 +196,7 @@ class TestTagRemoveCommand(_TagCommandFixture):
             remove_command, ["nonexistent"], obj=self.cli_context
         )
 
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.validation_error.assert_called_once()
 
     def test_delete_tag_general_exception(self):
@@ -206,5 +206,5 @@ class TestTagRemoveCommand(_TagCommandFixture):
 
         result = self.runner.invoke(remove_command, ["test"], obj=self.cli_context)
 
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.error.assert_called_once_with("deleting tag", error)

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_update_command.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_update_command.py
@@ -221,7 +221,7 @@ class TestUpdateCommand:
         )
 
         # Verify
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.validation_error.assert_called_once()
 
     def test_general_exception(self):
@@ -236,7 +236,7 @@ class TestUpdateCommand:
         )
 
         # Verify
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         self.console_writer.error.assert_called_once_with("updating task", error)
 
     def test_missing_task_id(self):

--- a/packages/taskdog-ui/tests/presentation/cli/test_error_handler.py
+++ b/packages/taskdog-ui/tests/presentation/cli/test_error_handler.py
@@ -1,0 +1,141 @@
+"""Tests for CLI error handling decorators."""
+
+from unittest.mock import MagicMock
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from taskdog.cli.error_handler import handle_command_errors, handle_task_errors
+from taskdog_core.domain.exceptions.task_exceptions import (
+    ServerConnectionError,
+    TaskNotFoundException,
+)
+
+
+@pytest.fixture
+def cli_context():
+    ctx = MagicMock()
+    ctx.console_writer = MagicMock()
+    return ctx
+
+
+def _run(command, cli_context):
+    return CliRunner().invoke(command, [], obj=cli_context)
+
+
+def test_handle_task_errors_exits_nonzero_on_task_not_found(cli_context):
+    @click.command()
+    @handle_task_errors("doing thing")
+    @click.pass_context
+    def cmd(ctx):
+        raise TaskNotFoundException(1)
+
+    result = _run(cmd, cli_context)
+
+    assert result.exit_code != 0
+    cli_context.console_writer.validation_error.assert_called_once()
+
+
+def test_handle_task_errors_exits_nonzero_on_server_error(cli_context):
+    @click.command()
+    @handle_task_errors("doing thing")
+    @click.pass_context
+    def cmd(ctx):
+        raise ServerConnectionError("http://localhost", RuntimeError("down"))
+
+    result = _run(cmd, cli_context)
+
+    assert result.exit_code != 0
+    cli_context.console_writer.validation_error.assert_called_once()
+
+
+def test_handle_task_errors_exits_nonzero_on_unexpected_error(cli_context):
+    @click.command()
+    @handle_task_errors("doing thing")
+    @click.pass_context
+    def cmd(ctx):
+        raise RuntimeError("boom")
+
+    result = _run(cmd, cli_context)
+
+    assert result.exit_code != 0
+    cli_context.console_writer.error.assert_called_once()
+
+
+def test_handle_task_errors_exits_zero_on_success(cli_context):
+    @click.command()
+    @handle_task_errors("doing thing")
+    @click.pass_context
+    def cmd(ctx):
+        ctx.obj.console_writer.print_success("ok")
+
+    result = _run(cmd, cli_context)
+
+    assert result.exit_code == 0
+
+
+def test_handle_task_errors_passes_through_internal_exit(cli_context):
+    """A deliberate ctx.exit(1) must not be re-reported as an unexpected error."""
+
+    @click.command()
+    @handle_task_errors("doing thing")
+    @click.pass_context
+    def cmd(ctx):
+        ctx.exit(1)
+
+    result = _run(cmd, cli_context)
+
+    assert result.exit_code == 1
+    cli_context.console_writer.error.assert_not_called()
+
+
+def test_handle_command_errors_passes_through_internal_exit(cli_context):
+    @click.command()
+    @handle_command_errors("displaying")
+    @click.pass_context
+    def cmd(ctx):
+        ctx.exit(1)
+
+    result = _run(cmd, cli_context)
+
+    assert result.exit_code == 1
+    cli_context.console_writer.error.assert_not_called()
+
+
+def test_handle_command_errors_exits_nonzero_on_server_error(cli_context):
+    @click.command()
+    @handle_command_errors("displaying")
+    @click.pass_context
+    def cmd(ctx):
+        raise ServerConnectionError("http://localhost", RuntimeError("down"))
+
+    result = _run(cmd, cli_context)
+
+    assert result.exit_code != 0
+    cli_context.console_writer.validation_error.assert_called_once()
+
+
+def test_handle_command_errors_exits_nonzero_on_unexpected_error(cli_context):
+    @click.command()
+    @handle_command_errors("displaying")
+    @click.pass_context
+    def cmd(ctx):
+        raise RuntimeError("boom")
+
+    result = _run(cmd, cli_context)
+
+    assert result.exit_code != 0
+    cli_context.console_writer.error.assert_called_once()
+
+
+def test_handle_command_errors_exits_zero_on_success(cli_context):
+    @click.command()
+    @handle_command_errors("displaying")
+    @click.pass_context
+    def cmd(ctx):
+        ctx.obj.console_writer.print_success("ok")
+
+    result = _run(cmd, cli_context)
+
+    assert result.exit_code == 0


### PR DESCRIPTION
## Summary

CLI commands exited `0` even on failure, so CI / shell scripts / systemd could not detect errors (#960).

- `@handle_task_errors` / `@handle_command_errors` caught exceptions, printed them, and returned `None` without re-raising → exit `0`.
- Bulk commands (`start`, `done`, `pause`, `cancel`, `reopen`, `restore`, `rm`) printed per-item failures but never reflected them in the exit code.

## Changes

- **error_handler**: re-raise `click.exceptions.Exit(1)` after reporting in both decorators. Also pass through deliberate `Exit`/`Abort` so an internal `ctx.exit()` (e.g. `fix-times` validation) is not re-reported as an unexpected error.
- **`BulkOperationOutput`**: add `failure_count` / `has_failures` properties.
- **Bulk commands**: `raise click.exceptions.Exit(1)` when any item in the batch failed. `rm` reporting extracted into `_report_hard_delete` / `_report_archive` helpers (keeps it under the complexity limit).

Out of scope: server-down on bulk commands still surfaces a raw traceback (exit code is already `1`). That's a UX cleanup to be handled when bulk command logic is extracted into a service.

## Verification

Exercised against a running server:

| command | exit |
|---|---|
| `start 99999` (missing id, per-item failure) | `1`, clean message |
| `show 99999` (decorated) | `1` |
| `fix-times 1` (internal `ctx.exit`) | `1`, no double error line |
| `start 1` (success) | `0` |
| `start 1 && echo ok` (server down) | chain stops (was passing before) |

- New tests: `test_error_handler.py` (9), `test_bulk_operation_output.py` (3).
- Existing error-path tests updated to assert `exit_code != 0`.
- UI 1126 / core 1119 passed; ruff, format, mypy clean.

Closes #960