### PR TITLE
feat(ui): add Activity tab with graphs to TUI statistics dialog

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     rev: v2.1.0
     hooks:
       - id: mypy
-        additional_dependencies: [click>=8.3.0, rich>=14.2.0, fastapi>=0.115.0, pydantic>=2.10.0, httpx>=0.27.0, "uvicorn[standard]>=0.32.0"]
+        additional_dependencies: [click>=8.3.0, rich>=14.2.0, fastapi>=0.115.0, pydantic>=2.10.0, httpx>=0.27.0, "uvicorn[standard]>=0.32.0", textual-plotext>=1.0.0]
         args: [--config-file=pyproject.toml, packages/taskdog-core/src/, packages/taskdog-client/src/, packages/taskdog-server/src/, packages/taskdog-ui/src/, packages/taskdog-mcp/src/]
         pass_filenames: false
 

--- a/packages/taskdog-client/src/taskdog_client/converters/statistics_converters.py
+++ b/packages/taskdog-client/src/taskdog_client/converters/statistics_converters.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import NotRequired, TypedDict
 
 from taskdog_core.application.dto.statistics_output import (
+    ActivityPatternStatistics,
     DeadlineComplianceStatistics,
     EstimationAccuracyStatistics,
     PriorityDistributionStatistics,
@@ -51,6 +52,7 @@ class EstimationPayload(TypedDict):
     exact_count: NotRequired[int]
     best_estimated_tasks: NotRequired[list[TaskSummaryPayload]]
     worst_estimated_tasks: NotRequired[list[TaskSummaryPayload]]
+    estimation_pairs: NotRequired[list[list[float]]]
 
 
 class DeadlinePayload(TypedDict):
@@ -76,6 +78,13 @@ class TrendPayload(TypedDict, total=False):
     monthly_completion_trend: dict[str, int]
 
 
+class ActivityPayload(TypedDict):
+    hourly_completions: dict[str, int]
+    daily_completions: dict[str, int]
+    heatmap: dict[str, dict[str, int]]
+    total_completed_with_time: int
+
+
 class StatisticsPayload(TypedDict):
     completion: CompletionPayload
     time: NotRequired[TimePayload | None]
@@ -83,6 +92,7 @@ class StatisticsPayload(TypedDict):
     deadline: NotRequired[DeadlinePayload | None]
     priority: PriorityPayload
     trends: NotRequired[TrendPayload | None]
+    activity: NotRequired[ActivityPayload | None]
 
 
 # -- Converters -----------------------------------------------------------
@@ -150,6 +160,7 @@ def _parse_estimation_statistics(
         worst_estimated_tasks=_parse_task_summary_list(
             data.get("worst_estimated_tasks")
         ),
+        estimation_pairs=[(p[0], p[1]) for p in data.get("estimation_pairs", [])],
     )
 
 
@@ -185,6 +196,18 @@ def _parse_trend_statistics(data: TrendPayload) -> TrendStatistics:
     )
 
 
+def _parse_activity_statistics(data: ActivityPayload) -> ActivityPatternStatistics:
+    return ActivityPatternStatistics(
+        hourly_completions={int(k): v for k, v in data["hourly_completions"].items()},
+        daily_completions={int(k): v for k, v in data["daily_completions"].items()},
+        heatmap={
+            int(d): {int(h): c for h, c in hours.items()}
+            for d, hours in data["heatmap"].items()
+        },
+        total_completed_with_time=data["total_completed_with_time"],
+    )
+
+
 def convert_to_statistics_output(data: StatisticsPayload) -> StatisticsOutput:
     """Convert API response to StatisticsOutput."""
     task_stats = _parse_task_statistics(data["completion"])
@@ -194,6 +217,7 @@ def convert_to_statistics_output(data: StatisticsPayload) -> StatisticsOutput:
     raw_estimation = data.get("estimation")
     raw_deadline = data.get("deadline")
     raw_trends = data.get("trends")
+    raw_activity = data.get("activity")
 
     return StatisticsOutput(
         task_stats=task_stats,
@@ -206,4 +230,7 @@ def convert_to_statistics_output(data: StatisticsPayload) -> StatisticsOutput:
         ),
         priority_stats=priority_stats,
         trend_stats=_parse_trend_statistics(raw_trends) if raw_trends else None,
