### PR TITLE
refactor(client): replace dict[str, Any] in statistics_converters with TypedDict

### DIFF
--- a/packages/taskdog-client/src/taskdog_client/converters/statistics_converters.py
+++ b/packages/taskdog-client/src/taskdog_client/converters/statistics_converters.py
@@ -18,11 +18,11 @@ from taskdog_core.application.dto.task_dto import TaskSummaryDto
 # -- TypedDicts mirroring the server's JSON response shape ----------------
 
 
-class TaskSummaryPayload(TypedDict, total=False):
+class TaskSummaryPayload(TypedDict):
     id: int
     name: str
-    estimated_duration: float | None
-    actual_duration_hours: float | None
+    estimated_duration: NotRequired[float | None]
+    actual_duration_hours: NotRequired[float | None]
 
 
 class CompletionPayload(TypedDict):
@@ -34,39 +34,39 @@ class CompletionPayload(TypedDict):
     completion_rate: float
 
 
-class TimePayload(TypedDict, total=False):
+class TimePayload(TypedDict):
     total_work_hours: float
-    average_work_hours: float | None
-    median_work_hours: float
-    longest_task: TaskSummaryPayload | None
-    shortest_task: TaskSummaryPayload | None
-    tasks_with_time_tracking: int
+    average_work_hours: NotRequired[float | None]
+    median_work_hours: NotRequired[float]
+    longest_task: NotRequired[TaskSummaryPayload | None]
+    shortest_task: NotRequired[TaskSummaryPayload | None]
+    tasks_with_time_tracking: NotRequired[int]
 
 
-class EstimationPayload(TypedDict, total=False):
+class EstimationPayload(TypedDict):
     total_tasks_with_estimation: int
-    accuracy_rate: float
-    over_estimated_count: int
-    under_estimated_count: int
-    exact_count: int
-    best_estimated_tasks: list[TaskSummaryPayload]
-    worst_estimated_tasks: list[TaskSummaryPayload]
+    accuracy_rate: NotRequired[float]
+    over_estimated_count: NotRequired[int]
+    under_estimated_count: NotRequired[int]
+    exact_count: NotRequired[int]
+    best_estimated_tasks: NotRequired[list[TaskSummaryPayload]]
+    worst_estimated_tasks: NotRequired[list[TaskSummaryPayload]]
 
 
-class DeadlinePayload(TypedDict, total=False):
+class DeadlinePayload(TypedDict):
     total_tasks_with_deadline: int
     met_deadline_count: int
     missed_deadline_count: int
     compliance_rate: float
-    average_delay_days: float
+    average_delay_days: NotRequired[float]
 
 
-class PriorityPayload(TypedDict, total=False):
+class PriorityPayload(TypedDict):
     distribution: dict[str, int]
-    high_priority_count: int
-    medium_priority_count: int
-    low_priority_count: int
-    high_priority_completion_rate: float
+    high_priority_count: NotRequired[int]
+    medium_priority_count: NotRequired[int]
+    low_priority_count: NotRequired[int]
+    high_priority_completion_rate: NotRequired[float]
 
 
 class TrendPayload(TypedDict, total=False):

--- a/packages/taskdog-client/src/taskdog_client/converters/statistics_converters.py
+++ b/packages/taskdog-client/src/taskdog_client/converters/statistics_converters.py
@@ -1,6 +1,8 @@
 """Statistics data converters."""
 
