### PR TITLE
feat(core): include daily_allocations in TaskRowDto and list API

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/dto/task_dto.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/task_dto.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from datetime import date, datetime
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from taskdog_core.domain.entities.task import TaskStatus
 
@@ -76,6 +76,7 @@ class TaskRowDto(BaseModel):
     is_fixed: bool
     depends_on: list[int]
     tags: list[str]
+    daily_allocations: dict[date, float] = Field(default_factory=dict)
     is_archived: bool
     is_finished: bool
     created_at: datetime
@@ -113,6 +114,7 @@ class TaskRowDto(BaseModel):
             is_fixed=task.is_fixed,
             depends_on=task.depends_on,
             tags=task.tags,
+            daily_allocations=task.daily_allocations,
             is_archived=task.is_archived,
             is_finished=task.is_finished,
             created_at=task.created_at,
@@ -144,6 +146,9 @@ class TaskRowDto(BaseModel):
             "is_fixed": self.is_fixed,
             "depends_on": self.depends_on,
             "tags": self.tags,
+            "daily_allocations": {
+                k.isoformat(): v for k, v in self.daily_allocations.items()
+            },
             "is_archived": self.is_archived,
             "is_finished": self.is_finished,
             "created_at": self.created_at.isoformat(),

--- a/packages/taskdog-server/src/taskdog_server/api/converters.py
+++ b/packages/taskdog-server/src/taskdog_server/api/converters.py
@@ -87,6 +87,7 @@ def convert_to_task_list_response(dto: TaskListOutput) -> TaskListResponse:
             depends_on=task.depends_on,
             tags=task.tags,
             is_fixed=task.is_fixed,
+            daily_allocations=format_date_dict(task.daily_allocations),
             is_archived=task.is_archived,
             is_finished=task.is_finished,
             has_notes=task.id in task_ids_with_notes,

--- a/packages/taskdog-server/src/taskdog_server/api/models/responses.py
+++ b/packages/taskdog-server/src/taskdog_server/api/models/responses.py
@@ -89,6 +89,8 @@ class TaskReadResponseBase(TaskFieldsBase):
 class TaskResponse(TaskReadResponseBase):
     """Response model for task row data (list views)."""
 
+    daily_allocations: dict[str, float] = Field(default_factory=dict)
+
 
 class TaskDetailResponse(TaskReadResponseBase):
     """Response model for detailed task view."""


### PR DESCRIPTION
## Summary

- Add `daily_allocations: dict[date, float]` field to `TaskRowDto` and populate it in `from_entity()` / `to_dict()`
- Add the field to `TaskResponse` (server list endpoint response model)
- Pass it through in the server converter

The `Task` entity already eager-loads allocations via `lazy="selectin"`, so there is no additional DB query — we were just discarding the data at the DTO boundary. This unblocks exporters and other list-based consumers from accessing allocation data without per-task detail fetches.