### PR TITLE
refactor(cli): clean up raw print() usage and note command editor wrapper

### DIFF
--- a/packages/taskdog-ui/src/taskdog/cli/commands/export.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/export.py
@@ -159,7 +159,7 @@ def export_command(
                 f.write(tasks_data)
             console_writer.success(f"Exported {len(tasks)} tasks to {output}")
         else:
-            print(tasks_data)
+            click.echo(tasks_data)
 
     except Exception as e:
         console_writer.error("exporting tasks", e)

--- a/packages/taskdog-ui/src/taskdog/cli/commands/note.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/note.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 import click
 
 from taskdog.cli.error_handler import handle_task_errors
-from taskdog.utils.note_editor import edit_task_note
+from taskdog.utils.note_editor import EditorInterruptedError, edit_task_note
 from taskdog_core.domain.exceptions.task_exceptions import TaskNotFoundException
 
 if TYPE_CHECKING:
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
 
     from taskdog.cli.context import CliContext
     from taskdog.console.console_writer import ConsoleWriter
-    from taskdog.infrastructure.cli_config_manager import CliConfig
 
 
 def _read_content_from_source(
@@ -93,42 +92,6 @@ def _save_content_directly(
         console_writer.error("saving notes", e)
 
 
-def _edit_with_editor_via_shared(
-    task_id: int,
-    task: object,
-    api_client: TaskdogApiClient,
-    console_writer: ConsoleWriter,
-    config: CliConfig | None = None,
-) -> None:
-    """Edit note using $EDITOR via shared note_editor utility.
-
-    Args:
-        task_id: Task ID
-        task: Task detail DTO
-        api_client: API client
-        console_writer: Console writer
-        config: CLI configuration for custom template (optional)
-    """
-
-    def on_success(name: str, tid: int) -> None:
-        console_writer.success(f"Notes saved for task #{tid}")
-
-    def on_error(action: str, e: Exception) -> None:
-        if isinstance(e, RuntimeError) and "interrupted" in str(e).lower():
-            print("\n")
-            console_writer.warning("Editor interrupted")
-        else:
-            console_writer.error(action, e)
-
-    edit_task_note(
-        task=task,  # type: ignore[arg-type]
-        notes_provider=api_client,
-        on_success=on_success,
-        on_error=on_error,
-        config=config,
-    )
-
-
 @click.command(
     name="note",
     help="Edit task notes in markdown. Supports stdin, --content, --file, or $EDITOR.",
@@ -194,8 +157,23 @@ def note_command(
     if new_content is not None:
         # Save content directly without editor
         _save_content_directly(task_id, new_content, append, api_client, console_writer)
-    else:
-        # No input source, use editor mode
-        _edit_with_editor_via_shared(
-            task_id, task, api_client, console_writer, ctx_obj.config
-        )
+        return
+
+    # No input source, use editor mode
+    def on_success(name: str, tid: int) -> None:
+        console_writer.success(f"Notes saved for task #{tid}")
+
+    def on_error(action: str, e: Exception) -> None:
+        if isinstance(e, EditorInterruptedError):
+            console_writer.empty_line()
+            console_writer.warning("Editor interrupted")
+        else:
+            console_writer.error(action, e)
+
+    edit_task_note(
+        task=task,
+        notes_provider=api_client,
+        on_success=on_success,
+        on_error=on_error,
+        config=ctx_obj.config,
+    )

--- a/packages/taskdog-ui/src/taskdog/utils/note_editor.py
+++ b/packages/taskdog-ui/src/taskdog/utils/note_editor.py
@@ -14,6 +14,13 @@ from taskdog_core.application.dto.task_dto import TaskDetailDto
 type EditorRunner = Callable[[str, Path], None]
 
 
+class EditorInterruptedError(RuntimeError):
+    """Raised when the editor session is interrupted by the user."""
+
+    def __init__(self) -> None:
+        super().__init__("Editor interrupted")
+
+
 class NotesProvider(Protocol):
     """Protocol for notes access (supports both API client and NotesRepository)."""
 
@@ -176,7 +183,7 @@ def _execute_edit(
             on_error("running editor", e)
     except KeyboardInterrupt:
         if on_error:
-            on_error("editor", RuntimeError("Editor interrupted"))
+            on_error("editor", EditorInterruptedError())
     except (OSError, UnicodeDecodeError) as e:
         if on_error:
             on_error("saving notes", e)

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_note.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_note.py
@@ -302,9 +302,7 @@ class TestNoteCommand:
         # Mock _read_content_from_source to return None (no stdin/file/content)
         with (
             patch("taskdog.cli.commands.note._read_content_from_source") as mock_read,
-            patch(
-                "taskdog.cli.commands.note._edit_with_editor_via_shared"
-            ) as mock_edit,
+            patch("taskdog.cli.commands.note.edit_task_note") as mock_edit,
         ):
             mock_read.return_value = None
 
@@ -320,11 +318,12 @@ class TestNoteCommand:
             mock_read.assert_called_once_with(None, None, self.console_writer)
             mock_edit.assert_called_once()
             # Verify it was called with correct arguments
-            call_args = mock_edit.call_args[0]
-            assert call_args[0] == 1  # task_id
-            assert call_args[1] == self.mock_task  # task
-            assert call_args[2] == self.api_client  # api_client
-            assert call_args[3] == self.console_writer  # console_writer
+            call_kwargs = mock_edit.call_args[1]
+            assert call_kwargs["task"] == self.mock_task
+            assert call_kwargs["notes_provider"] == self.api_client
+            assert call_kwargs["config"] == self.config
+            assert callable(call_kwargs["on_success"])
+            assert callable(call_kwargs["on_error"])
 
     def test_api_error_handling(self):
         """Test error handling when API call fails."""
@@ -404,9 +403,7 @@ class TestNoteCommand:
             tmp_path = Path(tmp.name)
 
         try:
-            with patch(
-                "taskdog.cli.commands.note._edit_with_editor_via_shared"
-            ) as mock_edit:
+            with patch("taskdog.cli.commands.note.edit_task_note") as mock_edit:
                 result = self.runner.invoke(
                     note_command,
                     ["1", "--file", str(tmp_path)],
@@ -438,66 +435,40 @@ class TestNoteCommand:
             # Verify: should return None to fall back to editor mode
             assert result is None
 
-    def test_edit_with_editor_via_shared_calls_edit_task_note(self):
-        """Test that _edit_with_editor_via_shared delegates to edit_task_note."""
-        from taskdog.cli.commands.note import _edit_with_editor_via_shared
+    def _invoke_editor_mode(self, mock_edit):
+        """Invoke note_command in editor mode and return edit_task_note kwargs."""
+        with patch("taskdog.cli.commands.note._read_content_from_source") as mock_read:
+            mock_read.return_value = None
+            result = self.runner.invoke(note_command, ["1"], obj=self.cli_context)
+            assert result.exit_code == 0
+        return mock_edit.call_args[1]
 
-        with patch("taskdog.cli.commands.note.edit_task_note") as mock_edit:
-            _edit_with_editor_via_shared(
-                1, self.mock_task, self.api_client, self.console_writer, None
-            )
-
-            mock_edit.assert_called_once()
-            call_kwargs = mock_edit.call_args[1]
-            assert call_kwargs["task"] == self.mock_task
-            assert call_kwargs["notes_provider"] == self.api_client
-            assert call_kwargs["config"] is None
-            assert callable(call_kwargs["on_success"])
-            assert callable(call_kwargs["on_error"])
-
-    def test_edit_with_editor_via_shared_on_success_callback(self):
+    def test_editor_on_success_callback(self):
         """Test that on_success callback writes success message."""
-        from taskdog.cli.commands.note import _edit_with_editor_via_shared
-
         with patch("taskdog.cli.commands.note.edit_task_note") as mock_edit:
-            _edit_with_editor_via_shared(
-                1, self.mock_task, self.api_client, self.console_writer, None
-            )
-
-            # Extract and call the on_success callback
-            on_success = mock_edit.call_args[1]["on_success"]
+            on_success = self._invoke_editor_mode(mock_edit)["on_success"]
             on_success("Test Task", 1)
 
             self.console_writer.success.assert_called_once_with(
                 "Notes saved for task #1"
             )
 
-    def test_edit_with_editor_via_shared_on_error_callback(self):
+    def test_editor_on_error_callback(self):
         """Test that on_error callback handles errors correctly."""
-        from taskdog.cli.commands.note import _edit_with_editor_via_shared
-
         with patch("taskdog.cli.commands.note.edit_task_note") as mock_edit:
-            _edit_with_editor_via_shared(
-                1, self.mock_task, self.api_client, self.console_writer, None
-            )
-
-            # Extract and call the on_error callback with a regular error
-            on_error = mock_edit.call_args[1]["on_error"]
+            on_error = self._invoke_editor_mode(mock_edit)["on_error"]
             on_error("finding editor", RuntimeError("No editor found"))
 
             self.console_writer.error.assert_called_once()
 
-    def test_edit_with_editor_via_shared_on_error_interrupt(self):
-        """Test that on_error callback handles keyboard interrupt correctly."""
-        from taskdog.cli.commands.note import _edit_with_editor_via_shared
+    def test_editor_on_error_interrupt(self):
+        """Test that on_error callback handles editor interruption by type."""
+        from taskdog.utils.note_editor import EditorInterruptedError
 
         with patch("taskdog.cli.commands.note.edit_task_note") as mock_edit:
-            _edit_with_editor_via_shared(
-                1, self.mock_task, self.api_client, self.console_writer, None
-            )
+            on_error = self._invoke_editor_mode(mock_edit)["on_error"]
+            on_error("editor", EditorInterruptedError())
 
-            # Extract and call the on_error callback with interrupt
-            on_error = mock_edit.call_args[1]["on_error"]
-            on_error("editor", RuntimeError("Editor interrupted"))
-
+            self.console_writer.empty_line.assert_called_once()
             self.console_writer.warning.assert_called_once_with("Editor interrupted")
+            self.console_writer.error.assert_not_called()

--- a/packages/taskdog-ui/tests/utils/test_note_editor.py
+++ b/packages/taskdog-ui/tests/utils/test_note_editor.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from taskdog.utils.note_editor import (
+    EditorInterruptedError,
     _create_temp_notes_file,
     _execute_edit,
     _prepare_temp_file,
@@ -238,6 +239,7 @@ class TestExecuteEdit:
 
         on_error.assert_called_once()
         assert "editor" in on_error.call_args[0][0]
+        assert isinstance(on_error.call_args[0][1], EditorInterruptedError)
 
     @patch("taskdog.utils.note_editor._edit_and_save_notes")
     def test_calls_error_callback_on_oserror(self, mock_edit_save: MagicMock) -> None:


### PR DESCRIPTION
## Summary

Completes the ConsoleWriter migration from #59 for the two remaining raw `print()` call sites, removes a redundant wrapper in the note command, and replaces fragile string matching for editor interruption with a typed exception.

## Changes

- `cli/commands/export.py`: `print(tasks_data)` → `click.echo(tasks_data)` — data output intentionally stays outside `ConsoleWriter` (pipe-safe, no Rich wrapping/markup)
- `cli/commands/note.py`: `print("\n")` → `console_writer.empty_line()`; inlined `_edit_with_editor_via_shared()` into `note_command` (calls `edit_task_note()` directly, as the TUI does) and dropped the unused `task_id` parameter
- `utils/note_editor.py`: added `EditorInterruptedError` and pass it to `on_error` instead of `RuntimeError("Editor interrupted")`; the CLI handler now detects interruption via `isinstance` instead of string matching
- Tests updated for the inlined structure; interrupt tests now assert the exception type

## Acceptance (from #1046)

- [x] No raw `print()` calls remain in `cli/commands/` (remaining hits are `console_writer.print()`)
- [x] `taskdog export --format json | jq .` still works — verified against a live server (valid JSON array returned)
- [x] Editor interruption still shows the "Editor interrupted" warning, now detected via `EditorInterruptedError`
- [x] `_edit_with_editor_via_shared` removed; `test_note.py` updated
- [x] `make check` and `make test` pass

Fixes #1046