### PR TITLE
feat(ui): modernize the CLI/TUI logo banner

### DIFF
--- a/packages/taskdog-ui/src/taskdog/cli_main.py
+++ b/packages/taskdog-ui/src/taskdog/cli_main.py
@@ -111,18 +111,10 @@ class TaskdogGroup(LazyGroup):
     """Root group: lazy loading (via LazyGroup) plus ASCII art in --help."""
 
     def format_help(self, ctx: click.Context, formatter: Any) -> None:
-        """Override format_help to add ASCII art before help text."""
-        from taskdog.constants.ascii_art import (
-            TASKDOG_ASCII_ART,
-            TASKDOG_DESCRIPTION,
-            TASKDOG_TAGLINE,
-        )
+        """Override format_help to add the branded banner before help text."""
+        from taskdog.constants.ascii_art import print_banner
 
-        console = Console()
-        console.print(TASKDOG_ASCII_ART, style="cyan")
-        console.print(f"  {TASKDOG_TAGLINE}", style="bold yellow")
-        console.print(f"  {TASKDOG_DESCRIPTION}", style="dim")
-        console.print()
+        print_banner(Console())
 
         # Call the original format_help
         super().format_help(ctx, formatter)

--- a/packages/taskdog-ui/src/taskdog/constants/ascii_art.py
+++ b/packages/taskdog-ui/src/taskdog/constants/ascii_art.py
@@ -1,13 +1,28 @@
 """ASCII art and branding constants for Taskdog."""
 
-TASKDOG_ASCII_ART = r"""
-     __            __       __
-    / /_____ _____/ /______/ /___  ____ _
-   / __/ __ `/ __/ //_/ __  / __ \/ __ `/
-  / /_/ /_/ (__  ) ,< / /_/ / /_/ / /_/ /
-  \__/\__,_/____/_/|_|\__,_/\____/\__, /
-                                 /____/
-"""
+from rich.console import Console
 
-TASKDOG_TAGLINE = "🐕 Your loyal task watchdog"
-TASKDOG_DESCRIPTION = "Taskdog is your faithful watchdog, keeping an eye on your tasks."
+# Modern box-drawing wordmark (pyfiglet "future" font) shown at the top of
+# `taskdog --help` and the TUI help dialog. The small face keeps the dog
+# motif from the name while matching the clean look of the Textual TUI.
+TASKDOG_WORDMARK = r"""  ╺┳╸┏━┓┏━┓╻┏ ╺┳┓┏━┓┏━╸
+   ┃ ┣━┫┗━┓┣┻┓ ┃┃┃ ┃┃╺┓   ⊙ᴥ⊙
+   ╹ ╹ ╹┗━┛╹ ╹╺┻┛┗━┛┗━┛"""
+
+# Fallback for terminals that cannot render box-drawing / unicode glyphs.
+TASKDOG_WORDMARK_ASCII = "  taskdog"
+
+TASKDOG_TAGLINE = "Local-first task management, done in your terminal"
+
+
+def print_banner(console: Console) -> None:
+    """Print the branded header for `taskdog --help`.
+
+    Uses the unicode wordmark on UTF-8 terminals and a plain-text fallback
+    elsewhere, so the banner degrades gracefully without unicode.
+    """
+    supports_unicode = "utf" in (console.encoding or "").lower()
+    wordmark = TASKDOG_WORDMARK if supports_unicode else TASKDOG_WORDMARK_ASCII
+    console.print(wordmark, style="bold cyan", highlight=False)
+    console.print(f"  {TASKDOG_TAGLINE}", style="dim")
+    console.print()

--- a/packages/taskdog-ui/src/taskdog/tui/dialogs/help_dialog.py
+++ b/packages/taskdog-ui/src/taskdog/tui/dialogs/help_dialog.py
@@ -9,6 +9,7 @@ from textual.css.query import NoMatches
 from textual.widgets import Markdown, Static, TabbedContent, TabPane, Tabs
 
 from taskdog import __version__
+from taskdog.constants.ascii_art import TASKDOG_TAGLINE, TASKDOG_WORDMARK
 from taskdog.tui.constants.keybindings import (
     BASIC_WORKFLOW,
     BUG_REPORT_INFO,
@@ -61,6 +62,9 @@ class HelpDialog(BaseModalDialog[None], ViNavigationMixin):
                         classes="help-tab-scroll",
                     ),
                 ):
+                    yield Static(TASKDOG_WORDMARK, classes="help-wordmark")
+                    yield Static(TASKDOG_TAGLINE, classes="help-tagline")
+                    yield Static("", classes="help-spacer")
                     yield Markdown(TASKDOG_OVERVIEW, classes="help-section")
                     yield Static("", classes="help-spacer")
                     yield Markdown(BASIC_WORKFLOW, classes="help-section")

--- a/packages/taskdog-ui/src/taskdog/tui/styles/dialogs.tcss
+++ b/packages/taskdog-ui/src/taskdog/tui/styles/dialogs.tcss
@@ -152,6 +152,17 @@ HelpDialog {
     overflow-y: auto;
 }
 
+.help-wordmark {
+    color: $primary;
+    text-style: bold;
+    padding: 0 1;
+}
+
+.help-tagline {
+    color: $text-muted;
+    padding: 0 1;
+}
+
 .help-section {
     padding: 0 1;
 }


### PR DESCRIPTION
## Summary

Replaces the dated slanted figlet banner on `taskdog --help` with a clean box-drawing wordmark (pyfiglet "future" font) and a small dog face, aligning the CLI branding with the modern Textual TUI. The same wordmark is embedded at the top of the TUI help dialog so both surfaces share one visual language.

### Before
```
     __            __       __
    / /_____ _____/ /______/ /___  ____ _
   / __/ __ `/ __/ //_/ __  / __ \/ __ `/
  / /_/ /_/ (__  ) ,< / /_/ / /_/ / /_/ /
  \__/\__,_/____/_/|_|\__,_/\____/\__, /
                                 /____/
```

### After
```
  ╺┳╸┏━┓┏━┓╻┏ ╺┳┓┏━┓┏━╸
   ┃ ┣━┫┗━┓┣┻┓ ┃┃┃ ┃┃╺┓   ⊙ᴥ⊙
   ╹ ╹ ╹┗━┛╹ ╹╺┻┛┗━┛┗━┛
  Local-first task management, done in your terminal
```

## Changes

- New box-drawing wordmark + dog face; retired the `TASKDOG_ASCII_ART` / `TASKDOG_DESCRIPTION` constants.
- Dropped the "watchdog" framing in favor of a local-first tagline.
- `print_banner()` degrades gracefully to plain `taskdog` on terminals without unicode support.
- Wordmark added to the TUI help dialog's Getting Started tab (cyan, matching the TUI primary accent).

## Verification

- `make check` (lint + mypy + codespell + vulture): passed
- taskdog-ui test suite: 1185 passed
- CLI `--help` output and TUI help dialog verified visually; installed to a real machine for confirmation.

Closes #958

🤖 Generated with [Claude Code](https://claude.com/claude-code)