### PR TITLE
fix(core): compare optimizer dates at day granularity

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/services/optimization/backward_optimization_strategy.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/optimization/backward_optimization_strategy.py
@@ -91,7 +91,9 @@ class BackwardOptimizationStrategy(OptimizationStrategy):
                 current_date -= timedelta(days=1)
                 continue
 
-            if current_date < params.start_date:
+            # Compare at day granularity: allocation is per-day, while start_date
+            # (defaults to now()) and deadline carry times of day (#964)
+            if current_date.date() < params.start_date.date():
                 return None
 
             date_obj = current_date.date()

--- a/packages/taskdog-core/src/taskdog_core/application/services/optimization/greedy_based_optimization_strategy.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/optimization/greedy_based_optimization_strategy.py
@@ -123,7 +123,9 @@ class GreedyBasedOptimizationStrategy(OptimizationStrategy):
                 current_date += timedelta(days=1)
                 continue
 
-            if effective_deadline and current_date > effective_deadline:
+            # Compare at day granularity: allocation is per-day, while start_date
+            # (defaults to now()) and deadline carry times of day (#964)
+            if effective_deadline and current_date.date() > effective_deadline.date():
                 for date_obj, hours in task_daily_allocations.items():
                     daily_allocations[date_obj] -= hours
                 return None

--- a/packages/taskdog-core/tests/application/services/optimization/test_backward_optimization_strategy.py
+++ b/packages/taskdog-core/tests/application/services/optimization/test_backward_optimization_strategy.py
@@ -178,3 +178,26 @@ class TestBackwardOptimizationStrategy(BaseOptimizationStrategyTest):
         assert updated_task is not None
         assert len(updated_task.daily_allocations) == 1
         assert date(2025, 10, 27) in updated_task.daily_allocations
+
+    def test_backward_schedules_task_due_today_after_deadline_time(self):
+        """Test that a task due today is scheduled regardless of wall-clock time.
+
+        Allocation is day-granular, so a task with a deadline of today 18:00
+        must still be schedulable when the optimizer runs later the same day
+        (e.g. start_date defaulting to now() at 19:00). Regression test for #964.
+        """
+        task = self.create_task(
+            "Due Today",
+            estimated_duration=2.0,
+            deadline=datetime(2025, 10, 20, 18, 0, 0),
+        )
+
+        # Optimizer runs at 19:00 on the deadline day
+        result = self.optimize_schedule(start_date=datetime(2025, 10, 20, 19, 0, 0))
+
+        assert len(result.successful_tasks) == 1
+        assert len(result.failed_tasks) == 0
+
+        updated_task = self.repository.get_by_id(task.id)
+        assert updated_task is not None
+        assert date(2025, 10, 20) in updated_task.daily_allocations

--- a/packages/taskdog-core/tests/application/services/optimization/test_greedy_optimization_strategy.py
+++ b/packages/taskdog-core/tests/application/services/optimization/test_greedy_optimization_strategy.py
@@ -174,3 +174,26 @@ class TestGreedyOptimizationStrategy(BaseOptimizationStrategyTest):
             assert hours <= 6.0, (
                 f"Total hours on {date_str} ({hours}h) exceeds max_hours_per_day (6.0h)"
             )
+
+    def test_greedy_schedules_task_due_today_after_deadline_time(self):
+        """Test that a task due today is scheduled regardless of wall-clock time.
+
+        Allocation is day-granular, so a task with a deadline of today 18:00
+        must still be schedulable when the optimizer runs later the same day
+        (e.g. start_date defaulting to now() at 19:00). Regression test for #964.
+        """
+        task = self.create_task(
+            "Due Today",
+            estimated_duration=2.0,
+            deadline=datetime(2025, 10, 20, 18, 0, 0),
+        )
+
+        # Optimizer runs at 19:00 on the deadline day
+        result = self.optimize_schedule(start_date=datetime(2025, 10, 20, 19, 0, 0))
+
+        assert len(result.successful_tasks) == 1
+        assert len(result.failed_tasks) == 0
+
+        updated_task = self.repository.get_by_id(task.id)
+        assert updated_task is not None
+        assert date(2025, 10, 20) in updated_task.daily_allocations


### PR DESCRIPTION
## Description

The optimizer allocates hours per day, but the deadline cutoff in `GreedyBasedOptimizationStrategy._allocate_task` and the start cutoff in `BackwardOptimizationStrategy._allocate_task` compared full `datetime`s. Since `start_date` defaults to `now()` (with a time component) and date-only deadlines are completed to 18:00, a task due *today* was silently dropped from the schedule whenever the optimizer ran after the deadline's time of day:

```text
deadline 2025-10-20 18:00, optimize with start_date 2025-10-20 17:00 → scheduled
deadline 2025-10-20 18:00, optimize with start_date 2025-10-20 19:00 → allocation failure
```

Both comparisons now use `.date()`, matching the day granularity of the allocation loop, as suggested in the issue.

## Related Issue

Closes #964

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `greedy_based_optimization_strategy.py`: deadline cutoff compares `current_date.date() > effective_deadline.date()`
- `backward_optimization_strategy.py`: start cutoff compares `current_date.date() < params.start_date.date()`
- Regression test per strategy: a task due today must be scheduled when the optimizer runs at 19:00 the same day; both fail on `main` and pass with the fix

## Testing

### Test Environment

- OS: Ubuntu 24.04
- Python version: 3.13
- UV version: 0.11.11

### Tests Performed

- [x] Unit tests pass (`make test-core`, 1122 passed)
- [x] Added new tests for the fix
- [x] Manual testing completed (reproduced the silent drop before, verified scheduling after)

## Code Quality Checklist

- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] Code is formatted (`make format`)
- [x] No new warnings introduced
- [x] Code follows project conventions

## Package Affected

- [x] taskdog-core