-from typing import Any
+from __future__ import annotations
+
+from typing import NotRequired, TypedDict
 
 from taskdog_core.application.dto.statistics_output import (
     DeadlineComplianceStatistics,
@@ -13,35 +15,80 @@ from taskdog_core.application.dto.statistics_output import (
 )
 from taskdog_core.application.dto.task_dto import TaskSummaryDto
 
-
-def _parse_task_statistics(completion_data: dict[str, Any]) -> TaskStatistics:
-    """Parse task completion statistics from API response.
-
-    Args:
-        completion_data: Completion section from API response
-
-    Returns:
-        TaskStatistics object
-    """
-    return TaskStatistics(
-        total_tasks=completion_data["total"],
-        pending_count=completion_data["pending"],
-        in_progress_count=completion_data["in_progress"],
-        completed_count=completion_data["completed"],
-        canceled_count=completion_data["canceled"],
-        completion_rate=completion_data["completion_rate"],
-    )
+# -- TypedDicts mirroring the server's JSON response shape ----------------
 
 
-def _parse_task_summary(data: dict[str, Any] | None) -> TaskSummaryDto | None:
-    """Parse task summary from API response.
+class TaskSummaryPayload(TypedDict, total=False):
+    id: int
+    name: str
+    estimated_duration: float | None
+    actual_duration_hours: float | None
 
-    Args:
-        data: Task summary data from API response
 
-    Returns:
-        TaskSummaryDto or None
-    """
+class CompletionPayload(TypedDict):
+    total: int
+    completed: int
+    in_progress: int
+    pending: int
+    canceled: int
+    completion_rate: float
+
+
+class TimePayload(TypedDict, total=False):
+    total_work_hours: float
+    average_work_hours: float | None
+    median_work_hours: float
+    longest_task: TaskSummaryPayload | None
+    shortest_task: TaskSummaryPayload | None
+    tasks_with_time_tracking: int
+
+
+class EstimationPayload(TypedDict, total=False):
+    total_tasks_with_estimation: int
+    accuracy_rate: float
+    over_estimated_count: int
+    under_estimated_count: int
+    exact_count: int
+    best_estimated_tasks: list[TaskSummaryPayload]
+    worst_estimated_tasks: list[TaskSummaryPayload]
+
+
+class DeadlinePayload(TypedDict, total=False):
+    total_tasks_with_deadline: int
+    met_deadline_count: int
+    missed_deadline_count: int
+    compliance_rate: float
+    average_delay_days: float
+
+
+class PriorityPayload(TypedDict, total=False):
+    distribution: dict[str, int]
+    high_priority_count: int
+    medium_priority_count: int
+    low_priority_count: int
+    high_priority_completion_rate: float
+
+
+class TrendPayload(TypedDict, total=False):
+    last_7_days_completed: int
+    last_30_days_completed: int
+    weekly_completion_trend: dict[str, int]
+    monthly_completion_trend: dict[str, int]
+
+
+class StatisticsPayload(TypedDict):
+    completion: CompletionPayload
+    time: NotRequired[TimePayload | None]
+    estimation: NotRequired[EstimationPayload | None]
+    deadline: NotRequired[DeadlinePayload | None]
+    priority: PriorityPayload
+    trends: NotRequired[TrendPayload | None]
+
+
+# -- Converters -----------------------------------------------------------
+
+
+def _parse_task_summary(data: TaskSummaryPayload | None) -> TaskSummaryDto | None:
     if data is None:
         return None
     return TaskSummaryDto(
@@ -52,164 +99,111 @@ def _parse_task_summary(data: dict[str, Any] | None) -> TaskSummaryDto | None:
     )
 
 
-def _parse_task_summary_list(data: list[dict[str, Any]] | None) -> list[TaskSummaryDto]:
-    """Parse list of task summaries from API response.
-
-    Args:
-        data: List of task summary data from API response
-
-    Returns:
-        List of TaskSummaryDto
-    """
+def _parse_task_summary_list(
+    data: list[TaskSummaryPayload] | None,
+) -> list[TaskSummaryDto]:
     if not data:
         return []
-    # Each element d is a dict (never None), so _parse_task_summary always returns TaskSummaryDto
-    return [_parse_task_summary(d) for d in data]  # type: ignore[misc]
+    return [
+        TaskSummaryDto(
+            id=d["id"],
+            name=d["name"],
+            estimated_duration=d.get("estimated_duration"),
+            actual_duration_hours=d.get("actual_duration_hours"),
+        )
+        for d in data
+    ]
 
 
-def _parse_time_statistics(time_data: dict[str, Any]) -> TimeStatistics:
-    """Parse time tracking statistics from API response.
+def _parse_task_statistics(data: CompletionPayload) -> TaskStatistics:
+    return TaskStatistics(
+        total_tasks=data["total"],
+        pending_count=data["pending"],
+        in_progress_count=data["in_progress"],
+        completed_count=data["completed"],
+        canceled_count=data["canceled"],
+        completion_rate=data["completion_rate"],
+    )
 
-    Args:
-        time_data: Time section from API response
 
-    Returns:
-        TimeStatistics object
-    """
+def _parse_time_statistics(data: TimePayload) -> TimeStatistics:
     return TimeStatistics(
-        total_work_hours=time_data["total_work_hours"],
-        average_work_hours=time_data.get("average_work_hours") or 0.0,
-        median_work_hours=time_data.get("median_work_hours", 0.0),
-        longest_task=_parse_task_summary(time_data.get("longest_task")),
-        shortest_task=_parse_task_summary(time_data.get("shortest_task")),
-        tasks_with_time_tracking=time_data.get("tasks_with_time_tracking", 0),
+        total_work_hours=data["total_work_hours"],
+        average_work_hours=data.get("average_work_hours") or 0.0,
+        median_work_hours=data.get("median_work_hours", 0.0),
+        longest_task=_parse_task_summary(data.get("longest_task")),
+        shortest_task=_parse_task_summary(data.get("shortest_task")),
+        tasks_with_time_tracking=data.get("tasks_with_time_tracking", 0),
     )
 
 
 def _parse_estimation_statistics(
-    estimation_data: dict[str, Any],
+    data: EstimationPayload,
 ) -> EstimationAccuracyStatistics:
-    """Parse estimation accuracy statistics from API response.
-
-    Args:
-        estimation_data: Estimation section from API response
-
-    Returns:
-        EstimationAccuracyStatistics object
-    """
     return EstimationAccuracyStatistics(
-        total_tasks_with_estimation=estimation_data["total_tasks_with_estimation"],
-        accuracy_rate=estimation_data.get("accuracy_rate", 0.0),
-        over_estimated_count=estimation_data.get("over_estimated_count", 0),
-        under_estimated_count=estimation_data.get("under_estimated_count", 0),
-        exact_count=estimation_data.get("exact_count", 0),
-        best_estimated_tasks=_parse_task_summary_list(
-            estimation_data.get("best_estimated_tasks")
-        ),
+        total_tasks_with_estimation=data["total_tasks_with_estimation"],
+        accuracy_rate=data.get("accuracy_rate", 0.0),
+        over_estimated_count=data.get("over_estimated_count", 0),
+        under_estimated_count=data.get("under_estimated_count", 0),
+        exact_count=data.get("exact_count", 0),
+        best_estimated_tasks=_parse_task_summary_list(data.get("best_estimated_tasks")),
         worst_estimated_tasks=_parse_task_summary_list(
-            estimation_data.get("worst_estimated_tasks")
+            data.get("worst_estimated_tasks")
         ),
     )
 
 
-def _parse_deadline_statistics(
-    deadline_data: dict[str, Any],
-) -> DeadlineComplianceStatistics:
-    """Parse deadline compliance statistics from API response.
-
-    Args:
-        deadline_data: Deadline section from API response
-
-    Returns:
-        DeadlineComplianceStatistics object
-    """
+def _parse_deadline_statistics(data: DeadlinePayload) -> DeadlineComplianceStatistics:
     return DeadlineComplianceStatistics(
-        total_tasks_with_deadline=deadline_data["total_tasks_with_deadline"],
-        met_deadline_count=deadline_data["met_deadline_count"],
-        missed_deadline_count=deadline_data["missed_deadline_count"],
-        compliance_rate=deadline_data["compliance_rate"],
-        average_delay_days=deadline_data.get("average_delay_days", 0.0),
+        total_tasks_with_deadline=data["total_tasks_with_deadline"],
+        met_deadline_count=data["met_deadline_count"],
+        missed_deadline_count=data["missed_deadline_count"],
+        compliance_rate=data["compliance_rate"],
+        average_delay_days=data.get("average_delay_days", 0.0),
     )
 
 
 def _parse_priority_statistics(
-    priority_data: dict[str, Any],
+    data: PriorityPayload,
 ) -> PriorityDistributionStatistics:
-    """Parse priority distribution statistics from API response.
-
-    Args:
-        priority_data: Priority section from API response
-
-    Returns:
-        PriorityDistributionStatistics object
-    """
-    distribution = priority_data["distribution"]
+    distribution = data["distribution"]
     return PriorityDistributionStatistics(
-        high_priority_count=priority_data.get("high_priority_count", 0),
-        medium_priority_count=priority_data.get("medium_priority_count", 0),
-        low_priority_count=priority_data.get("low_priority_count", 0),
-        high_priority_completion_rate=priority_data.get(
-            "high_priority_completion_rate", 0.0
-        ),
+        high_priority_count=data.get("high_priority_count", 0),
+        medium_priority_count=data.get("medium_priority_count", 0),
+        low_priority_count=data.get("low_priority_count", 0),
+        high_priority_completion_rate=data.get("high_priority_completion_rate", 0.0),
         priority_completion_map={int(k): v for k, v in distribution.items()},
     )
 
 
-def _parse_trend_statistics(trends_data: dict[str, Any]) -> TrendStatistics:
-    """Parse trend statistics from API response.
-
-    Args:
-        trends_data: Trends section from API response
-
-    Returns:
-        TrendStatistics object
-    """
+def _parse_trend_statistics(data: TrendPayload) -> TrendStatistics:
     return TrendStatistics(
-        last_7_days_completed=trends_data.get("last_7_days_completed", 0),
-        last_30_days_completed=trends_data.get("last_30_days_completed", 0),
-        weekly_completion_trend=trends_data.get("weekly_completion_trend", {}),
-        monthly_completion_trend=trends_data.get("monthly_completion_trend", {}),
+        last_7_days_completed=data.get("last_7_days_completed", 0),
+        last_30_days_completed=data.get("last_30_days_completed", 0),
+        weekly_completion_trend=data.get("weekly_completion_trend", {}),
+        monthly_completion_trend=data.get("monthly_completion_trend", {}),
     )
 
 
-def convert_to_statistics_output(data: dict[str, Any]) -> StatisticsOutput:
-    """Convert API response to StatisticsOutput.
-
-    Args:
-        data: API response data with format:
-            {
-                "completion": {...},
-                "time": {...} | None,
-                "estimation": {...} | None,
-                "deadline": {...} | None,
-                "priority": {...},
-                "trends": {...} | None
-            }
-
-    Returns:
-        StatisticsOutput with converted data
-    """
-    # Parse each statistics section using helper functions
+def convert_to_statistics_output(data: StatisticsPayload) -> StatisticsOutput:
+    """Convert API response to StatisticsOutput."""
     task_stats = _parse_task_statistics(data["completion"])
-    time_stats = _parse_time_statistics(data["time"]) if data.get("time") else None
-    estimation_stats = (
-        _parse_estimation_statistics(data["estimation"])
-        if data.get("estimation")
-        else None
-    )
-    deadline_stats = (
-        _parse_deadline_statistics(data["deadline"]) if data.get("deadline") else None
-    )
     priority_stats = _parse_priority_statistics(data["priority"])
-    trend_stats = (
-        _parse_trend_statistics(data["trends"]) if data.get("trends") else None
-    )
+
+    raw_time = data.get("time")
+    raw_estimation = data.get("estimation")
+    raw_deadline = data.get("deadline")
+    raw_trends = data.get("trends")
 
     return StatisticsOutput(
         task_stats=task_stats,
-        time_stats=time_stats,
-        estimation_stats=estimation_stats,
-        deadline_stats=deadline_stats,
+        time_stats=_parse_time_statistics(raw_time) if raw_time else None,
+        estimation_stats=(
+            _parse_estimation_statistics(raw_estimation) if raw_estimation else None
+        ),
+        deadline_stats=(
+            _parse_deadline_statistics(raw_deadline) if raw_deadline else None
+        ),
         priority_stats=priority_stats,
-        trend_stats=trend_stats,
+        trend_stats=_parse_trend_statistics(raw_trends) if raw_trends else None,
     )


### PR DESCRIPTION
## Summary

- Add TypedDict definitions (`CompletionPayload`, `TimePayload`, `EstimationPayload`, `DeadlinePayload`, `PriorityPayload`, `TrendPayload`, `StatisticsPayload`, `TaskSummaryPayload`) mirroring the server's statistics JSON response shape
- Annotate every converter helper with the appropriate TypedDict instead of `dict[str, Any]`
- Remove the `# type: ignore[misc]` marker from `_parse_task_summary_list`
- Inline `_parse_task_summary` calls in `_parse_task_summary_list` to avoid the `Optional` return type mismatch

Closes #867.