+        activity_stats=(
+            _parse_activity_statistics(raw_activity) if raw_activity else None
+        ),
     )

--- a/packages/taskdog-core/src/taskdog_core/application/dto/statistics_output.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/statistics_output.py
@@ -67,6 +67,7 @@ class EstimationAccuracyStatistics(BaseModel):
     exact_count: int
     best_estimated_tasks: list[TaskSummaryDto]
     worst_estimated_tasks: list[TaskSummaryDto]
+    estimation_pairs: list[tuple[float, float]] = []
 
 
 class DeadlineComplianceStatistics(BaseModel):
@@ -121,6 +122,22 @@ class TrendStatistics(BaseModel):
     monthly_completion_trend: dict[str, int]
 
 
+class ActivityPatternStatistics(BaseModel):
+    """Activity pattern statistics based on task completion times.
+
+    Attributes:
+        hourly_completions: Completion count per hour (0-23)
+        daily_completions: Completion count per day of week (0=Mon, 6=Sun)
+        heatmap: 7x24 matrix of completion counts (day_of_week x hour)
+        total_completed_with_time: Number of tasks with completion time data
+    """
+
+    hourly_completions: dict[int, int]
+    daily_completions: dict[int, int]
+    heatmap: dict[int, dict[int, int]]
+    total_completed_with_time: int
+
+
 class StatisticsOutput(BaseModel):
     """Complete statistics result.
 
@@ -131,6 +148,7 @@ class StatisticsOutput(BaseModel):
         deadline_stats: Deadline compliance statistics (None if no deadline data)
         priority_stats: Priority distribution statistics
         trend_stats: Trend statistics (None if period is not 'all')
+        activity_stats: Activity pattern statistics (None if no completion time data)
     """
 
     task_stats: TaskStatistics
@@ -139,6 +157,7 @@ class StatisticsOutput(BaseModel):
     deadline_stats: DeadlineComplianceStatistics | None
     priority_stats: PriorityDistributionStatistics
     trend_stats: TrendStatistics | None
+    activity_stats: ActivityPatternStatistics | None = None
 
 
 @dataclass

--- a/packages/taskdog-core/src/taskdog_core/application/services/task_statistics_calculator.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/task_statistics_calculator.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 
 from taskdog_core.application.dto.statistics_output import (
+    ActivityPatternStatistics,
     DeadlineComplianceStatistics,
     EstimationAccuracyStatistics,
     PriorityDistributionStatistics,
@@ -56,6 +57,8 @@ class TaskStatisticsCalculator:
             self._calculate_trends(filtered_tasks) if period == "all" else None
         )
 
+        activity_stats = self._calculate_activity_patterns(filtered_tasks)
+
         return StatisticsOutput(
             task_stats=task_stats,
             time_stats=time_stats,
@@ -63,6 +66,7 @@ class TaskStatisticsCalculator:
             deadline_stats=deadline_stats,
             priority_stats=priority_stats,
             trend_stats=trend_stats,
+            activity_stats=activity_stats,
         )
 
     def _filter_by_period(self, tasks: list[Task], period: str) -> list[Task]:
@@ -245,6 +249,12 @@ class TaskStatisticsCalculator:
         best_tasks_dto = [self._to_summary_dto(t) for t in best_tasks]
         worst_tasks_dto = [self._to_summary_dto(t) for t in worst_tasks]
 
