### PR TITLE
fix(export): unify default fields across JSON, CSV, and Markdown exporters

### DIFF
--- a/packages/taskdog-ui/src/taskdog/cli/commands/export.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/export.py
@@ -21,19 +21,28 @@ from taskdog.exporters import (
 )
 from taskdog.shared.click_types.field_list import FieldList
 
-# Valid fields for export
+# Valid fields for export. Mirrors the keys produced by
+# TaskRowDto.to_dict() so every format exposes the same field surface.
 VALID_FIELDS = {
     "id",
     "name",
     "priority",
     "status",
     "created_at",
+    "updated_at",
     "planned_start",
     "planned_end",
     "deadline",
     "actual_start",
     "actual_end",
     "estimated_duration",
+    "actual_duration_hours",
+    "is_fixed",
+    "is_archived",
+    "is_finished",
+    "has_notes",
+    "depends_on",
+    "tags",
     "daily_allocations",
 }
 
@@ -60,8 +69,10 @@ VALID_FIELDS = {
     "-f",
     type=FieldList(valid_fields=VALID_FIELDS),
     help="Comma-separated list of fields to export (e.g., 'id,name,priority,status'). "
-    "Available: id, name, priority, status, created_at, planned_start, planned_end, "
-    "deadline, actual_start, actual_end, estimated_duration, daily_allocations",
+    "Available: id, name, priority, status, created_at, updated_at, planned_start, "
+    "planned_end, deadline, actual_start, actual_end, estimated_duration, "
+    "actual_duration_hours, is_fixed, is_archived, is_finished, has_notes, "
+    "depends_on, tags, daily_allocations",
 )
 @click.option(
     "--tag",

--- a/packages/taskdog-ui/src/taskdog/exporters/csv_task_exporter.py
+++ b/packages/taskdog-ui/src/taskdog/exporters/csv_task_exporter.py
@@ -2,53 +2,24 @@
 
 import csv
 import io
-import json
 
 from taskdog.exporters.task_exporter import TaskExporter
 from taskdog_core.application.dto.task_dto import TaskRowDto
-
-# Default fields for CSV export when no specific fields are requested
-DEFAULT_CSV_FIELDS = [
-    "id",
-    "name",
-    "priority",
-    "status",
-    "deadline",
-    "planned_start",
-    "planned_end",
-    "estimated_duration",
-    "actual_start",
-    "actual_end",
-    "created_at",
-]
 
 
 class CsvTaskExporter(TaskExporter):
     """Exports tasks to CSV format."""
 
     def export(self, tasks: list[TaskRowDto]) -> str:
-        """Export tasks to CSV string.
-
-        Args:
-            tasks: List of task DTOs to export
-
-        Returns:
-            CSV string representation of tasks
-        """
-        # Determine fields to export
-        fields = self.field_list or DEFAULT_CSV_FIELDS
-
-        # Create CSV in memory
+        """Export tasks to a CSV string."""
         output = io.StringIO()
-        writer = csv.DictWriter(output, fieldnames=fields, extrasaction="ignore")
+        writer = csv.DictWriter(
+            output, fieldnames=self.field_list, extrasaction="ignore"
+        )
         writer.writeheader()
 
         for task in tasks:
             row = self._filter_fields(task.to_dict())
-            # Convert complex fields (dict) to JSON string for CSV compatibility
-            if row.get("daily_allocations"):
-                row["daily_allocations"] = json.dumps(row["daily_allocations"])
-            # Ensure all fields exist (fill with empty string if missing)
-            writer.writerow({k: row.get(k, "") for k in fields})
+            writer.writerow({k: row.get(k, "") for k in self.field_list})
 
         return output.getvalue()

--- a/packages/taskdog-ui/src/taskdog/exporters/markdown_table_exporter.py
+++ b/packages/taskdog-ui/src/taskdog/exporters/markdown_table_exporter.py
@@ -7,35 +7,13 @@ from taskdog.exporters.task_exporter import TaskExporter
 from taskdog.formatters.date_time_formatter import DateTimeFormatter
 from taskdog_core.application.dto.task_dto import TaskRowDto
 
-# Default fields for Markdown table export when no specific fields are requested
-DEFAULT_MARKDOWN_FIELDS = [
-    "id",
-    "name",
-    "priority",
-    "status",
-    "deadline",
-    "planned_start",
-    "planned_end",
-    "estimated_duration",
-]
-
 
 class MarkdownTableExporter(TaskExporter):
     """Exports tasks to Markdown table format."""
 
     def export(self, tasks: list[TaskRowDto]) -> str:
-        """Export tasks to Markdown table string.
-
-        Args:
-            tasks: List of task DTOs to export
-
-        Returns:
-            Markdown table string representation of tasks
-        """
-        # Determine fields to export
-        fields = self.field_list or DEFAULT_MARKDOWN_FIELDS
-
-        # Create markdown table
+        """Export tasks to a Markdown table string."""
+        fields = self.field_list
         lines = []
 
         # Header row

--- a/packages/taskdog-ui/src/taskdog/exporters/task_exporter.py
+++ b/packages/taskdog-ui/src/taskdog/exporters/task_exporter.py
@@ -5,6 +5,20 @@ from typing import Any
 
 from taskdog_core.application.dto.task_dto import TaskRowDto
 
+DEFAULT_EXPORT_FIELDS: list[str] = [
+    "id",
+    "name",
+    "priority",
+    "status",
+    "deadline",
+    "planned_start",
+    "planned_end",
+    "estimated_duration",
+    "actual_start",
+    "actual_end",
+    "created_at",
+]
+
 
 class TaskExporter(ABC):
     """Abstract base class for exporting tasks to different formats.
@@ -17,9 +31,13 @@ class TaskExporter(ABC):
         """Initialize the exporter.
 
         Args:
-            field_list: List of field names to export. If None, export all fields.
+            field_list: Field names to export. ``None`` falls back to
+                :data:`DEFAULT_EXPORT_FIELDS` so every format renders the same
+                columns by default.
         """
-        self.field_list = field_list
+        self.field_list = (
+            list(field_list) if field_list is not None else list(DEFAULT_EXPORT_FIELDS)
+        )
 
     @abstractmethod
     def export(self, tasks: list[TaskRowDto]) -> str:
@@ -33,15 +51,5 @@ class TaskExporter(ABC):
         """
 
     def _filter_fields(self, task_dict: dict[str, Any]) -> dict[str, Any]:
-        """Filter task dictionary to include only specified fields.
-
-        Args:
-            task_dict: Full task dictionary
-
-        Returns:
-            Filtered dictionary with only specified fields (or all if field_list is None)
-        """
-        if self.field_list is None:
-            return task_dict
-
+        """Filter ``task_dict`` down to ``self.field_list`` (preserving order)."""
         return {field: task_dict.get(field) for field in self.field_list}

--- a/packages/taskdog-ui/tests/presentation/exporters/test_csv_task_exporter.py
+++ b/packages/taskdog-ui/tests/presentation/exporters/test_csv_task_exporter.py
@@ -85,15 +85,15 @@ class TestCsvTaskExporter:
         assert "status" in fieldnames
 
     def test_export_uses_default_fields_when_not_specified(self) -> None:
-        """Test export uses DEFAULT_CSV_FIELDS when no fields specified."""
-        from taskdog.exporters.csv_task_exporter import DEFAULT_CSV_FIELDS
+        """Test export uses shared DEFAULT_EXPORT_FIELDS when no fields specified."""
+        from taskdog.exporters.task_exporter import DEFAULT_EXPORT_FIELDS
 
         exporter = CsvTaskExporter()
 
         result = exporter.export([self.task1])
 
         reader = csv.DictReader(io.StringIO(result))
-        assert list(reader.fieldnames) == list(DEFAULT_CSV_FIELDS)
+        assert list(reader.fieldnames) == list(DEFAULT_EXPORT_FIELDS)
 
     def test_export_uses_specified_fields(self) -> None:
         """Test export uses custom field list when provided."""

--- a/packages/taskdog-ui/tests/presentation/exporters/test_default_fields_consistency.py
+++ b/packages/taskdog-ui/tests/presentation/exporters/test_default_fields_consistency.py
@@ -1,0 +1,75 @@
+"""Regression tests: every exporter renders the same default columns."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from datetime import datetime
+
+import pytest
+
+from taskdog.exporters import (
+    CsvTaskExporter,
+    JsonTaskExporter,
+    MarkdownTableExporter,
+)
+from taskdog.exporters.task_exporter import DEFAULT_EXPORT_FIELDS
+from taskdog_core.application.dto.task_dto import TaskRowDto
+from taskdog_core.domain.entities.task import TaskStatus
+
+
+@pytest.fixture
+def task() -> TaskRowDto:
+    return TaskRowDto(
+        id=1,
+        name="Default Fields Probe",
+        priority=2,
+        status=TaskStatus.PENDING,
+        is_fixed=False,
+        depends_on=[],
+        tags=["never-shown-by-default"],
+        estimated_duration=4.0,
+        actual_duration_hours=None,
+        planned_start=datetime(2025, 1, 1, 9, 0),
+        planned_end=datetime(2025, 1, 1, 13, 0),
+        actual_start=None,
+        actual_end=None,
+        deadline=datetime(2025, 1, 5, 18, 0),
+        created_at=datetime(2024, 12, 31, 10, 0),
+        updated_at=datetime(2024, 12, 31, 10, 0),
+        is_archived=False,
+        is_finished=False,
+    )
+
+
+def _markdown_header_fields(table: str) -> list[str]:
+    header = table.splitlines()[0]
+    return list(header.strip("|").split("|"))
+
+
+def test_json_default_keys_match_shared_fields(task: TaskRowDto) -> None:
+    result = json.loads(JsonTaskExporter().export([task]))
+    assert list(result[0].keys()) == DEFAULT_EXPORT_FIELDS
+
+
+def test_csv_default_columns_match_shared_fields(task: TaskRowDto) -> None:
+    reader = csv.DictReader(io.StringIO(CsvTaskExporter().export([task])))
+    assert list(reader.fieldnames or []) == DEFAULT_EXPORT_FIELDS
+
+
+def test_markdown_default_columns_match_shared_fields(task: TaskRowDto) -> None:
+    table = MarkdownTableExporter().export([task])
+    expected = [field.replace("_", " ").title() for field in DEFAULT_EXPORT_FIELDS]
+    assert _markdown_header_fields(table) == expected
+
+
+def test_default_fields_exclude_internal_flags(task: TaskRowDto) -> None:
+    # Tags/depends_on/is_* are intentionally opt-in; verify none leak by default.
+    json_result = JsonTaskExporter().export([task])
+    csv_result = CsvTaskExporter().export([task])
+    md_result = MarkdownTableExporter().export([task])
+    for hidden in ("tags", "depends_on", "is_fixed", "is_archived", "is_finished"):
+        assert hidden not in json_result
+        assert hidden not in csv_result
+        assert hidden.replace("_", " ").title() not in md_result

--- a/packages/taskdog-ui/tests/presentation/exporters/test_json_task_exporter.py
+++ b/packages/taskdog-ui/tests/presentation/exporters/test_json_task_exporter.py
@@ -123,7 +123,7 @@ class TestJsonTaskExporter:
             is_archived=False,
             is_finished=False,
         )
-        exporter = JsonTaskExporter()
+        exporter = JsonTaskExporter(field_list=["name", "tags"])
 
         result = exporter.export([task_with_unicode])
 
@@ -147,7 +147,9 @@ class TestJsonTaskExporter:
 
     def test_export_handles_numeric_fields(self) -> None:
         """Test export preserves numeric fields correctly."""
-        exporter = JsonTaskExporter()
+        exporter = JsonTaskExporter(
+            field_list=["priority", "estimated_duration", "actual_duration_hours"]
+        )
 
         result = exporter.export([self.task2])
 
@@ -159,7 +161,7 @@ class TestJsonTaskExporter:
 
     def test_export_handles_list_fields(self) -> None:
         """Test export preserves list fields like tags and depends_on."""
-        exporter = JsonTaskExporter()
+        exporter = JsonTaskExporter(field_list=["tags", "depends_on"])
 
         result = exporter.export([self.task2])
 
@@ -222,7 +224,9 @@ class TestJsonTaskExporter:
 
     def test_export_preserves_boolean_fields(self) -> None:
         """Test export preserves boolean fields correctly."""
-        exporter = JsonTaskExporter()
+        exporter = JsonTaskExporter(
+            field_list=["is_fixed", "is_finished", "is_archived"]
+        )
 
         result = exporter.export([self.task2])
 
@@ -234,7 +238,9 @@ class TestJsonTaskExporter:
 
     def test_export_preserves_float_fields(self) -> None:
         """Test export preserves float fields with correct precision."""
-        exporter = JsonTaskExporter()
+        exporter = JsonTaskExporter(
+            field_list=["estimated_duration", "actual_duration_hours"]
+        )
 
         result = exporter.export([self.task2])
 
@@ -267,8 +273,8 @@ class TestJsonTaskExporter:
         ],
     )
     def test_export_with_all_fields(self, field) -> None:
-        """Test export with all available fields."""
-        exporter = JsonTaskExporter()
+        """Test export emits each TaskRowDto field when requested explicitly."""
+        exporter = JsonTaskExporter(field_list=[field])
 
         result = exporter.export([self.task2])
 
@@ -279,7 +285,7 @@ class TestJsonTaskExporter:
 
     def test_export_empty_collections(self) -> None:
         """Test export handles empty collections correctly."""
-        exporter = JsonTaskExporter()
+        exporter = JsonTaskExporter(field_list=["depends_on", "tags"])
 
         result = exporter.export([self.task1])
 


### PR DESCRIPTION
## Summary

- Move a shared `DEFAULT_EXPORT_FIELDS` (11 columns) into the base `TaskExporter` so all three formats render the same default columns
- Remove per-exporter `DEFAULT_CSV_FIELDS` and `DEFAULT_MARKDOWN_FIELDS` constants
- Remove dead `daily_allocations` JSON-serialization code from the CSV exporter (it operated on `TaskDetailDto` data that never reached the exporter)
- Expose `daily_allocations` as an opt-in `--fields` value now that #1030 added it to `TaskRowDto`
- Add `test_default_fields_consistency.py` regression tests verifying all three formats agree on default columns

### Before

| Format | Default columns |
|---|---|
| JSON | all 18 fields (no filtering) |
| CSV | 11 fields |
| Markdown | 8 fields |

### After

All formats default to the same 11 fields: id, name, priority, status, deadline, planned_start, planned_end, estimated_duration, actual_start, actual_end, created_at.

Depends on #1030.