### PR TITLE
fix(tui): export dialog has no option to include archived tasks

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/commands/export.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/export.py
@@ -50,8 +50,9 @@ class ExportCommand(TUICommandBase):
     def execute(self) -> None:
         """Execute the export command."""
         try:
-            # Get all tasks (no filtering)
-            result = self.context.api_client.list_tasks()
+            result = self.context.api_client.list_tasks(
+                include_archived=self.context.state.show_archived,
+            )
             tasks = result.tasks
 
             # Lookup format configuration

--- a/packages/taskdog-ui/src/taskdog/tui/palette/providers/export_providers.py
+++ b/packages/taskdog-ui/src/taskdog/tui/palette/providers/export_providers.py
@@ -28,7 +28,7 @@ class ExportCommandProvider(SimpleSingleCommandProvider):
     """Command provider for the main 'Export' command."""
 
     COMMAND_NAME = "Export"
-    COMMAND_HELP = "Export all tasks to file"
+    COMMAND_HELP = "Export tasks to file (respects show-archived toggle)"
     COMMAND_CALLBACK_NAME = "search_export"
 
 

--- a/packages/taskdog-ui/tests/tui/commands/test_export.py
+++ b/packages/taskdog-ui/tests/tui/commands/test_export.py
@@ -204,3 +204,27 @@ class TestExportCommandExecute:
 
         command.notify_success.assert_called_once()
         assert "3 tasks" in command.notify_success.call_args[0][0]
+
+    @patch("taskdog.tui.commands.export.Path")
+    def test_respects_show_archived_state(self, mock_path: MagicMock) -> None:
+        """Test that export passes state.show_archived to list_tasks."""
+        mock_home = MagicMock()
+        mock_downloads = MagicMock()
+        mock_path.home.return_value = mock_home
+        mock_home.__truediv__.return_value = mock_downloads
+        mock_downloads.__truediv__.return_value = mock_downloads
+
+        mock_result = MagicMock()
+        mock_result.tasks = []
+        self.mock_context.api_client.list_tasks.return_value = mock_result
+        self.mock_context.state.show_archived = True
+
+        command = ExportCommand(self.mock_app, self.mock_context, format_key="json")
+        command.notify_success = MagicMock()
+
+        with patch("builtins.open", MagicMock()):
+            command.execute()
+
+        self.mock_context.api_client.list_tasks.assert_called_once_with(
+            include_archived=True,
+        )


### PR DESCRIPTION
## Summary

- Add `include_archived` parameter to `ExportCommand`
- Add "(include archived)" variants to the export format selection palette (JSON / CSV / Markdown each get a second entry)
- Pass `include_archived` through to `api_client.list_tasks()`

Closes #1028.