### PR TITLE
refactor(tui): align AuditLogTable navigation with TaskTable

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/widgets/audit_log_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/audit_log_table.py
@@ -29,62 +29,56 @@ from taskdog.constants.audit_log import (
     JUSTIFY_AUDIT_TIMESTAMP,
 )
 from taskdog.constants.common import HEADER_ID, HEADER_NAME
+from taskdog.constants.task_table import PAGE_SCROLL_SIZE
 from taskdog.tui.widgets.audit_log_entry_builder import (
     build_changes_text,
     build_status_text,
 )
-from taskdog.tui.widgets.base_widget import TUIWidget
 from taskdog.tui.widgets.vi_navigation_mixin import ViNavigationMixin
 from taskdog.view_models.audit_log_view_model import AuditLogRowViewModel
 
 
-class AuditLogTable(DataTable, TUIWidget, ViNavigationMixin):  # type: ignore[type-arg]
+class AuditLogTable(DataTable, ViNavigationMixin):  # type: ignore[type-arg]
     """A DataTable widget for displaying audit log entries.
 
     Features:
     - Full-width columns: Timestamp, ID, Name, Operation, Changes, Client, Status
-    - Vi-style keyboard navigation (j/k/g/G/Ctrl+d/Ctrl+u)
+    - Vi-style keyboard navigation aligned with TaskTable (j/k/g/G/Ctrl+d/Ctrl+u)
+    - Row cursor for navigation
     - Error rows highlighted in red
     """
 
     BINDINGS: ClassVar = [
-        Binding("j", "scroll_down", "Down", show=False),
-        Binding("k", "scroll_up", "Up", show=False),
-        Binding("g", "goto_top", "Top", show=False),
-        Binding("G", "goto_bottom", "Bottom", show=False),
-        Binding("ctrl+d", "page_down", "Page Down", show=False),
-        Binding("ctrl+u", "page_up", "Page Up", show=False),
+        Binding("j", "cursor_down", "Down", show=False),
+        Binding("k", "cursor_up", "Up", show=False),
+        Binding("g", "vi_home", "Top", show=False),
+        Binding("G", "vi_end", "Bottom", show=False),
+        *ViNavigationMixin.VI_PAGE_BINDINGS,
     ]
 
     def __init__(self, **kwargs: Any) -> None:
         """Initialize the audit log table."""
         super().__init__(**kwargs)
-        self.cursor_type = "none"
+        self.cursor_type = "row"
         self.zebra_stripes = True
 
-    def action_scroll_down(self) -> None:
-        """Scroll down one line."""
-        self.scroll_down(animate=False)
+    def _safe_move_cursor(self, row: int) -> None:
+        if self.row_count > 0:
+            self.move_cursor(row=row)
 
-    def action_scroll_up(self) -> None:
-        """Scroll up one line."""
-        self.scroll_up(animate=False)
+    def action_vi_home(self) -> None:
+        self._safe_move_cursor(row=0)
 
-    def action_goto_top(self) -> None:
-        """Scroll to the top of the table."""
-        self.scroll_home(animate=False)
+    def action_vi_end(self) -> None:
+        self._safe_move_cursor(row=self.row_count - 1)
 
-    def action_goto_bottom(self) -> None:
-        """Scroll to the bottom of the table."""
-        self.scroll_end(animate=False)
+    def action_vi_page_down(self) -> None:
+        new_row = min(self.cursor_row + PAGE_SCROLL_SIZE, self.row_count - 1)
+        self._safe_move_cursor(row=new_row)
 
-    def action_page_down(self) -> None:
-        """Scroll down by half a page without animation."""
-        self.scroll_page_down(animate=False)
-
-    def action_page_up(self) -> None:
-        """Scroll up by half a page without animation."""
-        self.scroll_page_up(animate=False)
+    def action_vi_page_up(self) -> None:
+        new_row = max(self.cursor_row - PAGE_SCROLL_SIZE, 0)
+        self._safe_move_cursor(row=new_row)
 
     def on_mount(self) -> None:
         """Set up table columns."""
@@ -137,10 +131,9 @@ class AuditLogTable(DataTable, TUIWidget, ViNavigationMixin):  # type: ignore[ty
                     str(row.resource_id) if row.resource_id else "", style=style
                 )
 
