### PR TITLE
chore(ui): remove dead sort dialog styles from dialogs.tcss

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/styles/dialogs.tcss
+++ b/packages/taskdog-ui/src/taskdog/tui/styles/dialogs.tcss
@@ -6,7 +6,6 @@
 
 /* All dialog screens use center alignment */
 AlgorithmSelectionDialog,
-SortSelectionScreen,
 ConfirmationDialog,
 TaskFormDialog,
 TaskDetailDialog,
@@ -101,11 +100,6 @@ StatsDialog {
 /* Algorithm Selection Dialog */
 #algorithm-dialog {
     max-height: 60%;
-}
-
-/* Sort Selection Dialog */
-#sort-dialog {
-    max-height: 50%;  /* Smaller than algorithm dialog (no input fields) */
 }
 
 /* Confirmation Dialog */


### PR DESCRIPTION
## Summary

`SortSelectionScreen` (in the dialog alignment selector list) and the `#sort-dialog` rule in `dialogs.tcss` no longer match any widget — sort selection was migrated to the command palette (`SortCommandProvider`). Remove both dead selectors.

No behavior change: the selectors never matched anything.

## Acceptance

- `grep -rn "SortSelectionScreen\|sort-dialog" packages/taskdog-ui/src/` returns no hits ✅
- TUI dialogs render unchanged

Closes #1042

🤖 Generated with [Claude Code](https://claude.com/claude-code)