### PR TITLE
refactor(client): consolidate get_task_by_id() and get_task_detail() in QueryClient

### DIFF
--- a/packages/taskdog-client/src/taskdog_client/converters/__init__.py
+++ b/packages/taskdog-client/src/taskdog_client/converters/__init__.py
@@ -10,7 +10,6 @@ from .optimization_converters import convert_to_optimization_output
 from .statistics_converters import convert_to_statistics_output
 from .tag_converters import convert_to_tag_statistics_output
 from .task_converters import (
-    convert_to_get_task_by_id_output,
     convert_to_get_task_detail_output,
     convert_to_task_list_output,
     convert_to_task_operation_output,
@@ -20,7 +19,6 @@ from .task_converters import (
 __all__ = [
     "ConversionError",
     "convert_to_gantt_overlay",
-    "convert_to_get_task_by_id_output",
     "convert_to_get_task_detail_output",
     "convert_to_optimization_output",
     "convert_to_statistics_output",

--- a/packages/taskdog-client/src/taskdog_client/converters/task_converters.py
+++ b/packages/taskdog-client/src/taskdog_client/converters/task_converters.py
@@ -4,7 +4,6 @@ from typing import Any
 
 from pydantic import BaseModel, ValidationError
 
-from taskdog_core.application.dto.get_task_by_id_output import TaskByIdOutput
 from taskdog_core.application.dto.task_detail_output import TaskDetailOutput
 from taskdog_core.application.dto.task_dto import TaskDetailDto, TaskRowDto
 from taskdog_core.application.dto.task_list_output import TaskListOutput
@@ -43,7 +42,7 @@ def _model_validate[M: BaseModel](model_cls: type[M], data: dict[str, Any]) -> M
 def _build_task_detail_dto(data: dict[str, Any]) -> TaskDetailDto:
     """Build TaskDetailDto from API response data.
 
-    Shared by convert_to_get_task_by_id_output and convert_to_get_task_detail_output.
+    Used by convert_to_get_task_detail_output.
 
     Args:
         data: API response data containing task fields
@@ -113,19 +112,6 @@ def convert_to_task_list_output(data: dict[str, Any]) -> TaskListOutput:
         filtered_count=require_key(data, "filtered_count"),
         gantt_data=gantt_data,
     )
-
-
-def convert_to_get_task_by_id_output(data: dict[str, Any]) -> TaskByIdOutput:
-    """Convert API response to TaskByIdOutput.
-
-    Args:
-        data: API response data
-
-    Returns:
-        TaskByIdOutput with task data
-    """
-    task = _build_task_detail_dto(data)
-    return TaskByIdOutput(task=task)
 
 
 def convert_to_get_task_detail_output(data: dict[str, Any]) -> TaskDetailOutput:

--- a/packages/taskdog-client/src/taskdog_client/query_client.py
+++ b/packages/taskdog-client/src/taskdog_client/query_client.py
@@ -5,12 +5,10 @@ from typing import Any
 
 from taskdog_client.base_client import BaseApiClient
 from taskdog_client.converters import (
-    convert_to_get_task_by_id_output,
     convert_to_get_task_detail_output,
     convert_to_tag_statistics_output,
     convert_to_task_list_output,
 )
-from taskdog_core.application.dto.get_task_by_id_output import TaskByIdOutput
 from taskdog_core.application.dto.tag_statistics_output import TagStatisticsOutput
 from taskdog_core.application.dto.task_detail_output import TaskDetailOutput
 from taskdog_core.application.dto.task_list_output import TaskListOutput
@@ -120,23 +118,8 @@ class QueryClient:
         data = self._base._request_json("get", "/api/v1/tasks", params=params)
         return convert_to_task_list_output(data)
 
-    def get_task_by_id(self, task_id: int) -> TaskByIdOutput:
-        """Get task by ID.
-
-        Args:
-            task_id: Task ID
-
-        Returns:
-            TaskByIdOutput with task data
-
-        Raises:
-            TaskNotFoundException: If task not found
-        """
-        data = self._base._request_json("get", f"/api/v1/tasks/{task_id}")
-        return convert_to_get_task_by_id_output(data)
-
-    def get_task_detail(self, task_id: int) -> TaskDetailOutput:
-        """Get task details with notes.
+    def get_task_by_id(self, task_id: int) -> TaskDetailOutput:
+        """Get task by ID, including notes.
 
         Args:
             task_id: Task ID

--- a/packages/taskdog-client/src/taskdog_client/taskdog_api_client.py
+++ b/packages/taskdog-client/src/taskdog_client/taskdog_api_client.py
@@ -26,7 +26,6 @@ from taskdog_core.application.dto.audit_log_dto import (
 )
 from taskdog_core.application.dto.bulk_operation_output import BulkOperationOutput
 from taskdog_core.application.dto.delete_tag_output import DeleteTagOutput
-from taskdog_core.application.dto.get_task_by_id_output import TaskByIdOutput
 from taskdog_core.application.dto.optimization_output import OptimizationOutput
 from taskdog_core.application.dto.restore_result import RestoreResultDTO
 from taskdog_core.application.dto.statistics_output import StatisticsOutput
@@ -328,13 +327,9 @@ class TaskdogApiClient:
             gantt_end_date,
         )
 
-    def get_task_by_id(self, task_id: int) -> TaskByIdOutput:
-        """Get task by ID."""
+    def get_task_by_id(self, task_id: int) -> TaskDetailOutput:
+        """Get task by ID, including notes."""
         return self._queries.get_task_by_id(task_id)
-
-    def get_task_detail(self, task_id: int) -> TaskDetailOutput:
-        """Get task details with notes."""
-        return self._queries.get_task_detail(task_id)
 
     def get_gantt_data(
         self,

--- a/packages/taskdog-client/tests/converters/test_task_converters.py
+++ b/packages/taskdog-client/tests/converters/test_task_converters.py
@@ -6,7 +6,6 @@ import pytest
 from taskdog_client.converters.exceptions import ConversionError
 from taskdog_client.converters.task_converters import (
     _build_task_detail_dto,
-    convert_to_get_task_by_id_output,
     convert_to_get_task_detail_output,
     convert_to_task_list_output,
     convert_to_task_operation_output,
@@ -438,42 +437,6 @@ class TestBuildTaskDetailDto:
             _build_task_detail_dto(data)
 
         assert exc_info.value.field == "created_at"
-
-
-class TestConvertToGetTaskByIdOutput:
-    """Test cases for convert_to_get_task_by_id_output."""
-
-    def test_basic_conversion(self):
-        """Test basic conversion."""
-        data = {
-            "id": 1,
-            "name": "Task",
-            "priority": 50,
-            "status": "PENDING",
-            "planned_start": None,
-            "planned_end": None,
-            "deadline": None,
-            "actual_start": None,
-            "actual_end": None,
-            "estimated_duration": None,
-            "daily_allocations": {},
-            "is_fixed": False,
-            "depends_on": [],
-            "tags": [],
-            "is_archived": False,
-            "created_at": "2025-01-01T00:00:00",
-            "updated_at": "2025-01-01T00:00:00",
-            "actual_duration_hours": None,
-            "is_active": False,
-            "is_finished": False,
-            "can_be_modified": True,
-            "is_schedulable": True,
-        }
-
-        result = convert_to_get_task_by_id_output(data)
-
-        assert result.task.id == 1
-        assert result.task.name == "Task"
 
 
 class TestConvertToGetTaskDetailOutput:

--- a/packages/taskdog-client/tests/test_converters.py
+++ b/packages/taskdog-client/tests/test_converters.py
@@ -6,7 +6,6 @@ import pytest
 from taskdog_client.converters import (
     ConversionError,
     convert_to_gantt_overlay,
-    convert_to_get_task_by_id_output,
     convert_to_get_task_detail_output,
     convert_to_optimization_output,
     convert_to_statistics_output,
@@ -173,40 +172,6 @@ class TestConverters:
         assert result.tasks[1].id == 2
         assert result.tasks[1].is_finished is True
         assert result.tasks[1].has_notes is True
-
-    def test_convert_to_get_task_by_id_output(self):
-        """Test convert_to_get_task_by_id_output."""
-        data = {
-            "id": 1,
-            "name": "Task Detail",
-            "priority": 50,
-            "status": "PENDING",
-            "planned_start": None,
-            "planned_end": None,
-            "deadline": "2025-12-31T23:59:00",
-            "actual_start": None,
-            "actual_end": None,
-            "estimated_duration": 5.0,
-            "daily_allocations": {"2025-01-15": 2.5, "2025-01-16": 2.5},
-            "is_fixed": False,
-            "depends_on": [2],
-            "tags": ["test"],
-            "is_archived": False,
-            "created_at": "2025-01-01T00:00:00",
-            "updated_at": "2025-01-01T00:00:00",
-            "actual_duration_hours": None,
-            "is_active": False,
-            "is_finished": False,
-            "can_be_modified": True,
-            "is_schedulable": True,
-        }
-
-        result = convert_to_get_task_by_id_output(data)
-
-        assert result.task.id == 1
-        assert result.task.name == "Task Detail"
-        assert len(result.task.daily_allocations) == 2
-        assert result.task.can_be_modified is True
 
     def test_convert_to_get_task_detail_output(self):
         """Test convert_to_get_task_detail_output."""
@@ -497,7 +462,7 @@ class TestConverterErrorHandling:
         }
 
         with pytest.raises(ConversionError) as exc_info:
-            convert_to_get_task_by_id_output(data)
+            convert_to_get_task_detail_output(data)
 
         assert "daily_allocations" in str(exc_info.value)
         assert exc_info.value.field == "daily_allocations"
@@ -530,7 +495,7 @@ class TestConverterErrorHandling:
         }
 
         with pytest.raises(ConversionError) as exc_info:
-            convert_to_get_task_by_id_output(data)
+            convert_to_get_task_detail_output(data)
 
         assert "created_at" in str(exc_info.value)
         assert exc_info.value.field == "created_at"
@@ -563,7 +528,7 @@ class TestConverterErrorHandling:
         }
 
         with pytest.raises(ConversionError) as exc_info:
-            convert_to_get_task_by_id_output(data)
+            convert_to_get_task_detail_output(data)
 
         assert "created_at" in str(exc_info.value)
         assert exc_info.value.field == "created_at"
@@ -596,7 +561,7 @@ class TestConverterErrorHandling:
             "daily_allocations": {},  # Empty dict
         }
 
-        result = convert_to_get_task_by_id_output(data)
+        result = convert_to_get_task_detail_output(data)
 
         assert result.task.daily_allocations == {}
 
@@ -630,7 +595,7 @@ class TestConverterErrorHandling:
             },
         }
 
-        result = convert_to_get_task_by_id_output(data)
+        result = convert_to_get_task_detail_output(data)
 
         # Verify date keys are converted to date objects
         assert len(result.task.daily_allocations) == 2

--- a/packages/taskdog-client/tests/test_query_client.py
+++ b/packages/taskdog-client/tests/test_query_client.py
@@ -56,28 +56,17 @@ class TestQueryClient:
         assert result == mock_output
         mock_convert.assert_called_once_with(mock_json)
 
-    @pytest.mark.parametrize(
-        "method_name,converter_name,mock_json",
-        [
-            ("get_task_by_id", "convert_to_get_task_by_id_output", {"id": 1}),
-            (
-                "get_task_detail",
-                "convert_to_get_task_detail_output",
-                {"id": 1, "notes": "Content"},
-            ),
-        ],
-        ids=["get_task_by_id", "get_task_detail"],
-    )
-    def test_get_single_task_operations(self, method_name, converter_name, mock_json):
-        """Test single task GET operations make correct API calls."""
-        with patch(f"taskdog_client.query_client.{converter_name}") as mock_convert:
-            self.mock_base._request_json.return_value = mock_json
+    def test_get_task_by_id(self):
+        """Test get_task_by_id makes correct API call."""
+        with patch(
+            "taskdog_client.query_client.convert_to_get_task_detail_output"
+        ) as mock_convert:
+            self.mock_base._request_json.return_value = {"id": 1, "notes": "Content"}
 
             mock_output = Mock()
             mock_convert.return_value = mock_output
 
-            method = getattr(self.client, method_name)
-            result = method(task_id=1)
+            result = self.client.get_task_by_id(task_id=1)
 
             self.mock_base._request_json.assert_called_once_with(
                 "get", "/api/v1/tasks/1"

--- a/packages/taskdog-client/tests/test_taskdog_api_client.py
+++ b/packages/taskdog-client/tests/test_taskdog_api_client.py
@@ -281,11 +281,6 @@ class TestTaskdogApiClientDelegation:
         client.get_task_by_id(task_id=1)
         client._queries.get_task_by_id.assert_called_once_with(1)
 
-    def test_get_task_detail(self, client):
-        """Test get_task_detail delegates to QueryClient."""
-        client.get_task_detail(task_id=1)
-        client._queries.get_task_detail.assert_called_once_with(1)
-
     def test_get_gantt_data(self, client):
         """Test get_gantt_data delegates to QueryClient."""
         client.get_gantt_data()

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_crud.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_crud.py
@@ -81,7 +81,7 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
         Returns:
             Task details including notes
         """
-        result = client.get_task_detail(task_id)
+        result = client.get_task_by_id(task_id)
         task = result.task
         return {
             "id": task.id,

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_decomposition.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_decomposition.py
@@ -107,7 +107,7 @@ def register_decomposition_tools(mcp: FastMCP, client: TaskdogApiClient) -> None
         Returns:
             Decomposition result with created subtask IDs
         """
-        original = client.get_task_detail(task_id)
+        original = client.get_task_by_id(task_id)
         # TaskDetailOutput has .task (TaskDetailDto)
         original_task = original.task
         original_tags = str_list(original_task.tags)

--- a/packages/taskdog-mcp/tests/test_tools.py
+++ b/packages/taskdog-mcp/tests/test_tools.py
@@ -130,7 +130,7 @@ def create_mock_client() -> MagicMock:
     # TaskdogApiClient has flat methods (no nested clients)
     # CRUD methods
     client.list_tasks = MagicMock()
-    client.get_task_detail = MagicMock()
+    client.get_task_by_id = MagicMock()
     client.create_task = MagicMock()
     client.update_task = MagicMock()
     client.archive_task = MagicMock()
@@ -400,7 +400,7 @@ class TestTaskCrudTools:
         from taskdog_mcp.tools import task_crud
 
         client = create_mock_client()
-        client.get_task_detail.return_value = create_mock_task_detail_output(
+        client.get_task_by_id.return_value = create_mock_task_detail_output(
             task_id=1,
             name="Test Task",
             notes_content="# Notes\nSome notes here",
@@ -412,7 +412,7 @@ class TestTaskCrudTools:
         get_task_fn = mcp._tool_manager._tools["get_task"].fn
         result = get_task_fn(task_id=1)
 
-        client.get_task_detail.assert_called_once_with(1)
+        client.get_task_by_id.assert_called_once_with(1)
         assert result["id"] == 1
         assert result["name"] == "Test Task"
         assert result["notes"] == "# Notes\nSome notes here"
@@ -1038,7 +1038,7 @@ class TestTaskDecompositionTools:
         from taskdog_mcp.tools import task_decomposition
 
         client = create_mock_client()
-        client.get_task_detail.return_value = create_mock_task_detail_output(
+        client.get_task_by_id.return_value = create_mock_task_detail_output(
             task_id=1, name="Original Task"
         )
         created_subtask = create_mock_task_operation_output(task_id=2, name="Subtask 1")
@@ -1067,7 +1067,7 @@ class TestTaskDecompositionTools:
         from taskdog_mcp.tools import task_decomposition
 
         client = create_mock_client()
-        client.get_task_detail.return_value = create_mock_task_detail_output(
+        client.get_task_by_id.return_value = create_mock_task_detail_output(
             task_id=1, name="Original Task"
         )
         client.create_task.side_effect = [
@@ -1101,7 +1101,7 @@ class TestTaskDecompositionTools:
         from taskdog_mcp.tools import task_decomposition
 
         client = create_mock_client()
-        client.get_task_detail.return_value = create_mock_task_detail_output(
+        client.get_task_by_id.return_value = create_mock_task_detail_output(
             task_id=1, name="Original Task"
         )
         client.create_task.return_value = create_mock_task_operation_output(
@@ -1130,7 +1130,7 @@ class TestTaskDecompositionTools:
         from taskdog_mcp.tools import task_decomposition
 
         client = create_mock_client()
-        client.get_task_detail.return_value = create_mock_task_detail_output(
+        client.get_task_by_id.return_value = create_mock_task_detail_output(
             task_id=1, name="Original Task"
         )
         client.create_task.return_value = create_mock_task_operation_output(
@@ -1278,7 +1278,7 @@ class TestTaskDecompositionTools:
         from taskdog_mcp.tools import task_decomposition
 
         client = create_mock_client()
-        client.get_task_detail.return_value = create_mock_task_detail_output(
+        client.get_task_by_id.return_value = create_mock_task_detail_output(
             task_id=1, name="Original Task"
         )
         # First subtask succeeds, second fails
@@ -1312,7 +1312,7 @@ class TestTaskDecompositionTools:
         from taskdog_mcp.tools import task_decomposition
 
         client = create_mock_client()
-        client.get_task_detail.return_value = create_mock_task_detail_output(
+        client.get_task_by_id.return_value = create_mock_task_detail_output(
             task_id=1, name="Original Task"
         )
         client.create_task.side_effect = [
@@ -1346,7 +1346,7 @@ class TestTaskDecompositionTools:
         from taskdog_mcp.tools import task_decomposition
 
         client = create_mock_client()
-        client.get_task_detail.return_value = create_mock_task_detail_output(
+        client.get_task_by_id.return_value = create_mock_task_detail_output(
             task_id=1, name="Original Task"
         )
         client.create_task.return_value = create_mock_task_operation_output(
@@ -1377,7 +1377,7 @@ class TestTaskDecompositionTools:
         from taskdog_mcp.tools import task_decomposition
 
         client = create_mock_client()
-        client.get_task_detail.return_value = create_mock_task_detail_output(
+        client.get_task_by_id.return_value = create_mock_task_detail_output(
             task_id=1, name="Original Task"
         )
         client.create_task.return_value = create_mock_task_operation_output(

--- a/packages/taskdog-ui/src/taskdog/cli/commands/note.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/note.py
@@ -11,7 +11,6 @@ import click
 
 from taskdog.cli.error_handler import handle_task_errors
 from taskdog.utils.note_editor import EditorInterruptedError, edit_task_note
-from taskdog_core.domain.exceptions.task_exceptions import TaskNotFoundException
 
 if TYPE_CHECKING:
     from taskdog_client import TaskdogApiClient
@@ -146,10 +145,7 @@ def note_command(
         return
 
     # Get task from API
-    result = api_client.get_task_by_id(task_id)
-    if not result.task:
-        raise TaskNotFoundException(task_id)
-    task = result.task
+    task = api_client.get_task_by_id(task_id).task
 
     # Try to read content from sources (priority: --content, --file, stdin)
     new_content = _read_content_from_source(content, file, console_writer)

--- a/packages/taskdog-ui/src/taskdog/cli/commands/show.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/show.py
@@ -24,7 +24,7 @@ def show_command(ctx: click.Context, task_id: int, raw: bool) -> None:
     console_writer = ctx_obj.console_writer
 
     # Get task detail via API client
-    detail = ctx_obj.api_client.get_task_detail(task_id)
+    detail = ctx_obj.api_client.get_task_by_id(task_id)
 
     # Render and display using renderer
     renderer = RichDetailRenderer(console_writer)

--- a/packages/taskdog-ui/src/taskdog/cli/commands/tag/list.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/tag/list.py
@@ -10,7 +10,6 @@ from taskdog.cli.error_handler import handle_task_errors
 
 if TYPE_CHECKING:
     from taskdog.cli.context import CliContext
-from taskdog_core.domain.exceptions.task_exceptions import TaskNotFoundException
 
 
 @click.command(name="list", help="List all tags, or the tags of a single task.")
@@ -43,8 +42,6 @@ def list_command(ctx: click.Context, task_id: int | None) -> None:
 
     # Task ID - show tags for that task
     result = ctx_obj.api_client.get_task_by_id(task_id)
-    if not result.task:
-        raise TaskNotFoundException(task_id)
 
     if not result.task.tags:
         console_writer.info(f"Task {task_id} has no tags.")

--- a/packages/taskdog-ui/src/taskdog/tui/commands/edit.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/edit.py
@@ -22,9 +22,6 @@ class EditCommand(TUICommandBase):
 
         # Fetch task via API client
         output = self.context.api_client.get_task_by_id(task_id)
-        if output.task is None:
-            self.notify_warning(f"Task #{task_id} not found")
-            return
 
         # Store original task DTO
         original_task = output.task

--- a/packages/taskdog-ui/src/taskdog/tui/commands/fix_actual.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/fix_actual.py
@@ -19,9 +19,6 @@ class FixActualCommand(TUICommandBase):
 
         # Fetch task via API client
         output = self.context.api_client.get_task_by_id(task_id)
-        if output.task is None:
-            self.notify_warning(f"Task #{task_id} not found")
-            return
 
         # Store task reference
         task = output.task

--- a/packages/taskdog-ui/src/taskdog/tui/commands/note.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/note.py
@@ -64,9 +64,6 @@ class NoteCommand(TUICommandBase):
 
         # Fetch task via API client
         output = self.context.api_client.get_task_by_id(task_id)
-        if output.task is None:
-            self.notify_warning(f"Task #{task_id} not found")
-            return
 
         # Edit note using shared helper (uses API client via NotesProvider protocol)
         edit_task_note(

--- a/packages/taskdog-ui/src/taskdog/tui/commands/show.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/show.py
@@ -31,7 +31,7 @@ class ShowCommand(TUICommandBase):
         """
         try:
             detail = await asyncio.to_thread(
-                self.context.api_client.get_task_detail, task_id
+                self.context.api_client.get_task_by_id, task_id
             )
         except Exception as e:
             self.notify_error("Failed to fetch task details", e)

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_note.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_note.py
@@ -346,9 +346,12 @@ class TestNoteCommand:
 
     def test_task_not_found(self):
         """Test error when task doesn't exist."""
+        from taskdog_core.domain.exceptions.task_exceptions import (
+            TaskNotFoundException,
+        )
 
         # Setup - task not found
-        self.api_client.get_task_by_id.return_value = Mock(task=None)
+        self.api_client.get_task_by_id.side_effect = TaskNotFoundException(999)
 
         # Execute
         result = self.runner.invoke(

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_show_command.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_show_command.py
@@ -27,7 +27,7 @@ class TestShowCommand:
         """Test basic show display."""
         # Setup
         mock_detail = MagicMock()
-        self.api_client.get_task_detail.return_value = mock_detail
+        self.api_client.get_task_by_id.return_value = mock_detail
 
         mock_renderer = MagicMock()
         mock_renderer_class.return_value = mock_renderer
@@ -37,7 +37,7 @@ class TestShowCommand:
 
         # Verify
         assert result.exit_code == 0
-        self.api_client.get_task_detail.assert_called_once_with(1)
+        self.api_client.get_task_by_id.assert_called_once_with(1)
         mock_renderer.render.assert_called_once_with(mock_detail, raw=False)
 
     @patch("taskdog.cli.commands.show.RichDetailRenderer")
@@ -45,7 +45,7 @@ class TestShowCommand:
         """Test show with --raw option."""
         # Setup
         mock_detail = MagicMock()
-        self.api_client.get_task_detail.return_value = mock_detail
+        self.api_client.get_task_by_id.return_value = mock_detail
 
         mock_renderer = MagicMock()
         mock_renderer_class.return_value = mock_renderer
@@ -60,7 +60,7 @@ class TestShowCommand:
     def test_task_not_found(self):
         """Test show with non-existent task."""
         # Setup
-        self.api_client.get_task_detail.side_effect = TaskNotFoundException(999)
+        self.api_client.get_task_by_id.side_effect = TaskNotFoundException(999)
 
         # Execute
         result = self.runner.invoke(show_command, ["999"], obj=self.cli_context)
@@ -73,7 +73,7 @@ class TestShowCommand:
         """Test handling of general exception."""
         # Setup
         error = ValueError("Something went wrong")
-        self.api_client.get_task_detail.side_effect = error
+        self.api_client.get_task_by_id.side_effect = error
 
         # Execute
         result = self.runner.invoke(show_command, ["1"], obj=self.cli_context)

--- a/packages/taskdog-ui/tests/presentation/cli/commands/test_tag_command.py
+++ b/packages/taskdog-ui/tests/presentation/cli/commands/test_tag_command.py
@@ -80,9 +80,7 @@ class TestTagListCommand(_TagCommandFixture):
 
     def test_show_task_tags_not_found(self):
         """Test showing tags for non-existent task."""
-        mock_result = MagicMock()
-        mock_result.task = None
-        self.api_client.get_task_by_id.return_value = mock_result
+        self.api_client.get_task_by_id.side_effect = TaskNotFoundException(999)
 
         result = self.runner.invoke(list_command, ["999"], obj=self.cli_context)
 

--- a/packages/taskdog-ui/tests/tui/commands/test_show.py
+++ b/packages/taskdog-ui/tests/tui/commands/test_show.py
@@ -73,18 +73,18 @@ class TestShowCommand:
         """Test that task detail is fetched from API in background thread."""
         task = create_mock_task_dto(task_id=42)
         detail = TaskDetailOutput(task=task, notes_content="", has_notes=False)
-        self.mock_context.api_client.get_task_detail.return_value = detail
+        self.mock_context.api_client.get_task_by_id.return_value = detail
 
         await self.command._fetch_and_show_detail(42)
 
-        self.mock_context.api_client.get_task_detail.assert_called_once_with(42)
+        self.mock_context.api_client.get_task_by_id.assert_called_once_with(42)
 
     @pytest.mark.asyncio
     async def test_fetch_and_show_detail_pushes_detail_dialog(self) -> None:
         """Test that detail dialog is pushed after fetch."""
         task = create_mock_task_dto(task_id=42)
         detail = TaskDetailOutput(task=task, notes_content="", has_notes=False)
-        self.mock_context.api_client.get_task_detail.return_value = detail
+        self.mock_context.api_client.get_task_by_id.return_value = detail
 
         await self.command._fetch_and_show_detail(42)
 
@@ -93,7 +93,7 @@ class TestShowCommand:
     @pytest.mark.asyncio
     async def test_fetch_and_show_detail_notifies_error_on_failure(self) -> None:
         """Test that API errors are caught and shown as notifications."""
-        self.mock_context.api_client.get_task_detail.side_effect = ConnectionError(
+        self.mock_context.api_client.get_task_by_id.side_effect = ConnectionError(
             "Connection refused"
         )
         self.command.notify_error = MagicMock()


### PR DESCRIPTION
## Summary

`QueryClient.get_task_by_id()` and `get_task_detail()` both called `GET /api/v1/tasks/{task_id}`, and the server always responds with notes included — the two methods differed only in client-side wrapping. This consolidates them into a single method.

**Direction differs from the issue proposal**: the issue suggested removing `get_task_by_id()` in favor of `get_task_detail()`. Instead, this keeps the `get_task_by_id` name — it describes the lookup key, and the return type `TaskDetailOutput` already conveys the payload. Same end state: one method for fetching one task.

## Changes

- `QueryClient.get_task_by_id()` now returns `TaskDetailOutput`; `get_task_detail()` removed from `QueryClient` and the `TaskdogApiClient` facade
- `convert_to_get_task_by_id_output()` removed; former `get_task_detail()` call sites (`tui/show`, `cli/show`, MCP `task_crud` / `task_decomposition`) migrated to `get_task_by_id()`
- Unreachable `task is None` checks removed at the 5 former `get_task_by_id()` call sites (the client raises `TaskNotFoundException` on 404 and the DTO's `task` field is non-optional)
- Tests updated; not-found tests now mock `TaskNotFoundException` (the real client behavior) instead of `task=None`

## Out of scope (per issue)

- Core DTO `TaskByIdOutput` — still used server-side by `QueryController.get_task_by_id()`
- Server endpoint changes

## Verification

- `make check` and `make test` pass (all packages)
- Exercised against a live server: `taskdog show 1` renders the detail panel, `taskdog tag list 1` lists tags, `taskdog show 99999` exits 1 with "Task with ID 99999 not found"

Closes #1045