### PR TITLE
feat(ui): wire up custom TUI keybindings from cli.toml [keybindings]

### DIFF
--- a/examples/cli.toml
+++ b/examples/cli.toml
@@ -139,6 +139,32 @@ workload_moderate_hours = 8.0
 # - Compact view: min_display_days = 28 (4 weeks)
 
 # =============================================================================
+# TUI Keybindings
+# =============================================================================
+#
+# Remap TUI keys by mapping a binding id to a key string. Any id you omit
+# keeps its default key. Unknown ids are ignored with a warning on startup,
+# and a key that collides with another binding is reported at runtime.
+# Key strings follow Textual's syntax (e.g. "ctrl+s", "f5", "question_mark").
+#
+# Binding ids and their default keys:
+#   quit                "q"        add                  "a"
+#   start               "s"        pause                "P"
+#   done                "d"        cancel               "c"
+#   reopen              "R"        rm (archive)         "x"
+#   hard_delete         "X"        refresh              "r"
+#   show (info)         "i"        edit                 "e"
+#   fix_actual          "f"        note                 "v"
+#   show_search         "/"        hide_search          "escape"
+#   toggle_sort_reverse "ctrl+t"   show_help            "?"
+#   stats               "S"        toggle_maximize      "z"
+#   toggle_gantt_filter "t"
+
+[keybindings]
+# Example: remap "Start" from "s" to "ctrl+s".
+# start = "ctrl+s"
+
+# =============================================================================
 # Environment Variables
 # =============================================================================
 #

--- a/packages/taskdog-ui/src/taskdog/infrastructure/cli_config_manager.py
+++ b/packages/taskdog-ui/src/taskdog/infrastructure/cli_config_manager.py
@@ -114,7 +114,8 @@ class CliConfig:
         notes: Notes settings (template path, etc.)
         input_defaults: UI input completion defaults (datetime fields)
         gantt: Gantt chart display settings (workload thresholds)
