### PR TITLE
refactor(ui,client): decouple TaskStatus from domain (#855)

### DIFF
--- a/packages/taskdog-client/src/taskdog_client/task_client.py
+++ b/packages/taskdog-client/src/taskdog_client/task_client.py
@@ -10,7 +10,6 @@ from taskdog_client.converters import (
 )
 from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 from taskdog_core.application.dto.update_task_output import TaskUpdateOutput
-from taskdog_core.domain.entities.task import TaskStatus
 
 
 class TaskClient:
@@ -76,7 +75,7 @@ class TaskClient:
         self,
         name: str | None,
         priority: int | None,
-        status: TaskStatus | None,
+        status: str | None,
         planned_start: datetime | None,
         planned_end: datetime | None,
         deadline: datetime | None,
@@ -106,7 +105,7 @@ class TaskClient:
         if priority is not None:
             payload["priority"] = priority
         if status is not None:
-            payload["status"] = status.value
+            payload["status"] = status
         if planned_start is not None:
             payload["planned_start"] = planned_start.isoformat()
         if planned_end is not None:
@@ -126,7 +125,7 @@ class TaskClient:
         task_id: int,
         name: str | None = None,
         priority: int | None = None,
-        status: TaskStatus | None = None,
+        status: str | None = None,
         planned_start: datetime | None = None,
         planned_end: datetime | None = None,
         deadline: datetime | None = None,

--- a/packages/taskdog-client/src/taskdog_client/taskdog_api_client.py
+++ b/packages/taskdog-client/src/taskdog_client/taskdog_api_client.py
@@ -35,7 +35,6 @@ from taskdog_core.application.dto.task_detail_output import TaskDetailOutput
 from taskdog_core.application.dto.task_list_output import TaskListOutput
 from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 from taskdog_core.application.dto.update_task_output import TaskUpdateOutput
-from taskdog_core.domain.entities.task import TaskStatus
 from taskdog_core.domain.exceptions.task_exceptions import ServerConnectionError
 
 
@@ -162,7 +161,7 @@ class TaskdogApiClient:
         task_id: int,
         name: str | None = None,
         priority: int | None = None,
-        status: TaskStatus | None = None,
+        status: str | None = None,
         planned_start: datetime | None = None,
         planned_end: datetime | None = None,
         deadline: datetime | None = None,

--- a/packages/taskdog-client/tests/test_task_client.py
+++ b/packages/taskdog-client/tests/test_task_client.py
@@ -6,8 +6,6 @@ from unittest.mock import Mock, patch
 import pytest
 from taskdog_client.task_client import TaskClient
 
-from taskdog_core.domain.entities.task import TaskStatus
-
 
 class TestTaskClient:
     """Test cases for TaskClient."""
@@ -57,7 +55,7 @@ class TestTaskClient:
         payload = self.client._build_update_payload(
             name="Updated",
             priority=75,
-            status=TaskStatus.IN_PROGRESS,
+            status="IN_PROGRESS",
             planned_start=datetime(2025, 1, 1, 9, 0),
             planned_end=datetime(2025, 1, 5, 17, 0),
             deadline=datetime(2025, 12, 31, 23, 59),

--- a/packages/taskdog-ui/src/taskdog/cli/commands/update.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/update.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from datetime import datetime
 
     from taskdog.cli.context import CliContext
-from taskdog_core.domain.entities.task import TaskStatus
+from taskdog.view_models.status import TaskStatus
 
 
 def _validate_name(
@@ -103,15 +103,12 @@ def update_command(
     ctx_obj: CliContext = ctx.obj
     console_writer = ctx_obj.console_writer
 
-    # Convert status string to Enum if provided
-    status_enum = TaskStatus(status) if status else None
-
     # Update task via API client
     result = ctx_obj.api_client.update_task(
         task_id=task_id,
         name=name,
         priority=priority,
-        status=status_enum,
+        status=status,
         planned_start=planned_start,
         planned_end=planned_end,
         deadline=deadline,

--- a/packages/taskdog-ui/src/taskdog/formatters/duration_formatter.py
+++ b/packages/taskdog-ui/src/taskdog/formatters/duration_formatter.py
@@ -2,8 +2,8 @@
 
 from datetime import datetime
 
+from taskdog.view_models.status import TaskStatus
 from taskdog.view_models.task_view_model import TaskRowViewModel
-from taskdog_core.domain.entities.task import TaskStatus
 
 
 class DurationFormatter:

--- a/packages/taskdog-ui/src/taskdog/presenters/gantt_presenter.py
+++ b/packages/taskdog-ui/src/taskdog/presenters/gantt_presenter.py
@@ -6,6 +6,7 @@ strikethrough) to create presentation-ready view models.
 """
 
 from taskdog.view_models.gantt_view_model import GanttViewModel, TaskGanttRowViewModel
+from taskdog.view_models.status import TaskStatus
 from taskdog_core.application.dto.gantt_overlay import GanttOverlay
 from taskdog_core.application.dto.task_dto import TaskRowDto
 
@@ -62,7 +63,7 @@ class GanttPresenter:
             id=task.id,
             name=task.name,
             formatted_estimated_duration=formatted_estimated_duration,
-            status=task.status,
+            status=TaskStatus(task.status.value),
             planned_start=task.planned_start.date() if task.planned_start else None,
             planned_end=task.planned_end.date() if task.planned_end else None,
             actual_start=task.actual_start.date() if task.actual_start else None,

--- a/packages/taskdog-ui/src/taskdog/presenters/table_presenter.py
+++ b/packages/taskdog-ui/src/taskdog/presenters/table_presenter.py
@@ -4,6 +4,7 @@ This presenter extracts necessary fields from TaskRowDto within TaskListOutput
 and creates presentation-ready view models for table/list display.
 """
 
+from taskdog.view_models.status import TaskStatus
 from taskdog.view_models.task_view_model import TaskRowViewModel
 from taskdog_core.application.dto.task_dto import TaskRowDto
 from taskdog_core.application.dto.task_list_output import TaskListOutput
@@ -40,7 +41,7 @@ class TablePresenter:
         return TaskRowViewModel(
             id=task.id,
             name=task.name,
-            status=task.status,
+            status=TaskStatus(task.status.value),
             priority=task.priority,
             is_fixed=task.is_fixed,
             estimated_duration=task.estimated_duration,

--- a/packages/taskdog-ui/src/taskdog/presenters/timeline_presenter.py
+++ b/packages/taskdog-ui/src/taskdog/presenters/timeline_presenter.py
@@ -11,6 +11,7 @@ from taskdog.constants.timeline import (
     DEFAULT_START_HOUR,
     MIN_DISPLAY_HOURS,
 )
+from taskdog.view_models.status import TaskStatus
 from taskdog.view_models.timeline_view_model import (
     TimelineTaskRowViewModel,
     TimelineViewModel,
@@ -138,7 +139,7 @@ class TimelinePresenter:
             actual_start=start_time,
             actual_end=end_time,
             duration_hours=duration_hours,
-            status=task_row.status,
+            status=TaskStatus(task_row.status.value),
             is_finished=is_finished,
         )
 

--- a/packages/taskdog-ui/src/taskdog/renderers/gantt_cell_formatter.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/gantt_cell_formatter.py
@@ -35,7 +35,7 @@ from taskdog.constants.symbols import (
     SYMBOL_PENDING,
     SYMBOL_TODAY,
 )
-from taskdog_core.domain.entities.task import TaskStatus
+from taskdog.view_models.status import TaskStatus
 from taskdog_core.shared.constants import (
     SATURDAY,
     SUNDAY,

--- a/packages/taskdog-ui/src/taskdog/renderers/rich_renderer_base.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/rich_renderer_base.py
@@ -1,7 +1,7 @@
 """Base class for Rich-based task renderers."""
 
 from taskdog.constants.colors import STATUS_STYLES
-from taskdog_core.domain.entities.task import TaskStatus
+from taskdog.view_models.status import TaskStatus
 
 
 class RichRendererBase:

--- a/packages/taskdog-ui/src/taskdog/renderers/timeline_cell_formatter.py
+++ b/packages/taskdog-ui/src/taskdog/renderers/timeline_cell_formatter.py
@@ -14,7 +14,7 @@ from taskdog.constants.timeline import (
     TIMELINE_BAR_CHAR,
     TIMELINE_EMPTY_CHAR,
 )
-from taskdog_core.domain.entities.task import TaskStatus
+from taskdog.view_models.status import TaskStatus
 
 
 class TimelineCellFormatter:

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/task_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/task_table.py
@@ -57,8 +57,8 @@ from taskdog.constants.task_table import (
 from taskdog.tui.widgets.base_widget import TUIWidget
 from taskdog.tui.widgets.task_table_row_builder import TaskTableRowBuilder
 from taskdog.tui.widgets.vi_navigation_mixin import ViNavigationMixin
+from taskdog.view_models.status import TaskStatus
 from taskdog.view_models.task_view_model import TaskRowViewModel
-from taskdog_core.domain.entities.task import TaskStatus
 
 # Column index for elapsed time (0=checkbox, 1=ID, ..., 13=Elapsed)
 _ELAPSED_COL_INDEX = 13

--- a/packages/taskdog-ui/src/taskdog/view_models/gantt_view_model.py
+++ b/packages/taskdog-ui/src/taskdog/view_models/gantt_view_model.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from datetime import date
 
 from taskdog.view_models.base import BaseViewModel
-from taskdog_core.domain.entities.task import TaskStatus
+from taskdog.view_models.status import TaskStatus
 
 
 @dataclass(frozen=True)

--- a/packages/taskdog-ui/src/taskdog/view_models/status.py
+++ b/packages/taskdog-ui/src/taskdog/view_models/status.py
@@ -1,0 +1,16 @@
+"""Presentation-layer task status.
+
+Mirrors the core domain ``TaskStatus`` values but is owned by the UI layer so
+that presentation code does not depend on ``taskdog_core.domain`` directly.
+Presenters map the string status carried by DTOs into this enum at the layer
+boundary (``TaskStatus(dto.status.value)``).
+"""
+
+from enum import Enum
+
+
+class TaskStatus(Enum):
+    PENDING = "PENDING"
+    IN_PROGRESS = "IN_PROGRESS"
+    COMPLETED = "COMPLETED"
+    CANCELED = "CANCELED"

--- a/packages/taskdog-ui/src/taskdog/view_models/task_view_model.py
+++ b/packages/taskdog-ui/src/taskdog/view_models/task_view_model.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from taskdog.view_models.base import BaseViewModel
-from taskdog_core.domain.entities.task import TaskStatus
+from taskdog.view_models.status import TaskStatus
 
 
 @dataclass(frozen=True)

--- a/packages/taskdog-ui/src/taskdog/view_models/timeline_view_model.py
+++ b/packages/taskdog-ui/src/taskdog/view_models/timeline_view_model.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from datetime import date, time
 
 from taskdog.view_models.base import BaseViewModel
-from taskdog_core.domain.entities.task import TaskStatus
+from taskdog.view_models.status import TaskStatus
 
 
 @dataclass(frozen=True)

--- a/packages/taskdog-ui/tests/formatters/test_duration_formatter.py
+++ b/packages/taskdog-ui/tests/formatters/test_duration_formatter.py
@@ -6,8 +6,8 @@ from unittest.mock import patch
 import pytest
 
 from taskdog.formatters.duration_formatter import DurationFormatter
+from taskdog.view_models.status import TaskStatus
 from taskdog.view_models.task_view_model import TaskRowViewModel
-from taskdog_core.domain.entities.task import TaskStatus
 
 
 class TestDurationFormatter:

--- a/packages/taskdog-ui/tests/presentation/presenters/test_table_presenter.py
+++ b/packages/taskdog-ui/tests/presentation/presenters/test_table_presenter.py
@@ -6,6 +6,7 @@ import pytest
 from fixtures.repositories import InMemoryTaskRepository
 
 from taskdog.presenters.table_presenter import TablePresenter
+from taskdog.view_models.status import TaskStatus as UITaskStatus
 from taskdog_core.application.dto.task_dto import TaskRowDto
 from taskdog_core.application.dto.task_list_output import TaskListOutput
 from taskdog_core.domain.entities.task import TaskStatus
@@ -46,10 +47,10 @@ class TestTablePresenter:
         assert len(view_models) == 2
         assert view_models[0].id == task1.id
         assert view_models[0].name == "Task 1"
-        assert view_models[0].status == TaskStatus.PENDING
+        assert view_models[0].status == UITaskStatus.PENDING
         assert view_models[1].id == task2.id
         assert view_models[1].name == "Task 2"
-        assert view_models[1].status == TaskStatus.IN_PROGRESS
+        assert view_models[1].status == UITaskStatus.IN_PROGRESS
 
     def test_present_includes_has_notes_from_dto(self):
         """Test present uses has_notes from TaskRowDto."""

--- a/packages/taskdog-ui/tests/presentation/renderers/test_gantt_cell_formatter.py
+++ b/packages/taskdog-ui/tests/presentation/renderers/test_gantt_cell_formatter.py
@@ -12,7 +12,7 @@ from taskdog.constants.symbols import (
     SYMBOL_TODAY,
 )
 from taskdog.renderers.gantt_cell_formatter import GanttCellFormatter
-from taskdog_core.domain.entities.task import TaskStatus
+from taskdog.view_models.status import TaskStatus
 
 
 class TestGanttCellFormatter:

--- a/packages/taskdog-ui/tests/presentation/renderers/test_rich_table_renderer.py
+++ b/packages/taskdog-ui/tests/presentation/renderers/test_rich_table_renderer.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from taskdog.renderers.rich_table_renderer import RichTableRenderer
+from taskdog.view_models.status import TaskStatus
 from taskdog.view_models.task_view_model import TaskRowViewModel
-from taskdog_core.domain.entities.task import TaskStatus
 
 
 class TestRichTableRenderer:

--- a/packages/taskdog-ui/tests/presentation/tui/widgets/test_task_table_row_builder.py
+++ b/packages/taskdog-ui/tests/presentation/tui/widgets/test_task_table_row_builder.py
@@ -6,8 +6,8 @@ import pytest
 from rich.text import Text
 
 from taskdog.tui.widgets.task_table_row_builder import TaskTableRowBuilder
+from taskdog.view_models.status import TaskStatus
 from taskdog.view_models.task_view_model import TaskRowViewModel
-from taskdog_core.domain.entities.task import TaskStatus
 
 
 def make_vm(**overrides: object) -> TaskRowViewModel:


### PR DESCRIPTION
## Summary

Closes #855.

`taskdog-ui` and `taskdog-client` imported `TaskStatus` directly from
`taskdog_core.domain.entities.task`, violating the dependency direction
(Presentation/Client → Domain). This decouples them.

## Approach

Rather than scatter raw status strings through the UI (which would trade a
domain dependency for stringly-typed comparisons and lose type safety), the
UI now owns its own presentation-layer enum and maps at the boundary:

- Add `taskdog-ui/src/taskdog/view_models/status.py` — a presentation-layer
  `TaskStatus` enum mirroring the domain values.
- Presenters convert DTO status to the UI enum at the single boundary point
  (`TaskStatus(dto.status.value)`).
- UI view models, renderers, formatters, and the TUI widget reference the UI
  enum instead of the domain enum (logic unchanged).
- `update.py` passes the status string straight to the client; the enum
  conversion is removed.
- Client `update_task` / `_build_update_payload` now take `status: str`.

## Note on scope

The issue's "taskdog-client (4 files)" list referenced `converters/*`
constructing `TaskStatus(data["status"])`. That converter layer was already
removed by #922 (collapsed into Pydantic `model_validate`), so the remaining
client work was just the method signatures in `task_client.py` /
`taskdog_api_client.py`.

`ServerConnectionError` (a domain *exception*) is still imported by the client;
that is a separate concern, out of scope here.

## Verification

- All tests pass: core 1119 / server 324 / client 223 / mcp 93 / ui 1126
- `make check` (ruff + mypy) clean
- No `taskdog_core.domain ... import TaskStatus` remaining in ui/client src
- Manual CLI e2e (server up → add / list / start / update --status / gantt)
  renders correctly