### PR TITLE
feat(tui): expose Gantt filter toggle via command palette

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -40,6 +40,7 @@ from taskdog.tui.palette.providers import (
     BackupCommandProvider,
     ExportCommandProvider,
     ExportFormatProvider,
+    GanttFilterCommandProvider,
     HelpCommandProvider,
     OptimizeCommandProvider,
     SortCommandProvider,
@@ -208,6 +209,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         OptimizeCommandProvider,
         ExportCommandProvider,
         BackupCommandProvider,
+        GanttFilterCommandProvider,
         HelpCommandProvider,
     }
 

--- a/packages/taskdog-ui/src/taskdog/tui/palette/providers/__init__.py
+++ b/packages/taskdog-ui/src/taskdog/tui/palette/providers/__init__.py
@@ -9,6 +9,9 @@ from taskdog.tui.palette.providers.export_providers import (
     ExportCommandProvider,
     ExportFormatProvider,
 )
+from taskdog.tui.palette.providers.gantt_filter_provider import (
+    GanttFilterCommandProvider,
+)
 from taskdog.tui.palette.providers.help_provider import HelpCommandProvider
 from taskdog.tui.palette.providers.optimize_providers import OptimizeCommandProvider
 from taskdog.tui.palette.providers.sort_providers import (
@@ -24,6 +27,7 @@ __all__ = [
     "BaseListProvider",
     "ExportCommandProvider",
     "ExportFormatProvider",
+    "GanttFilterCommandProvider",
     "HelpCommandProvider",
     "OptimizeCommandProvider",
     "SortCommandProvider",

--- a/packages/taskdog-ui/src/taskdog/tui/palette/providers/gantt_filter_provider.py
+++ b/packages/taskdog-ui/src/taskdog/tui/palette/providers/gantt_filter_provider.py
@@ -1,0 +1,13 @@
+"""Command provider for toggling the Gantt chart search filter."""
+
+from __future__ import annotations
+
+from taskdog.tui.palette.providers.base import SimpleSingleCommandProvider
+
+
+class GanttFilterCommandProvider(SimpleSingleCommandProvider):
+    """Command provider for toggling the Gantt chart search filter."""
+
+    COMMAND_NAME = "Toggle Gantt Filter"
+    COMMAND_HELP = "Toggle search filter for Gantt chart"
+    COMMAND_CALLBACK_NAME = "action_toggle_gantt_filter"

--- a/packages/taskdog-ui/tests/presentation/tui/palette/providers/test_gantt_filter_provider.py
+++ b/packages/taskdog-ui/tests/presentation/tui/palette/providers/test_gantt_filter_provider.py
@@ -1,0 +1,32 @@
+"""Tests for the Gantt filter command provider."""
+
+from taskdog.tui.app import TaskdogTUI
+from taskdog.tui.palette.providers.base import SimpleSingleCommandProvider
+from taskdog.tui.palette.providers.gantt_filter_provider import (
+    GanttFilterCommandProvider,
+)
+
+
+class TestGanttFilterCommandProvider:
+    """Test cases for GanttFilterCommandProvider."""
+
+    def test_inherits_simple_single_command_provider(self):
+        """Test that GanttFilterCommandProvider uses SimpleSingleCommandProvider."""
+        assert issubclass(GanttFilterCommandProvider, SimpleSingleCommandProvider)
+
+    def test_command_attributes(self):
+        """Test that class attributes are correctly defined."""
+        assert GanttFilterCommandProvider.COMMAND_NAME == "Toggle Gantt Filter"
+        assert (
+            GanttFilterCommandProvider.COMMAND_CALLBACK_NAME
+            == "action_toggle_gantt_filter"
+        )
+        assert len(GanttFilterCommandProvider.COMMAND_HELP) > 0
+
+    def test_callback_exists_on_app(self):
+        """Test that the configured callback is a real method on the app."""
+        assert hasattr(TaskdogTUI, GanttFilterCommandProvider.COMMAND_CALLBACK_NAME)
+
+    def test_registered_in_app_commands(self):
+        """Test that the provider is registered in the command palette."""
+        assert GanttFilterCommandProvider in TaskdogTUI.COMMANDS


### PR DESCRIPTION
## Summary

The Gantt chart search filter was only reachable through the `t`
keybinding. This adds `GanttFilterCommandProvider` so it can also be
invoked from the command palette as **"Toggle Gantt Filter"**, reusing
the existing `action_toggle_gantt_filter` callback (no logic
duplication).

## Changes

- New `palette/providers/gantt_filter_provider.py`
  (`SimpleSingleCommandProvider`, callback → `action_toggle_gantt_filter`).
- Register the provider in `palette/providers/__init__.py` and
  `TaskdogTUI.COMMANDS`.
- Add `test_gantt_filter_provider.py` following the existing single-command
  provider test pattern.

## Testing

- `make check` — clean.
- `pytest tests/presentation/tui/palette/` — 19 passed.