-                # Resource name (truncated)
                 if row.resource_name:
                     name = (
-                        row.resource_name[:AUDIT_TUI_NAME_WIDTH] + "\u2026"
+                        row.resource_name[:AUDIT_TUI_NAME_WIDTH] + "…"
                         if len(row.resource_name) > AUDIT_TUI_NAME_WIDTH
                         else row.resource_name
                     )

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/audit_log_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/audit_log_table.py
@@ -70,15 +70,18 @@ class AuditLogTable(DataTable, ViNavigationMixin):  # type: ignore[type-arg]
         self._safe_move_cursor(row=0)
 
     def action_vi_end(self) -> None:
-        self._safe_move_cursor(row=self.row_count - 1)
+        if self.row_count > 0:
+            self._safe_move_cursor(row=self.row_count - 1)
 
     def action_vi_page_down(self) -> None:
-        new_row = min(self.cursor_row + PAGE_SCROLL_SIZE, self.row_count - 1)
-        self._safe_move_cursor(row=new_row)
+        if self.row_count > 0:
+            new_row = min(self.cursor_row + PAGE_SCROLL_SIZE, self.row_count - 1)
+            self._safe_move_cursor(row=new_row)
 
     def action_vi_page_up(self) -> None:
-        new_row = max(self.cursor_row - PAGE_SCROLL_SIZE, 0)
-        self._safe_move_cursor(row=new_row)
+        if self.row_count > 0:
+            new_row = max(self.cursor_row - PAGE_SCROLL_SIZE, 0)
+            self._safe_move_cursor(row=new_row)
 
     def on_mount(self) -> None:
         """Set up table columns."""

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/task_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/task_table.py
@@ -320,17 +320,20 @@ class TaskTable(DataTable, TUIWidget, ViNavigationMixin):  # type: ignore[type-a
 
     def action_vi_end(self) -> None:
         """Move cursor to bottom (G key)."""
-        self._safe_move_cursor(row=self.row_count - 1)
+        if self.row_count > 0:
+            self._safe_move_cursor(row=self.row_count - 1)
 
     def action_vi_page_down(self) -> None:
         """Move cursor down by half page (Ctrl+d)."""
-        new_row = min(self.cursor_row + PAGE_SCROLL_SIZE, self.row_count - 1)
-        self._safe_move_cursor(row=new_row)
+        if self.row_count > 0:
+            new_row = min(self.cursor_row + PAGE_SCROLL_SIZE, self.row_count - 1)
+            self._safe_move_cursor(row=new_row)
 
     def action_vi_page_up(self) -> None:
         """Move cursor up by half page (Ctrl+u)."""
-        new_row = max(self.cursor_row - PAGE_SCROLL_SIZE, 0)
-        self._safe_move_cursor(row=new_row)
+        if self.row_count > 0:
+            new_row = max(self.cursor_row - PAGE_SCROLL_SIZE, 0)
+            self._safe_move_cursor(row=new_row)
 
     def action_vi_scroll_left(self) -> None:
         """Scroll table left (h key)."""

--- a/packages/taskdog-ui/tests/tui/widgets/test_audit_log_table.py
+++ b/packages/taskdog-ui/tests/tui/widgets/test_audit_log_table.py
@@ -1,31 +1,104 @@
-"""Tests for AuditLogTable keyboard navigation behavior."""
+"""Tests for AuditLogTable navigation behavior."""
 
+from unittest.mock import PropertyMock, patch
+
+from taskdog.constants.task_table import PAGE_SCROLL_SIZE
 from taskdog.tui.widgets.audit_log_table import AuditLogTable
 
 
-class TestAuditLogTablePageScrollActions:
-    """Ctrl+d/Ctrl+u should use discrete page scrolling like other audit log moves."""
-
-    def test_page_down_disables_animation(self, monkeypatch) -> None:
-        calls: list[bool] = []
+class TestAuditLogTableCursorType:
+    def test_cursor_type_is_row(self) -> None:
         table = AuditLogTable()
+        assert table.cursor_type == "row"
 
-        monkeypatch.setattr(
-            table, "scroll_page_down", lambda *, animate: calls.append(animate)
-        )
 
-        table.action_page_down()
-
-        assert calls == [False]
-
-    def test_page_up_disables_animation(self, monkeypatch) -> None:
-        calls: list[bool] = []
+class TestAuditLogTableNavActions:
+    def test_vi_home_moves_to_first_row(self) -> None:
         table = AuditLogTable()
+        calls: list[int] = []
+        table.move_cursor = lambda row: calls.append(row)  # type: ignore[assignment]
+        with patch.object(
+            type(table), "row_count", new_callable=PropertyMock, return_value=10
+        ):
+            table.action_vi_home()
+        assert calls == [0]
 
