### PR TITLE
refactor(mcp): consolidate ISO datetime parsing into serializers helper

### DIFF
--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/serializers.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/serializers.py
@@ -2,15 +2,33 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from datetime import datetime
+from datetime import datetime
+from typing import Any
 
 
 def iso(dt: datetime | None) -> str | None:
     """ISO-format a datetime, or None."""
     return dt.isoformat() if dt else None
+
+
+def parse_iso_datetime(
+    value: str | None, field_name: str | None = None
+) -> datetime | None:
+    """Parse an ISO datetime string, or None when the value is empty.
+
+    Raises ValueError with a unified message on malformed input, including the
+    field name and offending value when ``field_name`` is given.
+    """
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError as e:
+        target = f" for '{field_name}'" if field_name else ""
+        raise ValueError(
+            f"Invalid datetime format{target}: {value!r}. "
+            "Expected ISO format (e.g., '2025-12-11T09:00:00')"
+        ) from e
 
 
 def str_list(values: Any) -> list[Any]:

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_audit.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_audit.py
@@ -5,8 +5,9 @@ Tools for retrieving audit logs.
 
 from __future__ import annotations
 
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
+
+from taskdog_mcp.tools.serializers import parse_iso_datetime
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
@@ -45,20 +46,8 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
         Returns:
             Dictionary with logs list and metadata
         """
-        try:
-            start_date = datetime.fromisoformat(since) if since else None
-        except ValueError as e:
-            raise ValueError(
-                f"Invalid datetime format for 'since': {since}. "
-                "Expected ISO format (e.g., '2025-12-11T09:00:00')"
-            ) from e
-        try:
-            end_date = datetime.fromisoformat(until) if until else None
-        except ValueError as e:
-            raise ValueError(
-                f"Invalid datetime format for 'until': {until}. "
-                "Expected ISO format (e.g., '2025-12-11T17:00:00')"
-            ) from e
+        start_date = parse_iso_datetime(since, "since")
+        end_date = parse_iso_datetime(until, "until")
         success = False if failed else None
 
         result = client.list_audit_logs(

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_crud.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_crud.py
@@ -5,10 +5,14 @@ Tools for creating, reading, updating, and deleting tasks.
 
 from __future__ import annotations
 
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from taskdog_mcp.tools.serializers import iso, str_list, task_result
+from taskdog_mcp.tools.serializers import (
+    iso,
+    parse_iso_datetime,
+    str_list,
+    task_result,
+)
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
@@ -122,19 +126,9 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
         Returns:
             Created task data with ID
         """
