### PR TITLE
docs(tui): rewrite stale help Features tab

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/constants/keybindings.py
+++ b/packages/taskdog-ui/src/taskdog/tui/constants/keybindings.py
@@ -32,29 +32,91 @@ BASIC_WORKFLOW: str = """## Getting Started
 # Main features explanation
 MAIN_FEATURES: str = """## Key Features
 
-- **Task Table** - Main view showing all your tasks
-  - Use `j`/`k` or arrow keys to navigate
+### Navigate
 
-- **Gantt Chart** - Visual timeline of your tasks
-  - Shows task schedules and workload per day
-  - Use `Ctrl+J`/`Ctrl+K` to move focus between widgets
+Move around the task table and Gantt chart.
 
-- **Search** - Press `/` to filter tasks by name
-  - Smart case: case-insensitive unless query contains uppercase
-  - Press `Escape` to clear search
+- `j`/`k` or arrow keys to move the cursor
+- `g`/`G` to jump to top/bottom
+- `Ctrl+J`/`Ctrl+K` to move focus between the table and Gantt
+- `z` to zoom (maximize) the focused widget
 
-- **Notes** - Press `v` to edit markdown notes for any task
-  - Opens your `$EDITOR` (vim, nano, etc.)
+### Manage tasks
 
-- **Schedule Optimization** - Auto-schedule tasks based on deadlines
-  - Access via `Ctrl+P` → Optimize
-  - Assigns `planned_start` and `planned_end` dates
-  - Respects `max_hours_per_day` limit and task dependencies
+Create, inspect, edit, and move tasks through their lifecycle.
 
