### PR TITLE
fix(core): make has_notes content-based so empty notes count as absent

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_notes_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/sqlite_notes_repository.py
@@ -55,15 +55,21 @@ class SqliteNotesRepository(SqliteBaseRepository, NotesRepository):
     def has_notes(self, task_id: int) -> bool:
         """Check if task has associated notes.
 
+        Notes are content-based: an empty note row (left behind by
+        ``delete_notes``) counts as no notes.
+
         Args:
             task_id: Task ID
 
         Returns:
-            True if notes exist in database
+            True if a note with non-empty content exists in database
         """
         with self.Session() as session:
             result = session.execute(
-                select(NoteModel.task_id).where(NoteModel.task_id == task_id)
+                select(NoteModel.task_id).where(
+                    NoteModel.task_id == task_id,
+                    NoteModel.content != "",
+                )
             ).scalar()
             return result is not None
 
@@ -124,7 +130,10 @@ class SqliteNotesRepository(SqliteBaseRepository, NotesRepository):
 
         with self.Session() as session:
             result = session.execute(
-                select(NoteModel.task_id).where(NoteModel.task_id.in_(task_ids))  # type: ignore[attr-defined]
+                select(NoteModel.task_id).where(
+                    NoteModel.task_id.in_(task_ids),  # type: ignore[attr-defined]
+                    NoteModel.content != "",
+                )
             ).scalars()
             return set(result)
 

--- a/packages/taskdog-core/tests/infrastructure/persistence/database/test_sqlite_notes_repository.py
+++ b/packages/taskdog-core/tests/infrastructure/persistence/database/test_sqlite_notes_repository.py
@@ -78,6 +78,20 @@ class TestSqliteNotesRepository:
 
         assert repository.has_notes(1) is True
 
+    def test_has_notes_false_after_delete_clears_content(
+        self, repository: SqliteNotesRepository, create_task: Callable[[int], None]
+    ):
+        """Regression for #991: blanking content (the delete path) reports no notes."""
+        create_task(1)
+        repository.write_notes(1, "Test content")
+        assert repository.has_notes(1) is True
+
+        repository.write_notes(1, "")  # delete_notes path
+
+        assert repository.has_notes(1) is False
+        assert repository.read_notes(1) == ""
+        assert repository.get_task_ids_with_notes([1]) == set()
+
     def test_read_notes_returns_none_when_no_notes(
         self, repository: SqliteNotesRepository
     ):
@@ -138,12 +152,12 @@ class TestSqliteNotesRepository:
     def test_write_notes_handles_empty_string(
         self, repository: SqliteNotesRepository, create_task: Callable[[int], None]
     ):
-        """Test write_notes can write empty string."""
+        """Empty content is stored but does not count as having notes."""
         create_task(1)
         repository.write_notes(1, "")
 
         assert repository.read_notes(1) == ""
-        assert repository.has_notes(1) is True
+        assert repository.has_notes(1) is False
 
     def test_write_notes_preserves_multiline_content(
         self, repository: SqliteNotesRepository, create_task: Callable[[int], None]


### PR DESCRIPTION
Closes #991

## Problem

`delete_notes()` blanks a note's content via `write_notes(id, "")`, which keeps the row. But `has_notes()` (and `get_task_ids_with_notes()`) checked **row existence**, not content — so after a delete they reported `True`, contradicting the `delete_notes()` response (`has_notes=False`) and a later `GET .../notes`.

## Fix

Filter on non-empty content in both queries (`NoteModel.content != ""`). An empty note row now consistently counts as no notes.

This aligns the real `SqliteNotesRepository` with the test fake `InMemoryNotesRepository`, which was already content-based (`len(...) > 0`) — that mismatch is exactly why the server integration tests passed while the real repo carried the bug.

## Changes

- `sqlite_notes_repository.py`: `has_notes` and `get_task_ids_with_notes` exclude empty-content rows.
- Updated `test_write_notes_handles_empty_string` to the corrected semantics.
- Added `test_has_notes_false_after_delete_clears_content` regression covering delete → `has_notes`/`read_notes`/`get_task_ids_with_notes` consistency.

## Verification

- `pytest packages/taskdog-core/tests/` — 1120 passed
- `pytest packages/taskdog-server/tests/api/routers/test_notes.py` — 13 passed
- `ruff check` clean, `mypy` clean (183 source files)