-        keybindings: Future: Custom keybindings for TUI (not yet implemented)
+        keybindings: Custom TUI keybindings, mapping a binding id to a key
+            string (e.g. ``{"start": "ctrl+s"}``). Overrides the default keys.
     """
 
     api: CliApiConfig = field(default_factory=CliApiConfig)

--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -59,6 +59,25 @@ from taskdog_core.domain.exceptions.task_exceptions import (
 logger = logging.getLogger(__name__)
 
 
+def resolve_keymap(
+    config_keybindings: dict[str, str], valid_ids: set[str]
+) -> tuple[dict[str, str], list[str]]:
+    """Split user keybindings into a Textual keymap and unknown binding ids.
+
+    Entries whose id matches a real binding become a keymap (binding id -> key)
+    passed to ``App.set_keymap``; unrecognised ids are returned separately so the
+    caller can warn and fall back to the default keys.
+    """
+    keymap: dict[str, str] = {}
+    unknown: list[str] = []
+    for binding_id, key in config_keybindings.items():
+        if binding_id in valid_ids:
+            keymap[binding_id] = key
+        else:
+            unknown.append(binding_id)
+    return keymap, unknown
+
+
 class TaskdogTUI(App):  # type: ignore[type-arg]
     """Taskdog TUI application."""
 
@@ -71,15 +90,24 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
             "Quit",
             show=True,
             tooltip="Quit the app and return to the command prompt",
+            id="quit",
         ),
-        Binding("a", "add", "Add", show=True, tooltip="Create a new task"),
-        Binding("s", "start", "Start", show=False, tooltip="Start the selected task"),
+        Binding("a", "add", "Add", show=True, tooltip="Create a new task", id="add"),
+        Binding(
+            "s",
+            "start",
+            "Start",
+            show=False,
+            tooltip="Start the selected task",
+            id="start",
+        ),
         Binding(
             "P",
             "pause",
             "Pause",
             show=False,
             tooltip="Pause the selected task and reset to PENDING status",
+            id="pause",
         ),
         Binding(
             "d",
@@ -87,9 +115,15 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
             "Done",
             show=False,
             tooltip="Mark the selected task as completed",
+            id="done",
         ),
         Binding(
-            "c", "cancel", "Cancel", show=False, tooltip="Cancel the selected task"
+            "c",
+            "cancel",
+            "Cancel",
+            show=False,
+            tooltip="Cancel the selected task",
+            id="cancel",
         ),
         Binding(
             "R",
@@ -97,6 +131,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
             "Reopen",
             show=False,
             tooltip="Reopen a completed or canceled task",
+            id="reopen",
         ),
         Binding(
             "x",
@@ -104,6 +139,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
             "Archive",
             show=False,
             tooltip="Archive the selected task (soft delete)",
+            id="rm",
         ),
         Binding(
             "X",
@@ -111,6 +147,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
             "Delete",
             show=False,
             tooltip="Permanently delete the selected task",
+            id="hard_delete",
         ),
         Binding(
             "r",
@@ -118,6 +155,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
             "Refresh",
             show=True,
             tooltip="Refresh the task list from the server",
+            id="refresh",
         ),
         Binding(
             "i",
@@ -125,6 +163,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
             "Info",
             show=False,
             tooltip="Show detailed information about the selected task",
+            id="show",
         ),
         Binding(
             "e",
@@ -132,6 +171,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
             "Edit",
             show=False,
             tooltip="Edit the selected task's properties",
+            id="edit",
         ),
         Binding(
             "f",
@@ -139,6 +179,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
             "Fix Time",
             show=False,
             tooltip="Fix actual start/end times or duration for the selected task",
+            id="fix_actual",
         ),
         Binding(
             "v",
@@ -146,10 +187,17 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
             "Edit Note",
             show=False,
             tooltip="Edit markdown notes for the selected task",
+            id="note",
         ),
         Binding(
-            "/", "show_search", "Search", show=False, tooltip="Search for tasks by name"
+            "/",
+            "show_search",
+            "Search",
+            show=False,
+            tooltip="Search for tasks by name",
+            id="show_search",
         ),
+        # Fixed alias for show_search (not user-remappable; remap "show_search").
         Binding(
             "ctrl+r",
             "show_search",
@@ -163,6 +211,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
             "Clear Search",
             show=False,
             tooltip="Clear the search filter and show all tasks",
+            id="hide_search",
         ),
         Binding(
             "ctrl+t",
@@ -170,6 +219,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
             "Toggle Sort",
             show=False,
             tooltip="Toggle sort direction (ascending ⇔ descending)",
+            id="toggle_sort_reverse",
         ),
         Binding(
             "?",
@@ -177,6 +227,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
             "Help",
             show=True,
             tooltip="Show help screen with keybindings and usage instructions",
+            id="show_help",
         ),
         Binding(
             "S",
@@ -184,6 +235,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
             "Stats",
             show=True,
             tooltip="Show task statistics dashboard",
+            id="stats",
         ),
         Binding(
             "z",
@@ -191,6 +243,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
             "Zoom",
             show=False,
             tooltip="Zoom: Toggle maximize/minimize for the focused widget",
+            id="toggle_maximize",
         ),
         Binding(
             "t",
@@ -198,6 +251,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
             "Gantt Filter",
             show=False,
             tooltip="Toggle search filter for Gantt chart",
+            id="toggle_gantt_filter",
         ),
     ]
 
@@ -352,6 +406,8 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
 
     async def on_mount(self) -> None:
         """Called when app is mounted."""
+        self._apply_custom_keybindings()
+
         # Apply theme from config with fallback for invalid themes
         try:
             self.theme = self._theme
@@ -390,6 +446,26 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         """Called when app is unmounted."""
         # Disconnect WebSocket
         await self.websocket_client.disconnect()
+
+    def _apply_custom_keybindings(self) -> None:
+        """Override default keys from ``cli.toml [keybindings]`` (id -> key)."""
+        valid_ids = {b.id for b in self.BINDINGS if isinstance(b, Binding) and b.id}
+        keymap, unknown = resolve_keymap(self._cli_config.keybindings, valid_ids)
+        if unknown:
+            self.notify(
+                f"Unknown keybinding id(s) in cli.toml: {', '.join(sorted(unknown))}",
+                severity="warning",
+            )
+        if keymap:
+            self.set_keymap(keymap)
+
+    def handle_bindings_clash(self, clashed_bindings: set[Binding], node: Any) -> None:
+        """Warn when custom keybindings collide with existing ones."""
+        keys = sorted({b.key for b in clashed_bindings})
+        self.notify(
+            f"Keybinding clash on: {', '.join(keys)}. Check cli.toml [keybindings].",
+            severity="warning",
+        )
 
     def _handle_api_error(
         self, error: ServerConnectionError | AuthenticationError | ServerError

--- a/packages/taskdog-ui/tests/tui/test_keybindings.py
+++ b/packages/taskdog-ui/tests/tui/test_keybindings.py
@@ -1,0 +1,94 @@
+"""Tests for custom TUI keybinding resolution from cli.toml [keybindings]."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from taskdog.infrastructure.cli_config_manager import CliConfig
+from taskdog.tui.app import TaskdogTUI, resolve_keymap
+
+
+def _make_app(keybindings: dict[str, str]) -> TaskdogTUI:
+    api_client = MagicMock()
+    api_client.client_id = "test"
+    websocket_client = MagicMock()
+    websocket_client.connect = AsyncMock()
+    websocket_client.disconnect = AsyncMock()
+    return TaskdogTUI(
+        api_client=api_client,
+        websocket_client=websocket_client,
+        cli_config=CliConfig(keybindings=keybindings),
+    )
+
+
+class TestBindingIds:
+    """Every remappable binding must expose a unique, stable id."""
+
+    def test_core_action_bindings_have_ids(self):
+        ids = [b.id for b in TaskdogTUI.BINDINGS if b.id]
+        # A representative set of actions users expect to remap.
+        for expected in ("quit", "add", "start", "done", "refresh", "show_help"):
+            assert expected in ids
+
+    def test_binding_ids_are_unique(self):
+        ids = [b.id for b in TaskdogTUI.BINDINGS if b.id]
+        assert len(ids) == len(set(ids))
+
+
+class TestResolveKeymap:
+    """resolve_keymap filters config against the set of valid binding ids."""
+
+    def test_keeps_known_ids(self):
+        keymap, unknown = resolve_keymap(
+            {"start": "ctrl+s", "done": "ctrl+d"}, valid_ids={"start", "done"}
+        )
+        assert keymap == {"start": "ctrl+s", "done": "ctrl+d"}
+        assert unknown == []
+
+    def test_drops_and_reports_unknown_ids(self):
+        keymap, unknown = resolve_keymap(
+            {"start": "ctrl+s", "bogus": "x"}, valid_ids={"start"}
+        )
+        assert keymap == {"start": "ctrl+s"}
+        assert unknown == ["bogus"]
+
+    def test_empty_config(self):
+        keymap, unknown = resolve_keymap({}, valid_ids={"start"})
+        assert keymap == {}
+        assert unknown == []
+
+    def test_resolves_against_real_app_bindings(self):
+        valid_ids = {b.id for b in TaskdogTUI.BINDINGS if b.id}
+        keymap, unknown = resolve_keymap({"start": "ctrl+s"}, valid_ids=valid_ids)
+        assert keymap == {"start": "ctrl+s"}
+        assert unknown == []
+
+
+class TestKeymapApplied:
+    """The configured keymap is applied to the live app on mount."""
+
+    @pytest.mark.asyncio
+    async def test_custom_key_overrides_default(self):
+        app = _make_app({"start": "ctrl+s"})
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            start_keys = [
+                key
+                for key, active in app.active_bindings.items()
+                if active.binding.action == "start"
+            ]
+        assert start_keys == ["ctrl+s"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_id_warns_and_keeps_defaults(self):
+        app = _make_app({"bogus": "z"})
+        app.notify = MagicMock()  # type: ignore[method-assign]
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            start_keys = [
+                key
+                for key, active in app.active_bindings.items()
+                if active.binding.action == "start"
+            ]
+        assert start_keys == ["s"]
+        assert any("bogus" in str(call.args[0]) for call in app.notify.call_args_list)

--- a/scripts/vulture_whitelist.py
+++ b/scripts/vulture_whitelist.py
@@ -20,3 +20,5 @@ _.matches  # unused method (packages/taskdog-ui/src/taskdog/tui/widgets/task_sea
 VI_ALL_BINDINGS  # unused variable (packages/taskdog-ui/src/taskdog/tui/widgets/vi_navigation_mixin.py:96)
 VI_SCROLL_BINDINGS  # unused variable (packages/taskdog-ui/src/taskdog/tui/widgets/vi_navigation_mixin.py:105)
 VI_SCROLL_ALL_BINDINGS  # unused variable (packages/taskdog-ui/src/taskdog/tui/widgets/vi_navigation_mixin.py:116)
+_.handle_bindings_clash  # Textual override called by the framework (packages/taskdog-ui/src/taskdog/tui/app.py)
+node  # Textual override signature param (packages/taskdog-ui/src/taskdog/tui/app.py)


### PR DESCRIPTION
## Summary

Wires up the previously inert `cli.toml [keybindings]` config so users can remap TUI keys. The config was already read into `CliConfig.keybindings`, but the TUI's `BINDINGS` were hardcoded and never consulted it.

Implemented via Textual's native keymap (`App.set_keymap`) rather than a hand-rolled merge:

- Each remappable `Binding` now carries a stable `id` matching its action (`start`, `done`, `refresh`, …).
- `resolve_keymap()` filters the config against the set of valid binding ids; unknown ids are reported.
- `on_mount` applies the resulting keymap; unknown ids raise a startup warning, and `handle_bindings_clash` warns at runtime when a remap collides with another binding.
- `examples/cli.toml` documents the `[keybindings]` section and lists every binding id with its default key.

The `ctrl+r` search alias is intentionally left without an id (not user-remappable); remap `show_search` instead.

## Config example

```toml
[keybindings]
start = "ctrl+s"
refresh = "f5"
```

## Tests

`packages/taskdog-ui/tests/tui/test_keybindings.py`:

- Pure unit tests for `resolve_keymap` (known/unknown/empty) and binding-id uniqueness.
- Integration tests via `App.run_test()` confirming the remap actually takes effect on the live app (`start` → `ctrl+s`) and that an unknown id warns while keeping the default key.

Full `taskdog-ui` suite (1147 tests), ruff, mypy (strict), and vulture all pass.

## Follow-up

The always-visible footer hint line and the help-dialog prose still show hardcoded keys and will diverge from custom remaps. The keymap-aware **Keys panel** (`Ctrl+P → Keys`) already shows correct keys. Tracked in #1020.

Closes #986