-        monkeypatch.setattr(
-            table, "scroll_page_up", lambda *, animate: calls.append(animate)
-        )
+    def test_vi_end_moves_to_last_row(self) -> None:
+        table = AuditLogTable()
+        calls: list[int] = []
+        table.move_cursor = lambda row: calls.append(row)  # type: ignore[assignment]
+        with patch.object(
+            type(table), "row_count", new_callable=PropertyMock, return_value=10
+        ):
+            table.action_vi_end()
+        assert calls == [9]
 
-        table.action_page_up()
+    def test_vi_page_down_moves_by_page_scroll_size(self) -> None:
+        table = AuditLogTable()
+        calls: list[int] = []
+        table.move_cursor = lambda row: calls.append(row)  # type: ignore[assignment]
+        with (
+            patch.object(
+                type(table), "row_count", new_callable=PropertyMock, return_value=100
+            ),
+            patch.object(
+                type(table), "cursor_row", new_callable=PropertyMock, return_value=5
+            ),
+        ):
+            table.action_vi_page_down()
+        assert calls == [5 + PAGE_SCROLL_SIZE]
 
-        assert calls == [False]
+    def test_vi_page_up_moves_by_page_scroll_size(self) -> None:
+        table = AuditLogTable()
+        calls: list[int] = []
+        table.move_cursor = lambda row: calls.append(row)  # type: ignore[assignment]
+        with (
+            patch.object(
+                type(table), "row_count", new_callable=PropertyMock, return_value=100
+            ),
+            patch.object(
+                type(table), "cursor_row", new_callable=PropertyMock, return_value=20
+            ),
+        ):
+            table.action_vi_page_up()
+        assert calls == [20 - PAGE_SCROLL_SIZE]
+
+    def test_vi_page_down_clamps_to_last_row(self) -> None:
+        table = AuditLogTable()
+        calls: list[int] = []
+        table.move_cursor = lambda row: calls.append(row)  # type: ignore[assignment]
+        with (
+            patch.object(
+                type(table), "row_count", new_callable=PropertyMock, return_value=5
+            ),
+            patch.object(
+                type(table), "cursor_row", new_callable=PropertyMock, return_value=3
+            ),
+        ):
+            table.action_vi_page_down()
+        assert calls == [4]
+
+    def test_vi_page_up_clamps_to_zero(self) -> None:
+        table = AuditLogTable()
+        calls: list[int] = []
+        table.move_cursor = lambda row: calls.append(row)  # type: ignore[assignment]
+        with (
+            patch.object(
+                type(table), "row_count", new_callable=PropertyMock, return_value=100
+            ),
+            patch.object(
+                type(table), "cursor_row", new_callable=PropertyMock, return_value=2
+            ),
+        ):
+            table.action_vi_page_up()
+        assert calls == [0]
+
+    def test_safe_move_cursor_noop_on_empty_table(self) -> None:
+        table = AuditLogTable()
+        calls: list[int] = []
+        table.move_cursor = lambda row: calls.append(row)  # type: ignore[assignment]
+        with patch.object(
+            type(table), "row_count", new_callable=PropertyMock, return_value=0
+        ):
+            table._safe_move_cursor(0)
+        assert calls == []


### PR DESCRIPTION
## Summary

- Drop unused `TUIWidget` base class from `AuditLogTable`
- Switch `cursor_type` from `"none"` (raw scroll) to `"row"` (cursor-based, matching `TaskTable`)
- Replace hand-written bindings with `ViNavigationMixin.VI_PAGE_BINDINGS`
- Navigation actions (g/G/Ctrl+d/Ctrl+u) now move the row cursor instead of raw-scrolling

### Before vs After

| | Before | After |
|---|---|---|
| cursor | `none` (scroll only) | `row` (highlight + move) |
| j/k | scroll one line | move row cursor (DataTable built-in) |
| Ctrl+d/u | full-page scroll | half-page cursor jump (`PAGE_SCROLL_SIZE`) |
| base classes | `DataTable, TUIWidget, ViNavigationMixin` | `DataTable, ViNavigationMixin` |

**Note**: `animate=False` was dropped — the cursor-based approach follows the cursor naturally without needing to suppress animation. If scroll stuttering recurs, this is the commit to bisect.

Closes #949.

See also #1034 for column order/header unification between CLI and TUI.