-        try:
-            deadline_dt = datetime.fromisoformat(deadline) if deadline else None
-            planned_start_dt = (
-                datetime.fromisoformat(planned_start) if planned_start else None
-            )
-            planned_end_dt = (
-                datetime.fromisoformat(planned_end) if planned_end else None
-            )
-        except ValueError as e:
-            raise ValueError(
-                f"Invalid datetime format. Use ISO format "
-                f"(e.g., '2025-12-11T09:00:00'): {e}"
-            ) from e
+        deadline_dt = parse_iso_datetime(deadline, "deadline")
+        planned_start_dt = parse_iso_datetime(planned_start, "planned_start")
+        planned_end_dt = parse_iso_datetime(planned_end, "planned_end")
 
         result = client.create_task(
             name=name,
@@ -180,19 +174,9 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
         Returns:
             Updated task data
         """
-        try:
-            deadline_dt = datetime.fromisoformat(deadline) if deadline else None
-            planned_start_dt = (
-                datetime.fromisoformat(planned_start) if planned_start else None
-            )
-            planned_end_dt = (
-                datetime.fromisoformat(planned_end) if planned_end else None
-            )
-        except ValueError as e:
-            raise ValueError(
-                f"Invalid datetime format. Use ISO format "
-                f"(e.g., '2025-12-11T09:00:00'): {e}"
-            ) from e
+        deadline_dt = parse_iso_datetime(deadline, "deadline")
+        planned_start_dt = parse_iso_datetime(planned_start, "planned_start")
+        planned_end_dt = parse_iso_datetime(planned_end, "planned_end")
 
         result = client.update_task(
             task_id=task_id,

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_lifecycle.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_lifecycle.py
@@ -5,10 +5,9 @@ Tools for changing task status (start, complete, pause, cancel, reopen).
 
 from __future__ import annotations
 
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from taskdog_mcp.tools.serializers import iso, task_result
+from taskdog_mcp.tools.serializers import iso, parse_iso_datetime, task_result
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
@@ -133,11 +132,8 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
         Returns:
             Updated task data with new timestamps
         """
-        try:
-            start_dt = datetime.fromisoformat(actual_start) if actual_start else None
-            end_dt = datetime.fromisoformat(actual_end) if actual_end else None
-        except ValueError as e:
-            raise ValueError(f"Invalid datetime format: {e}") from e
+        start_dt = parse_iso_datetime(actual_start, "actual_start")
+        end_dt = parse_iso_datetime(actual_end, "actual_end")
 
         if actual_duration is not None and actual_duration <= 0:
             raise ValueError("actual_duration must be greater than 0")

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_optimization.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_optimization.py
@@ -6,8 +6,9 @@ optimization algorithms.
 
 from __future__ import annotations
 
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
+
+from taskdog_mcp.tools.serializers import parse_iso_datetime
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
@@ -57,10 +58,7 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
             Optimization result with successful_tasks, failed_tasks,
             daily_allocations, and summary metrics.
         """
-        try:
-            start_dt = datetime.fromisoformat(start_date) if start_date else None
-        except ValueError as e:
-            raise ValueError(f"Invalid datetime format: {e}") from e
+        start_dt = parse_iso_datetime(start_date, "start_date")
 
         if max_hours_per_day <= 0:
             raise ValueError("max_hours_per_day must be greater than 0")

--- a/packages/taskdog-mcp/tests/test_tools.py
+++ b/packages/taskdog-mcp/tests/test_tools.py
@@ -1896,3 +1896,35 @@ class TestTaskOptimizationTools:
             "display_name": "Greedy",
             "description": "Front-load tasks by priority",
         }
+
+
+class TestParseIsoDatetime:
+    """Tests for the shared parse_iso_datetime serializer helper."""
+
+    def test_parses_valid_iso_string(self) -> None:
+        from taskdog_mcp.tools.serializers import parse_iso_datetime
+
+        assert parse_iso_datetime("2025-12-11T09:00:00") == datetime(
+            2025, 12, 11, 9, 0, 0
+        )
+
+    @pytest.mark.parametrize("value", [None, ""])
+    def test_returns_none_for_empty(self, value: str | None) -> None:
+        from taskdog_mcp.tools.serializers import parse_iso_datetime
+
+        assert parse_iso_datetime(value) is None
+
+    def test_invalid_without_field_name(self) -> None:
+        from taskdog_mcp.tools.serializers import parse_iso_datetime
+
+        with pytest.raises(ValueError, match="Invalid datetime format: 'nope'"):
+            parse_iso_datetime("nope")
+
+    def test_invalid_with_field_name_preserves_field_and_value(self) -> None:
+        from taskdog_mcp.tools.serializers import parse_iso_datetime
+
+        with pytest.raises(
+            ValueError,
+            match="Invalid datetime format for 'since': 'nope'",
+        ):
+            parse_iso_datetime("nope", "since")


### PR DESCRIPTION
Closes #995

## What

Add `parse_iso_datetime(value, field_name=None)` to `serializers.py` and route all MCP tool parse sites through it.

## Why

ISO datetime parsing (`datetime.fromisoformat(value) if value else None` in a `try/except`) was duplicated across 5 try/except blocks (11 parse calls) in 4 tool modules, with 3 inconsistent error-message styles.

## Changes

- `serializers.py`: new `parse_iso_datetime` helper with a single unified error message. When `field_name` is passed, the message includes the field name and offending value.
- `task_crud.py` (`create_task` / `update_task`), `task_lifecycle.py` (`fix_actual_times`), `task_optimization.py` (`optimize_schedule`), `task_audit.py` (`list_audit_logs`): replaced inline parsing with the helper, passing `field_name` at every site so no information is lost.
- Dropped now-unused `datetime` imports.
- Added `TestParseIsoDatetime` covering valid input, empty/None, and the with/without-`field_name` error messages.

## Verification

`make`-equivalent checks in the worktree all pass:
- `pytest tests/test_tools.py` — 79 passed
- `ruff check` — clean
- `mypy` — no issues