### PR TITLE
fix: make uninstall uses wrong package name for taskdog-ui

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ else ifeq ($(PLATFORM),macos)
 	-rm -f ~/Library/LaunchAgents/com.github.kohei-wada.taskdog-server.plist
 endif
 	@echo "Uninstalling taskdog commands..."
-	-uv tool uninstall taskdog 2>/dev/null || true
+	-uv tool uninstall taskdog-ui 2>/dev/null || true
 	-uv tool uninstall taskdog-server 2>/dev/null || true
 	-uv tool uninstall taskdog-mcp 2>/dev/null || true
 	@echo "✓ Uninstalled successfully!"


### PR DESCRIPTION
## Summary

`make install` registers the CLI via `uv tool install .` from `packages/taskdog-ui/`, which registers the package as `taskdog-ui` (its pyproject.toml name). But `make uninstall` was calling `uv tool uninstall taskdog`, which silently failed — leaving `~/.local/bin/taskdog` behind.

Fix: `taskdog` → `taskdog-ui`.