+        pairs = [
+            (t.estimated_duration, t.actual_duration_hours)
+            for t in estimated_tasks
+            if t.estimated_duration is not None and t.actual_duration_hours is not None
+        ]
+
         return EstimationAccuracyStatistics(
             total_tasks_with_estimation=len(estimated_tasks),
             accuracy_rate=round(avg_accuracy, 2),
@@ -253,6 +263,7 @@ class TaskStatisticsCalculator:
             exact_count=exact,
             best_estimated_tasks=best_tasks_dto,
             worst_estimated_tasks=worst_tasks_dto,
+            estimation_pairs=pairs,
         )
 
     def _calculate_deadline_compliance(
@@ -362,6 +373,33 @@ class TaskStatisticsCalculator:
         if task.id is None:
             raise ValueError("Task must have an ID")
         return TaskSummaryDto(id=task.id, name=task.name)
+
+    def _calculate_activity_patterns(
+        self, tasks: list[Task]
+    ) -> ActivityPatternStatistics | None:
+        tasks_with_end = [t for t in tasks if t.actual_end and t.is_finished]
+
+        if not tasks_with_end:
+            return None
+
+        hourly: dict[int, int] = defaultdict(int)
+        daily: dict[int, int] = defaultdict(int)
+        heatmap: dict[int, dict[int, int]] = {d: defaultdict(int) for d in range(7)}
+
+        for task in tasks_with_end:
+            assert task.actual_end is not None
+            hour = task.actual_end.hour
+            day = task.actual_end.weekday()
+            hourly[hour] += 1
+            daily[day] += 1
+            heatmap[day][hour] += 1
+
+        return ActivityPatternStatistics(
+            hourly_completions=dict(hourly),
+            daily_completions=dict(daily),
+            heatmap={d: dict(h) for d, h in heatmap.items()},
+            total_completed_with_time=len(tasks_with_end),
+        )
 
     def _calculate_trends(self, tasks: list[Task]) -> TrendStatistics:
         """Calculate trend statistics over time.

--- a/packages/taskdog-server/src/taskdog_server/api/models/responses.py
+++ b/packages/taskdog-server/src/taskdog_server/api/models/responses.py
@@ -216,6 +216,7 @@ class EstimationStatistics(BaseModel):
     exact_count: int = 0
     best_estimated_tasks: list[TaskSummaryResponse] = Field(default_factory=list)
     worst_estimated_tasks: list[TaskSummaryResponse] = Field(default_factory=list)
+    estimation_pairs: list[tuple[float, float]] = Field(default_factory=list)
 
 
 class DeadlineStatistics(BaseModel):
@@ -247,6 +248,15 @@ class TrendData(BaseModel):
     monthly_completion_trend: dict[str, int] = Field(default_factory=dict)
 
 
+class ActivityPattern(BaseModel):
+    """Activity pattern statistics based on task completion times."""
+
+    hourly_completions: dict[int, int]
+    daily_completions: dict[int, int]
+    heatmap: dict[int, dict[int, int]]
+    total_completed_with_time: int
+
+
 class StatisticsResponse(BaseModel):
     """Response model for task statistics."""
 
@@ -256,6 +266,7 @@ class StatisticsResponse(BaseModel):
     deadline: DeadlineStatistics | None = None
     priority: PriorityDistribution
     trends: TrendData | None = None
+    activity: ActivityPattern | None = None
 
 
 class TagStatisticsItem(BaseModel):

--- a/packages/taskdog-server/src/taskdog_server/api/routers/analytics.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/analytics.py
@@ -26,6 +26,7 @@ from taskdog_server.api.dependencies import (
 )
 from taskdog_server.api.models.requests import OptimizeScheduleRequest
 from taskdog_server.api.models.responses import (
+    ActivityPattern,
     CompletionStatistics,
     DeadlineStatistics,
     EstimationStatistics,
@@ -138,6 +139,7 @@ async def get_statistics(
                     worst_estimated_tasks=to_task_summary_list(
                         result.estimation_stats.worst_estimated_tasks
                     ),
+                    estimation_pairs=result.estimation_stats.estimation_pairs,
                 )
                 if result.estimation_stats
                 else None
@@ -168,6 +170,16 @@ async def get_statistics(
                     monthly_completion_trend=result.trend_stats.monthly_completion_trend,
                 )
                 if result.trend_stats
+                else None
+            ),
+            activity=(
+                ActivityPattern(
+                    hourly_completions=result.activity_stats.hourly_completions,
+                    daily_completions=result.activity_stats.daily_completions,
+                    heatmap=result.activity_stats.heatmap,
+                    total_completed_with_time=result.activity_stats.total_completed_with_time,
+                )
+                if result.activity_stats
                 else None
             ),
         )

--- a/packages/taskdog-ui/pyproject.toml
+++ b/packages/taskdog-ui/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "click>=8.3.0",
     "rich>=14.2.0",
     "textual>=8.0.0",
+    "textual-plotext>=1.0.0",
     "python-dateutil>=2.8.0",
     "websockets>=14.0",
 ]
@@ -68,6 +69,10 @@ warn_unused_ignores = false
 # Ignore missing imports for taskdog_client (installed separately)
 [[tool.mypy.overrides]]
 module = "taskdog_client"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "textual_plotext"
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/packages/taskdog-ui/src/taskdog/presenters/statistics_presenter.py
+++ b/packages/taskdog-ui/src/taskdog/presenters/statistics_presenter.py
@@ -58,6 +58,7 @@ class StatisticsPresenter:
             deadline_stats=statistics_result.deadline_stats,
             priority_stats=statistics_result.priority_stats,
             trend_stats=statistics_result.trend_stats,
+            activity_stats=statistics_result.activity_stats,
         )
 
     def _map_time_statistics(
@@ -118,6 +119,7 @@ class StatisticsPresenter:
             exact_count=estimation_stats.exact_count,
             best_estimated_tasks=best_estimated_tasks_vm,
             worst_estimated_tasks=worst_estimated_tasks_vm,
+            estimation_pairs=estimation_stats.estimation_pairs,
         )
 
     def _map_task_to_summary(self, task: TaskSummaryDto) -> TaskSummaryViewModel:

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/stats_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/stats_dialog.py
@@ -9,6 +9,7 @@ from textual.binding import Binding
 from textual.containers import Container, Horizontal, Vertical, VerticalScroll
 from textual.css.query import NoMatches
 from textual.widgets import Label, Static, TabbedContent, TabPane, Tabs
+from textual_plotext import PlotextPlot
 
 from taskdog.presenters.statistics_presenter import StatisticsPresenter
 from taskdog.tui.dialogs.base_dialog import BaseModalDialog
@@ -17,11 +18,14 @@ from taskdog.view_models.statistics_view_model import (
     StatisticsViewModel,
 )
 
+_DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
 # Mapping from tab pane ID to its VerticalScroll child ID
 _TAB_SCROLL_MAP: dict[str, str] = {
     "tab-all": "stats-all-scroll",
     "tab-7d": "stats-7d-scroll",
     "tab-30d": "stats-30d-scroll",
+    "tab-activity": "stats-activity-scroll",
 }
 
 # Mapping from tab pane ID to API period parameter
@@ -116,6 +120,17 @@ class StatsDialog(BaseModalDialog[None], ViNavigationMixin):
                         id="stats-30d-placeholder",
                     )
 
+                with (
+                    TabPane("Activity", id="tab-activity"),
+                    VerticalScroll(
+                        id="stats-activity-scroll", classes="stats-tab-scroll"
+                    ),
+                ):
+                    yield Static(
+                        "[dim]Select this tab to load activity graphs...[/dim]",
+                        id="stats-activity-placeholder",
+                    )
+
     def on_mount(self) -> None:
         """Load the initial tab (All) on mount."""
         self._load_period("tab-all")
@@ -125,7 +140,9 @@ class StatsDialog(BaseModalDialog[None], ViNavigationMixin):
     ) -> None:
         """Handle tab activation to lazy-load statistics."""
         pane = event.tabbed_content.active
-        if pane in _TAB_PERIOD_MAP and not self._loaded_periods.get(pane):
+        if pane == "tab-activity" and not self._loaded_periods.get(pane):
+            self._load_activity()
+        elif pane in _TAB_PERIOD_MAP and not self._loaded_periods.get(pane):
             self._load_period(pane)
 
     def _load_period(self, tab_id: str) -> None:
@@ -423,6 +440,156 @@ class StatsDialog(BaseModalDialog[None], ViNavigationMixin):
             Label("Completion Trends", classes="stats-section-title"),
             Vertical(*rows, classes="stats-section"),
         ]
+
+    # ── Activity tab ────────────────────────────────────────────────────
+
+    def _load_activity(self) -> None:
+        if self._loaded_periods.get("tab-activity"):
+            return
+        self._loaded_periods["tab-activity"] = True
+        self.app.run_worker(self._fetch_activity(), exclusive=False)
+
+    async def _fetch_activity(self) -> None:
+        try:
+            result = await asyncio.to_thread(
+                self._api_client.calculate_statistics,
+                period="all",
+            )
+            view_model = StatisticsPresenter().present(result)
+        except Exception as e:
+            self._loaded_periods["tab-activity"] = False
+            self.notify(f"Failed to load activity data: {e}", severity="error")
+            return
+
+        try:
+            placeholder = self.query_one("#stats-activity-placeholder", Static)
+            placeholder.remove()
+        except NoMatches:
+            pass
+
+        try:
+            scroll = self.query_one("#stats-activity-scroll", VerticalScroll)
+        except NoMatches:
+            return
+
+        if not view_model.activity_stats:
+            scroll.mount(
+                Static("[dim]No completed tasks with time data available.[/dim]")
+            )
+            return
+
+        widgets = self._build_activity_widgets(view_model)
+        scroll.mount(*widgets)
+
+    def _build_activity_widgets(
+        self,
+        view_model: StatisticsViewModel,
+    ) -> list[Static | Label | PlotextPlot]:
+        stats = view_model.activity_stats
+        trend_stats = view_model.trend_stats
+        assert stats is not None
+        widgets: list[Static | Label | PlotextPlot] = []
+
+        widgets.append(
+            Label(
+                f"Activity Patterns ({stats.total_completed_with_time} tasks)",
+                classes="stats-section-title",
+            )
+        )
+
+        # Hourly completions line chart
+        hourly_plot = PlotextPlot()
+        hourly_plot.styles.height = 20
+        hourly_plot.styles.margin = (0, 1, 1, 1)
+
+        def setup_hourly(plot: PlotextPlot) -> None:
+            plt = plot.plt
+            plt.clear_figure()
+            hours = list(range(24))
+            counts = [stats.hourly_completions.get(h, 0) for h in hours]
+            plt.plot(hours, counts, marker="braille")
+            plt.title("Completions by Hour")
+            plt.xlabel("Hour")
+            plt.ylabel("Tasks")
+            plt.xticks([float(h) for h in hours], [str(h) for h in hours])
+
+        hourly_plot.call_after_refresh(lambda: setup_hourly(hourly_plot))
+        widgets.append(hourly_plot)
+
+        # Daily completions line chart
+        daily_plot = PlotextPlot()
+        daily_plot.styles.height = 17
+        daily_plot.styles.margin = (0, 1, 1, 1)
+
+        def setup_daily(plot: PlotextPlot) -> None:
+            plt = plot.plt
+            plt.clear_figure()
+            days = list(range(7))
+            counts = [stats.daily_completions.get(d, 0) for d in days]
+            plt.plot(days, counts, marker="braille")
+            plt.title("Completions by Day of Week")
+            plt.xticks([float(d) for d in days], _DAY_LABELS)
+            plt.ylabel("Tasks")
+
+        daily_plot.call_after_refresh(lambda: setup_daily(daily_plot))
+        widgets.append(daily_plot)
+
+        # Estimation accuracy ratio chart
+        if view_model.estimation_stats and view_model.estimation_stats.estimation_pairs:
+            est_plot = PlotextPlot()
+            est_plot.styles.height = 20
+            est_plot.styles.margin = (0, 1, 1, 1)
+            pairs = view_model.estimation_stats.estimation_pairs
+
+            def setup_estimation(
+                plot: PlotextPlot, data: list[tuple[float, float]]
+            ) -> None:
+                plt = plot.plt
+                plt.clear_figure()
+                estimated = [e for e, _ in data if e > 0]
+                actual = [a for e, a in data if e > 0]
+                if not estimated:
+                    return
+                # Clip to 95th percentile to prevent outlier compression
+                all_vals = estimated + actual
+                all_vals.sort()
+                p95 = all_vals[int(len(all_vals) * 0.95)]
+                clip = max(p95 * 1.1, 0.1)
+                est_c = [min(e, clip) for e in estimated]
+                act_c = [min(a, clip) for a in actual]
+                plt.scatter(est_c, act_c, marker="braille")
+                plt.plot([0, clip], [0, clip], marker="braille")
+                plt.title("Estimation Accuracy (diagonal = perfect)")
+                plt.xlabel("Estimated (h)")
+                plt.ylabel("Actual (h)")
+
+            est_plot.call_after_refresh(lambda: setup_estimation(est_plot, pairs))
+            widgets.append(est_plot)
+
+        # Monthly completion trend line chart
+        if trend_stats and trend_stats.monthly_completion_trend:
+            trend_plot = PlotextPlot()
+            trend_plot.styles.height = 20
+            trend_plot.styles.margin = (0, 1, 1, 1)
+            monthly = trend_stats.monthly_completion_trend
+
+            def setup_trend(plot: PlotextPlot, data: dict[str, int]) -> None:
+                plt = plot.plt
+                plt.clear_figure()
+                sorted_months = sorted(data.items())
+                labels = [m for m, _ in sorted_months]
+                values = [c for _, c in sorted_months]
+                x = list(range(len(labels)))
+                plt.plot(x, values, marker="braille")
+                plt.title("Monthly Completion Trend")
+                plt.xlabel("Month")
+                plt.ylabel("Tasks")
+                plt.xticks([float(i) for i in x], labels)
+
+            trend_plot.call_after_refresh(lambda: setup_trend(trend_plot, monthly))
+            widgets.append(trend_plot)
+
+        return widgets
 
     def _create_stat_row(
         self, label: str, value: str, value_class: str = ""

--- a/packages/taskdog-ui/src/taskdog/view_models/statistics_view_model.py
+++ b/packages/taskdog-ui/src/taskdog/view_models/statistics_view_model.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 
 from taskdog.view_models.base import BaseViewModel
 from taskdog_core.application.dto.statistics_output import (
+    ActivityPatternStatistics,
     DeadlineComplianceStatistics,
     PriorityDistributionStatistics,
     TaskStatistics,
@@ -78,6 +79,7 @@ class EstimationAccuracyStatisticsViewModel(BaseViewModel):
     exact_count: int
     best_estimated_tasks: list[TaskSummaryViewModel]
     worst_estimated_tasks: list[TaskSummaryViewModel]
+    estimation_pairs: list[tuple[float, float]]
 
 
 @dataclass(frozen=True)
@@ -106,3 +108,4 @@ class StatisticsViewModel(BaseViewModel):
     deadline_stats: DeadlineComplianceStatistics | None
     priority_stats: PriorityDistributionStatistics
     trend_stats: TrendStatistics | None
+    activity_stats: ActivityPatternStatistics | None

--- a/packages/taskdog-ui/tests/renderers/test_rich_statistics_renderer.py
+++ b/packages/taskdog-ui/tests/renderers/test_rich_statistics_renderer.py
@@ -50,6 +50,7 @@ class TestRichStatisticsRenderer:
             estimation_stats=None,
             deadline_stats=None,
             trend_stats=None,
+            activity_stats=None,
         )
 
     def test_render_all_sections(self):
@@ -126,6 +127,7 @@ class TestRichStatisticsRenderer:
             estimation_stats=None,
             deadline_stats=None,
             trend_stats=None,
+            activity_stats=None,
         )
 
         # Execute
@@ -164,6 +166,7 @@ class TestRichStatisticsRenderer:
             estimation_stats=None,
             deadline_stats=None,
             trend_stats=None,
+            activity_stats=None,
         )
 
         # Execute
@@ -214,9 +217,11 @@ class TestRichStatisticsRenderer:
                         actual_duration_hours=10.0,
                     )
                 ],
+                estimation_pairs=[(5.0, 5.0), (2.0, 10.0)],
             ),
             deadline_stats=None,
             trend_stats=None,
+            activity_stats=None,
         )
 
         # Execute
@@ -254,6 +259,7 @@ class TestRichStatisticsRenderer:
                 average_delay_days=2.0,
             ),
             trend_stats=None,
+            activity_stats=None,
         )
 
         # Execute
@@ -290,6 +296,7 @@ class TestRichStatisticsRenderer:
                 weekly_completion_trend={},
                 monthly_completion_trend={"2025-01": 5, "2025-02": 7},
             ),
+            activity_stats=None,
         )
 
         # Execute

--- a/scripts/vulture_whitelist.py
+++ b/scripts/vulture_whitelist.py
@@ -22,3 +22,5 @@ VI_SCROLL_BINDINGS  # unused variable (packages/taskdog-ui/src/taskdog/tui/widge
 VI_SCROLL_ALL_BINDINGS  # unused variable (packages/taskdog-ui/src/taskdog/tui/widgets/vi_navigation_mixin.py:116)
 _.handle_bindings_clash  # Textual override called by the framework (packages/taskdog-ui/src/taskdog/tui/app.py)
 node  # Textual override signature param (packages/taskdog-ui/src/taskdog/tui/app.py)
+activity  # StatisticsPayload / StatisticsResponse field (used by API serialization)
+_.margin  # Textual widget styles attribute (PlotextPlot styling)

--- a/uv.lock
+++ b/uv.lock
@@ -845,6 +845,15 @@ wheels = [
 ]
 
 [[package]]
+name = "plotext"
+version = "5.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/d7/f75f397af966fe252d0d34ffd3cae765317fce2134f925f95e7d6725d1ce/plotext-5.3.2.tar.gz", hash = "sha256:52d1e932e67c177bf357a3f0fe6ce14d1a96f7f7d5679d7b455b929df517068e", size = 61967, upload-time = "2024-09-24T15:13:37.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/1e/12fe7c40cd2099a1f454518754ed229b01beaf3bbb343127f0cc13ce6c22/plotext-5.3.2-py3-none-any.whl", hash = "sha256:394362349c1ddbf319548cfac17ca65e6d5dfc03200c40dfdc0503b3e95a2283", size = 64047, upload-time = "2024-09-24T15:13:36.296Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1494,6 +1503,7 @@ dependencies = [
     { name = "taskdog-client" },
     { name = "taskdog-core" },
     { name = "textual" },
+    { name = "textual-plotext" },
     { name = "websockets" },
 ]
 
@@ -1523,6 +1533,7 @@ requires-dist = [
     { name = "taskdog-core", editable = "packages/taskdog-core" },
     { name = "taskdog-server", marker = "extra == 'server'", editable = "packages/taskdog-server" },
     { name = "textual", specifier = ">=8.0.0" },
+    { name = "textual-plotext", specifier = ">=1.0.0" },
     { name = "websockets", specifier = ">=14.0" },
 ]
 provides-extras = ["dev", "server"]
@@ -1568,6 +1579,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9b/7a/c519db0aba5024f86e71e9631810bfdd6866ed2c8695bd7fa34b90e7ef59/textual-8.2.7.tar.gz", hash = "sha256:658f568ff81e30ed43890c3e07520390e5cf1b4763822006e060656b0a88f105", size = 1859249, upload-time = "2026-05-19T10:52:49.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/f5/c1e18bc0707300a0e90204343abbf7d7acd6fb7ebe03a6d4893b99a234b8/textual-8.2.7-py3-none-any.whl", hash = "sha256:4caaa13a90bc4cf9c6c862c067ccd34fe84e9c161710a2a907a8026313b6bd73", size = 731129, upload-time = "2026-05-19T10:52:51.773Z" },
+]
+
+[[package]]
+name = "textual-plotext"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "plotext" },
+    { name = "textual" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/b0/e4e0f38df057db778252db0dd2c08522d7222b8537b6a0181d797b9044bd/textual_plotext-1.0.1.tar.gz", hash = "sha256:836f53a3316756609e194129a35c2875638e7958c261f541e0a794f7c98011be", size = 16489, upload-time = "2024-11-30T19:25:56.625Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/53/fba7da208f9d3f59254413660fa0aa6599f2aca806f3ae356670455fd4ea/textual_plotext-1.0.1-py3-none-any.whl", hash = "sha256:6b6bfd00b29f121ddf216eaaf9bdac9d688ed72f40028484d279a10cbbb169ed", size = 16558, upload-time = "2024-11-30T19:25:32.208Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add "Activity" tab to TUI statistics dialog with productivity pattern visualizations using textual-plotext
- Line charts: hourly completions (0-23h), day-of-week completions, monthly completion trend
- Scatter plot: estimation accuracy (estimated vs actual hours, 95th percentile clipped)
- New `ActivityPatternStatistics` DTO and `estimation_pairs` field wired through all layers (core → server → client → UI)
- Add `textual-plotext` dependency to taskdog-ui

## Test plan
- [x] All existing tests pass (core: 1122, server: 324, client: 223, ui: 1120)
- [x] mypy strict passes across all packages
- [x] Manually verified Activity tab renders in TUI