### PR TITLE
chore: auto-discover packages to prevent missing-subpackage bugs (#1009)

### DIFF
--- a/packages/taskdog-client/pyproject.toml
+++ b/packages/taskdog-client/pyproject.toml
@@ -41,13 +41,9 @@ Repository = "https://github.com/Kohei-Wada/taskdog"
 requires = ["setuptools>=68.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = [
-    "taskdog_client",
-    "taskdog_client.converters",
-    "taskdog_client.websocket",
-]
-package-dir = { "" = "src" }
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["taskdog*"]
 
 [tool.setuptools.package-data]
 taskdog_client = ["py.typed"]

--- a/packages/taskdog-core/pyproject.toml
+++ b/packages/taskdog-core/pyproject.toml
@@ -41,42 +41,9 @@ Repository = "https://github.com/Kohei-Wada/taskdog"
 requires = ["setuptools>=68.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = [
-    "taskdog_core",
-    "taskdog_core.domain",
-    "taskdog_core.domain.entities",
-    "taskdog_core.domain.services",
-    "taskdog_core.domain.repositories",
-    "taskdog_core.domain.exceptions",
-    "taskdog_core.application",
-    "taskdog_core.application.dto",
-    "taskdog_core.application.use_cases",
-    "taskdog_core.application.services",
-    "taskdog_core.application.services.optimization",
-    "taskdog_core.application.queries",
-    "taskdog_core.application.queries.filters",
-    "taskdog_core.application.queries.workload",
-    "taskdog_core.application.queries.workload._strategies",
-    "taskdog_core.application.sorters",
-    "taskdog_core.application.validators",
-    "taskdog_core.application.constants",
-    "taskdog_core.application.utils",
-    "taskdog_core.infrastructure",
-    "taskdog_core.infrastructure.persistence",
-    "taskdog_core.infrastructure.persistence.database",
-    "taskdog_core.infrastructure.persistence.database.models",
-    "taskdog_core.infrastructure.persistence.database.query_builders",
-    "taskdog_core.infrastructure.persistence.database.mutation_builders",
-    "taskdog_core.infrastructure.persistence.mappers",
-    "taskdog_core.controllers",
-    "taskdog_core.shared",
-    "taskdog_core.shared.constants",
-    "taskdog_core.shared.utils",
-    "taskdog_core.infrastructure.persistence.database.migrations",
-    "taskdog_core.infrastructure.persistence.database.migrations.versions",
-]
-package-dir = { "" = "src" }
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["taskdog*"]
 
 [tool.setuptools.package-data]
 taskdog_core = ["py.typed"]

--- a/packages/taskdog-mcp/pyproject.toml
+++ b/packages/taskdog-mcp/pyproject.toml
@@ -44,13 +44,9 @@ Repository = "https://github.com/Kohei-Wada/taskdog"
 requires = ["setuptools>=68.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = [
-    "taskdog_mcp",
-    "taskdog_mcp.config",
-    "taskdog_mcp.tools",
-]
-package-dir = { "" = "src" }
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["taskdog*"]
 
 [tool.setuptools.package-data]
 taskdog_mcp = ["py.typed"]

--- a/packages/taskdog-server/pyproject.toml
+++ b/packages/taskdog-server/pyproject.toml
@@ -47,18 +47,9 @@ Repository = "https://github.com/Kohei-Wada/taskdog"
 requires = ["setuptools>=68.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = [
-    "taskdog_server",
-    "taskdog_server.api",
-    "taskdog_server.api.models",
-    "taskdog_server.api.routers",
-    "taskdog_server.config",
-    "taskdog_server.websocket",
-    "taskdog_server.infrastructure",
-    "taskdog_server.infrastructure.logging",
-]
-package-dir = { "" = "src" }
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["taskdog*"]
 
 [tool.setuptools.package-data]
 taskdog_server = ["py.typed"]

--- a/packages/taskdog-ui/pyproject.toml
+++ b/packages/taskdog-ui/pyproject.toml
@@ -51,44 +51,9 @@ Repository = "https://github.com/Kohei-Wada/taskdog"
 requires = ["setuptools>=68.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = [
-    "taskdog",
-    "taskdog.formatters",
-    "taskdog.services",
-    "taskdog.cli",
-    "taskdog.cli.commands",
-    "taskdog.cli.commands.audit",
-    "taskdog.cli.commands.db",
-    "taskdog.cli.commands.dep",
-    "taskdog.cli.commands.tag",
-    "taskdog.tui",
-    "taskdog.tui.commands",
-    "taskdog.tui.constants",
-    "taskdog.tui.palette",
-    "taskdog.tui.palette.providers",
-    "taskdog.tui.services",
-    "taskdog.tui.utils",
-    "taskdog.tui.screens",
-    "taskdog.tui.dialogs",
-    "taskdog.tui.widgets",
-    "taskdog.tui.forms",
-    "taskdog.tui.forms.suggesters",
-    "taskdog.tui.forms.validators",
-    "taskdog.tui.state",
-    "taskdog.tui.styles",
-    "taskdog.console",
-    "taskdog.renderers",
-    "taskdog.exporters",
-    "taskdog.constants",
-    "taskdog.presenters",
-    "taskdog.view_models",
-    "taskdog.utils",
-    "taskdog.shared",
-    "taskdog.shared.click_types",
-    "taskdog.infrastructure",
-]
-package-dir = { "" = "src" }
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["taskdog*"]
 
 [tool.setuptools.package-data]
 taskdog = ["py.typed"]


### PR DESCRIPTION
## Summary

Every package declared a **static** `[tool.setuptools] packages = [...]` list that had to be hand-updated when a subpackage was added. Editable installs use the source tree, so the omission is invisible to tests/CI while the built wheel ships incomplete — exactly the #1006 / #1007 trap (new CLI subpackages missing from the `uv tool install` wheel).

Replace the static list with setuptools automatic discovery in all five packages:

```toml
[tool.setuptools.packages.find]
where = ["src"]
include = ["taskdog*"]
```

- `find` with `where = ["src"]` handles the src layout, so the explicit `package-dir = { "" = "src" }` is dropped.
- `taskdog.tui.styles` is data-only (`*.tcss`, no `__init__.py`) and `find` would skip it, so an empty `src/taskdog/tui/styles/__init__.py` is added; its tcss keep shipping via the existing `package-data` entry.

## Verification (artifact level, not just editable install)

Built each wheel and diffed the discovered `taskdog*` subpackages against the previous static list:

| package | orig | discovered | missing | extra |
|---|---|---|---|---|
| core | 32 | 32 | 0 | 0 |
| server | 8 | 8 | 0 | 0 |
| client | 3 | 3 | 0 | 0 |
| mcp | 3 | 3 | 0 | 0 |
| ui | 34 | 34 | 0 | 0 |

- `taskdog-ui` wheel still bundles all four `*.tcss` files.
- No new setuptools warnings (only the pre-existing `project.license` deprecation, out of scope).
- All tests pass: core 1119 / server 324 / client 223 / ui 1126 / mcp 88. Import smoke incl. `taskdog.tui.styles` and the `audit/db/dep/tag` CLI subpackages OK.

## Out of scope

- No build-backend switch (stays setuptools).
- No `find_namespace` / PEP 420 (empty `__init__.py` + plain `find` preferred).
- No runtime/CLI behavior change.

Closes #1009