### PR TITLE
fix(ui): unify audit log column order and headers between CLI and TUI

### DIFF
--- a/packages/taskdog-ui/src/taskdog/cli/commands/audit/list.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/audit/list.py
@@ -22,12 +22,11 @@ from taskdog.constants.audit_log import (
     HEADER_AUDIT_CHANGES,
     HEADER_AUDIT_CLIENT,
     HEADER_AUDIT_OPERATION,
-    HEADER_AUDIT_RESOURCE,
     HEADER_AUDIT_STATUS,
     HEADER_AUDIT_TIMESTAMP,
     JUSTIFY_AUDIT_CHANGES,
 )
-from taskdog.constants.common import HEADER_ID, TABLE_HEADER_STYLE
+from taskdog.constants.common import HEADER_ID, HEADER_NAME, TABLE_HEADER_STYLE
 from taskdog.constants.formatting import format_table_title
 from taskdog.formatters.audit_log_formatter import compact_changes, truncate_error
 from taskdog.presenters.audit_log_presenter import AuditLogPresenter
@@ -185,9 +184,9 @@ def list_command(
         show_header=True,
         header_style=TABLE_HEADER_STYLE,
     )
-    table.add_column(HEADER_ID, style=COLUMN_AUDIT_ID_STYLE, width=AUDIT_ID_WIDTH)
     table.add_column(HEADER_AUDIT_TIMESTAMP, width=AUDIT_TIMESTAMP_WIDTH)
-    table.add_column(HEADER_AUDIT_RESOURCE)
+    table.add_column(HEADER_ID, style=COLUMN_AUDIT_ID_STYLE, width=AUDIT_ID_WIDTH)
+    table.add_column(HEADER_NAME)
     table.add_column(HEADER_AUDIT_OPERATION, width=AUDIT_OPERATION_WIDTH)
     table.add_column(
         HEADER_AUDIT_CHANGES,
@@ -205,8 +204,8 @@ def list_command(
         )
         status_label = "OK" if row.success else "FAILED"
         table.add_row(
-            str(row.id),
             row.timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+            str(row.id),
             _format_resource(row),
             row.operation,
             _format_changes(row),

--- a/packages/taskdog-ui/src/taskdog/constants/audit_log.py
+++ b/packages/taskdog-ui/src/taskdog/constants/audit_log.py
@@ -6,10 +6,8 @@ from taskdog.constants.common import JustifyValue
 HEADER_AUDIT_TIMESTAMP = "Timestamp"
 HEADER_AUDIT_CLIENT = "Client"
 HEADER_AUDIT_OPERATION = "Operation"
-HEADER_AUDIT_RESOURCE = "Resource"
 HEADER_AUDIT_STATUS = "Status"
 HEADER_AUDIT_CHANGES = "Changes"
-HEADER_AUDIT_STATUS_SHORT = "St"
 
 # Audit Log Table Dimensions (CLI)
 AUDIT_ID_WIDTH = 6

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/audit_log_entry_builder.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/audit_log_entry_builder.py
@@ -14,7 +14,7 @@ from taskdog.constants.audit_log import (
     HEADER_AUDIT_CHANGES,
     HEADER_AUDIT_CLIENT,
     HEADER_AUDIT_OPERATION,
-    HEADER_AUDIT_STATUS_SHORT,
+    HEADER_AUDIT_STATUS,
     HEADER_AUDIT_TIMESTAMP,
     JUSTIFY_AUDIT_CHANGES,
     JUSTIFY_AUDIT_CLIENT,
@@ -97,7 +97,7 @@ def create_audit_log_table(
         Text(HEADER_AUDIT_CLIENT, justify=JUSTIFY_AUDIT_CLIENT), key="client"
     )
     table.add_column(
-        Text(HEADER_AUDIT_STATUS_SHORT, justify=JUSTIFY_AUDIT_STATUS), key="status"
+        Text(HEADER_AUDIT_STATUS, justify=JUSTIFY_AUDIT_STATUS), key="status"
     )
 
     for row in rows:

--- a/packages/taskdog-ui/src/taskdog/tui/widgets/audit_log_table.py
+++ b/packages/taskdog-ui/src/taskdog/tui/widgets/audit_log_table.py
@@ -18,7 +18,7 @@ from taskdog.constants.audit_log import (
     HEADER_AUDIT_CHANGES,
     HEADER_AUDIT_CLIENT,
     HEADER_AUDIT_OPERATION,
-    HEADER_AUDIT_STATUS_SHORT,
+    HEADER_AUDIT_STATUS,
     HEADER_AUDIT_TIMESTAMP,
     JUSTIFY_AUDIT_CHANGES,
     JUSTIFY_AUDIT_CLIENT,
@@ -112,7 +112,7 @@ class AuditLogTable(DataTable, ViNavigationMixin):  # type: ignore[type-arg]
             Text(HEADER_AUDIT_CLIENT, justify=JUSTIFY_AUDIT_CLIENT), key="client"
         )
         self.add_column(
-            Text(HEADER_AUDIT_STATUS_SHORT, justify=JUSTIFY_AUDIT_STATUS),
+            Text(HEADER_AUDIT_STATUS, justify=JUSTIFY_AUDIT_STATUS),
             key="status",
             width=AUDIT_TUI_STATUS_WIDTH,
         )


### PR DESCRIPTION
## Summary

- Reorder CLI `audit list` columns to match TUI: Timestamp first, then ID (was ID first)
- Replace CLI-only `HEADER_AUDIT_RESOURCE` ("Resource") with shared `HEADER_NAME` ("Name")
- Promote TUI's `HEADER_AUDIT_STATUS_SHORT` ("St") to full `HEADER_AUDIT_STATUS` ("Status")
- Remove unused constants: `HEADER_AUDIT_RESOURCE`, `HEADER_AUDIT_STATUS_SHORT`

### Before

| CLI | TUI |
|---|---|
| ID, Timestamp, Resource, Operation, Changes, Client, Status | Timestamp, ID, Name, Operation, Changes, Client, St |

### After

Both: Timestamp, ID, Name, Operation, Changes, Client, Status

Closes #1034.