### PR TITLE
fix(ui): make form dialogs scrollable on small terminals

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/algorithm_selection_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/algorithm_selection_dialog.py
@@ -5,7 +5,7 @@ from typing import Any, ClassVar
 
 from textual.app import ComposeResult
 from textual.binding import Binding
-from textual.containers import Container, Vertical
+from textual.containers import Container, VerticalScroll
 from textual.validation import Number
 from textual.widgets import Checkbox, Input, Label, Select, Static
 
@@ -79,7 +79,7 @@ class AlgorithmSelectionDialog(
             # Error message area
             yield Static("", id="error-message")
 
-            with Vertical(id="form-container"):
+            with VerticalScroll(id="form-container", can_focus=False):
                 yield Label("Algorithm:", classes="field-label")
                 options = [
                     (f"{name}: {desc}", algo_id)

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/fix_actual_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/fix_actual_dialog.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from textual.app import ComposeResult
-from textual.containers import Container, Vertical
+from textual.containers import Container, VerticalScroll
 from textual.validation import Number
 from textual.widgets import Input, Label, Static
 
@@ -111,7 +111,7 @@ class FixActualDialog(FormDialogBase[FixActualFormData | None]):
             # Error message area
             yield Static("", id="error-message")
 
-            with Vertical(id="form-container"):
+            with VerticalScroll(id="form-container", can_focus=False):
                 # Actual Start field
                 yield Label("Actual Start:", classes="field-label")
                 yield Input(

--- a/packages/taskdog-ui/src/taskdog/tui/forms/task_form_fields.py
+++ b/packages/taskdog-ui/src/taskdog/tui/forms/task_form_fields.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from textual.app import ComposeResult
-from textual.containers import Vertical
+from textual.containers import VerticalScroll
 from textual.suggester import Suggester
 from textual.validation import Length, Number, Regex
 from textual.widgets import Checkbox, Input, Label, Static
@@ -117,7 +117,7 @@ class TaskFormFields:
         # Error message area (hidden by default)
         yield Static("", id="error-message")
 
-        with Vertical(id="form-container"):
+        with VerticalScroll(id="form-container", can_focus=False):
             # Task name field (required)
             yield Label("Task Name [red]*[/red]:", classes="field-label", markup=True)
             yield Input(


### PR DESCRIPTION
## Summary

Form dialogs clipped their lower fields on short terminals: with `Vertical(#form-container)` (overflow hidden) inside a `max-height`-constrained container, fields like Tags and the Fixed checkbox were laid out off-screen and unreachable.

This replaces `Vertical` with `VerticalScroll` for the form container in:

- `TaskFormDialog` (add/edit, via `TaskFormFields.compose_form_fields`)
- `AlgorithmSelectionDialog` (optimize)
- `FixActualDialog`

`can_focus=False` keeps the scroll container itself out of the Tab order, and Textual's built-in scroll-on-focus brings each field into view as focus moves. No TCSS changes needed.

## Verification

Checked with Textual pilot at various terminal sizes:

- 100x12 / 100x15 / 100x20: focusing the last field (e.g. Fixed checkbox) scrolls it into view in all three dialogs; previously it stayed off-screen with no way to scroll.
- 100x50 / 100x60: dialog/form regions identical to before the change (compared against stashed baseline) — no layout regression on large terminals.
- `make lint`, `make typecheck`, and the taskdog-ui test suite (1120 passed) are green.

Other dialogs were audited: Help/TaskDetail/Stats already use `VerticalScroll` per tab; ConfirmationDialog fits at realistic sizes and remains operable via Y/N/Esc bindings. Dead sort dialog styles found during the audit are tracked in #1042.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
