### PR TITLE
feat(tui): add Stats command to the command palette

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/app.py
+++ b/packages/taskdog-ui/src/taskdog/tui/app.py
@@ -45,6 +45,7 @@ from taskdog.tui.palette.providers import (
     OptimizeCommandProvider,
     SortCommandProvider,
     SortOptionsProvider,
+    StatsCommandProvider,
 )
 from taskdog.tui.screens.main_screen import MainScreen
 from taskdog.tui.selection import AppSelectionProvider
@@ -265,6 +266,7 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
         BackupCommandProvider,
         GanttFilterCommandProvider,
         HelpCommandProvider,
+        StatsCommandProvider,
     }
 
     # CSS paths are resolved relative to this module's directory by Textual.
@@ -522,6 +524,10 @@ class TaskdogTUI(App):  # type: ignore[type-arg]
     def search_help(self) -> None:
         """Show the help screen with keybindings and usage instructions."""
         self.command_factory.execute("show_help")
+
+    def search_stats(self) -> None:
+        """Show the statistics dashboard."""
+        self.command_factory.execute("stats")
 
     def _refresh_mode_badges(self) -> None:
         """Refresh the footer mode badges to reflect current toggle/sort state."""

--- a/packages/taskdog-ui/src/taskdog/tui/palette/providers/__init__.py
+++ b/packages/taskdog-ui/src/taskdog/tui/palette/providers/__init__.py
@@ -18,6 +18,7 @@ from taskdog.tui.palette.providers.sort_providers import (
     SortCommandProvider,
     SortOptionsProvider,
 )
+from taskdog.tui.palette.providers.stats_provider import StatsCommandProvider
 
 __all__ = [
     "EXPORT_FORMATS",
@@ -32,4 +33,5 @@ __all__ = [
     "OptimizeCommandProvider",
     "SortCommandProvider",
     "SortOptionsProvider",
+    "StatsCommandProvider",
 ]

--- a/packages/taskdog-ui/src/taskdog/tui/palette/providers/stats_provider.py
+++ b/packages/taskdog-ui/src/taskdog/tui/palette/providers/stats_provider.py
@@ -1,0 +1,13 @@
+"""Command provider for statistics functionality."""
+
+from __future__ import annotations
+
+from taskdog.tui.palette.providers.base import SimpleSingleCommandProvider
+
+
+class StatsCommandProvider(SimpleSingleCommandProvider):
+    """Command provider for stats command."""
+
+    COMMAND_NAME = "Stats"
+    COMMAND_HELP = "Show the statistics dashboard"
+    COMMAND_CALLBACK_NAME = "search_stats"

--- a/packages/taskdog-ui/tests/presentation/tui/palette/providers/test_simple_command_providers.py
+++ b/packages/taskdog-ui/tests/presentation/tui/palette/providers/test_simple_command_providers.py
@@ -12,12 +12,14 @@ from taskdog.tui.palette.providers.audit_provider import AuditCommandProvider
 from taskdog.tui.palette.providers.backup_provider import BackupCommandProvider
 from taskdog.tui.palette.providers.base import SimpleSingleCommandProvider
 from taskdog.tui.palette.providers.help_provider import HelpCommandProvider
+from taskdog.tui.palette.providers.stats_provider import StatsCommandProvider
 
 PROVIDERS = [
     ArchiveCommandProvider,
     AuditCommandProvider,
     BackupCommandProvider,
     HelpCommandProvider,
+    StatsCommandProvider,
 ]
 
 


### PR DESCRIPTION
## Summary

Adds a `Stats` entry to the Textual command palette so the statistics dashboard is discoverable, matching the pattern already used by Help, Export, Audit, Backup, and Optimize. Previously `StatsDialog` was reachable only via the `S` keybinding.

## Changes

- New `StatsCommandProvider(SimpleSingleCommandProvider)` (`COMMAND_NAME = "Stats"`, callback `search_stats`)
- `search_stats()` on `TaskdogTUI` calling `self.command_factory.execute("stats")` (same shape as `search_help`)
- Registered the provider in `TaskdogTUI.COMMANDS`
- Extended `test_simple_command_providers.py` to cover the new provider

No changes to `StatsCommand`, `StatsDialog`, or the `S` keybinding.

## Verification

- `make check` and `make test-ui` pass (1178 passed)
- Ran the provider directly: discovery mode lists "Stats", `search("stats")` returns one hit with score > 0, and the callback resolves to `app.search_stats`

Closes #1048