### PR TITLE
docs(readme): add Arch Linux (AUR) install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ make install
 
 This installs the CLI/TUI and server, and sets up a systemd (Linux) or launchd (macOS) service so the server starts automatically.
 
+### Arch Linux (AUR)
+
+```bash
+yay -S taskdog
+```
+
+Installs the CLI/TUI, server, and MCP binaries plus the systemd **user** service
+(enable per-user with `systemctl --user enable --now taskdog-server`). See
+[`contrib/aur/`](contrib/aur/) for packaging details.
+
 ### From PyPI
 
 ```bash


### PR DESCRIPTION
## What

Adds an **Arch Linux (AUR)** subsection to the README Installation section, now
that taskdog is published on the AUR (`yay -S taskdog`).

Documents the one-liner install and notes the bundled systemd **user** service,
linking to `contrib/aur/` for packaging details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)