### PR TITLE
fix(cli): abort note command when --file read fails

### DIFF
--- a/packages/taskdog-ui/src/taskdog/cli/commands/note.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/note.py
@@ -33,6 +33,9 @@ def _read_content_from_source(
 
     Returns:
         str | None: Content if available, None if should use editor
+
+    Raises:
+        click.Abort: If an explicitly given --file cannot be read
     """
     if content is not None:
         return content
@@ -42,7 +45,7 @@ def _read_content_from_source(
             return Path(file).read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError) as e:
             console_writer.error("reading file", e)
-            return None
+            raise click.Abort() from e
 
     # Check stdin only if no explicit options provided
     if not sys.stdin.isatty() and select.select([sys.stdin], [], [], 0)[0]:

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_note.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_note.py
@@ -363,7 +363,9 @@ class TestNoteCommand:
         self.console_writer.validation_error.assert_called_once()
 
     def test_file_read_oserror(self):
-        """Test error handling when file read fails with OSError."""
+        """Test that file read failure with OSError aborts the command."""
+        import click
+
         from taskdog.cli.commands.note import _read_content_from_source
 
         # Create a mock file path that will fail to read
@@ -372,15 +374,15 @@ class TestNoteCommand:
             mock_path.read_text.side_effect = OSError("Permission denied")
             mock_path_cls.return_value = mock_path
 
-            # Execute
-            result = _read_content_from_source(None, "/fake/path", self.console_writer)
-
-            # Verify
-            assert result is None
+            # Execute & Verify: explicit --file failure must abort, not fall back
+            with pytest.raises(click.Abort):
+                _read_content_from_source(None, "/fake/path", self.console_writer)
             self.console_writer.error.assert_called_once()
 
     def test_file_read_unicode_error(self):
-        """Test error handling when file has encoding issues."""
+        """Test that file with encoding issues aborts the command."""
+        import click
+
         from taskdog.cli.commands.note import _read_content_from_source
 
         with patch("taskdog.cli.commands.note.Path") as mock_path_cls:
@@ -390,12 +392,33 @@ class TestNoteCommand:
             )
             mock_path_cls.return_value = mock_path
 
-            # Execute
-            result = _read_content_from_source(None, "/fake/path", self.console_writer)
-
-            # Verify
-            assert result is None
+            # Execute & Verify: explicit --file failure must abort, not fall back
+            with pytest.raises(click.Abort):
+                _read_content_from_source(None, "/fake/path", self.console_writer)
             self.console_writer.error.assert_called_once()
+
+    def test_file_read_failure_does_not_open_editor(self):
+        """Test that a non-UTF8 --file exits non-zero without opening editor."""
+        with NamedTemporaryFile(mode="wb", suffix=".md", delete=False) as tmp:
+            tmp.write(b"\xff\xfe invalid utf-8 \x80")
+            tmp_path = Path(tmp.name)
+
+        try:
+            with patch(
+                "taskdog.cli.commands.note._edit_with_editor_via_shared"
+            ) as mock_edit:
+                result = self.runner.invoke(
+                    note_command,
+                    ["1", "--file", str(tmp_path)],
+                    obj=self.cli_context,
+                )
+
+                assert result.exit_code != 0
+                mock_edit.assert_not_called()
+                self.api_client.update_task_notes.assert_not_called()
+                self.console_writer.error.assert_called_once()
+        finally:
+            tmp_path.unlink(missing_ok=True)
 
     def test_empty_stdin_falls_back_to_editor(self):
         """Test that empty stdin returns None (falls back to editor mode)."""


### PR DESCRIPTION
## Summary

`_read_content_from_source()` returned `None` when reading an explicitly given `--file` failed, which the caller interprets as "no input source, use editor mode" — so after printing the error, the command opened `$EDITOR` anyway. Click's `--file` type catches missing/unreadable files upfront, but `UnicodeDecodeError` and TOCTOU/permission edge cases still reached this path.

Now the command raises `click.Abort()` after the error message. Editor fallback only happens when no input source was provided at all.

## Changes

- `cli/commands/note.py`: raise `click.Abort()` instead of returning `None` on `--file` read failure (`handle_task_errors` already re-raises `Abort`)
- Updated the two unit tests that asserted the old fallback behavior, and added a command-level test: a non-UTF8 `--file` exits non-zero without opening the editor

## Acceptance (from #1047)

- [x] `taskdog note <id> --file <non-utf8 file>` prints an error and exits non-zero without opening an editor
- [x] `taskdog note <id>` with no input source still opens the editor as before
- [x] `--content`, stdin, and `--append` behavior unchanged
- [x] `make check` and `make test` pass

Fixes #1047