-- **Fixed Tasks** - Tasks excluded from schedule optimization
-  - Set `is_fixed` when creating or editing a task
-  - Use for recurring meetings, standups, or time-blocked events
-  - Fixed tasks keep their schedule; optimizer works around them"""
+- `a` add, `e` edit, `i` view full details, `r` refresh from the server
+- Lifecycle: `s` start, `d` done, `c` cancel, `P` pause, `R` reopen
+- `x` archive (soft delete, keeps the original status), `X` delete permanently
+
+### Track time
+
+- `f` fix the actual start/end times or duration of a task — correct or clear
+  time-tracking data after the fact
+
+### Select & act in bulk
+
+Operate on many tasks at once.
+
+- `Space` to select the current task, `Ctrl+A` select all, `Ctrl+N` clear
+- Lifecycle keys (`s` start, `d` done, `c` cancel, `P` pause, `x` archive)
+  apply to every selected task; with no selection they act on the cursor
+- Optimize uses the selection too — only selected tasks are scheduled
+  (all tasks if nothing is selected)
+
+### Search & filter
+
+Press `/` (or `Ctrl+R`) to filter, `Escape` to clear.
+
+- Substring match with smart case (case-insensitive unless query has uppercase)
+- fzf-style exclusion: `!term` excludes matches
+- Status filters: `!completed`, `!pending`, `!in_progress`, `!canceled`,
+  or `!status:VALUE`
+- Tag filter: `!tag:NAME`
+- Multiple tokens combine with AND (e.g. `bug !completed`)
+
+### Gantt chart
+
+Visual timeline with workload per day.
+
+- `w`/`b` jump one week forward/back, `T` jump to today
+- `H`/`L` pan into the past/future, `0`/`$` go to row start/end
+- Lifecycle keys work on the task under the Gantt cursor too
+- `t` toggles the search filter for the Gantt view
+
+### Notes
+
+- `v` edits markdown notes for any task, opening your `$EDITOR` (vim, nano, etc.)
+
+### Schedule optimization
+
+Auto-schedule tasks based on deadlines via `Ctrl+P` → Optimize.
+
+- Choose an algorithm (greedy, balanced, and more) and set
+  `max_hours_per_day`, start date, and whether to schedule on all days
+- Assigns `planned_start` and `planned_end`, respecting dependencies
+- **Fixed tasks** (`is_fixed`) keep their schedule; the optimizer works
+  around them — use for meetings, standups, or time-blocked events
+
+### Statistics
+
+- `S` opens the statistics dashboard — completion rates, workload, and
+  progress metrics
+
+### Export & backup
+
+- `Ctrl+P` → Export writes all tasks to `~/Downloads` as JSON, CSV, or Markdown
+- `Ctrl+P` → Backup downloads a consistent `.db` snapshot to `~/Downloads`
+
+### Audit log
+
+- `Ctrl+P` → Audit Logs shows the history of operations (what changed, when,
+  and from which client)
+
+### Archived tasks
+
+- `x` archives a task without losing its status; `Ctrl+P` → Toggle Archive
+  shows or hides archived tasks in the list"""
 
 # Command palette explanation
 COMMAND_PALETTE_INFO: str = """## Command Palette
@@ -66,8 +128,15 @@ Press `Ctrl+P` to open the command palette:
 
 - **Optimize** - Run schedule optimization
   - Multiple algorithms available (greedy, balanced, etc.)
+  - Optimizes only selected tasks, or all tasks if none are selected
 
-- **Export** - Export tasks to JSON, CSV, or Markdown
+- **Export** - Export tasks to JSON, CSV, or Markdown (saved to `~/Downloads`)
+
+- **Backup** - Download a `.db` snapshot of the database to `~/Downloads`
+
+- **Audit Logs** - Open the operation history screen
+
+- **Toggle Archive** - Show or hide archived tasks in the list
 
 - **Keys** - View all keyboard shortcuts
   - Complete list of keybindings with descriptions
@@ -79,9 +148,12 @@ QUICK_TIPS: list[str] = [
     "Press [cyan]Ctrl+P[/cyan] then type [cyan]'Keys'[/cyan] to see all keyboard shortcuts",
     "Use [cyan]a[/cyan] → [cyan]s[/cyan] → [cyan]d[/cyan] workflow for quick task management",
     "Edit task details with [cyan]e[/cyan], add notes with [cyan]v[/cyan]",
-    "Archive tasks with [cyan]x[/cyan] (soft delete), restore them later",
+    "Archive tasks with [cyan]x[/cyan]; toggle [cyan]Ctrl+P[/cyan] → [cyan]Toggle Archive[/cyan] to see them",
     "Press [cyan]i[/cyan] to see full task details including notes",
     "Use [cyan]/[/cyan] for quick search, [cyan]Escape[/cyan] to clear",
+    "Select tasks with [cyan]Space[/cyan], then lifecycle keys or Optimize act on all of them",
+    "Hide finished tasks with the exclusion search [cyan]!completed[/cyan]",
+    "Press [cyan]S[/cyan] for the statistics dashboard",
 ]
 
 # Bug reports and feedback


### PR DESCRIPTION
## Summary

Closes #953. The TUI help dialog's **Features** tab (`MAIN_FEATURES`) still reflected the early feature set, so several shipped capabilities were undiscoverable.

Rewrote it capability-first with `###` sections (the old single-`##`-with-nested-bullets layout rendered poorly), and added the missing capabilities — verified against the code, not guessed:

- **Manage tasks** — `i` details, `e` edit, `R` reopen, `X` hard delete
- **Track time** — `f` fix actual times (`commands/fix_actual.py`)
- **Select & act in bulk** — `Space`/`Ctrl+A`/`Ctrl+N`, batch lifecycle, optimize-selected (`selection.py`, `commands/optimize.py`, `commands/batch_command_base.py`)
- **Search & filter** — fzf-style exclusion `!term` / `!completed` / `!status:` / `!tag:` (`widgets/search_query_parser.py`)
- **Gantt chart** — `w`/`b`/`T`/`H`/`L`/`0`/`$`, lifecycle on the cursor task (`widgets/gantt_data_table.py`, `selection.py`)
- **Statistics** — `S` (`commands/stats.py`)
- **Export & backup** — `Ctrl+P` → Export / Backup, saved to `~/Downloads` (`commands/export.py`, `commands/backup.py`)
- **Audit log** — `Ctrl+P` → Audit Logs (`palette/providers/audit_provider.py`)
- **Archived tasks** — `x` archive + `Ctrl+P` → Toggle Archive (`palette/providers/archive_provider.py`)

Also synced two adjacent help sections that were drifting:

- `COMMAND_PALETTE_INFO` — added Backup, Audit Logs, Toggle Archive, and the optimize-selected note.
- `QUICK_TIPS` — added multi-select, exclusion search, and stats tips; **replaced** the `"restore them later"` tip, which was inaccurate (the TUI has no restore action — archived tasks can only be re-shown via Toggle Archive).

## Verification

- ruff format / check / mypy / codespell / unit tests pass (pre-commit + pre-push).
- Content cross-checked against the actual bindings and command implementations.

Not done: visual render inside a running Textual session (would need a live server). The change is a Markdown string only.