### PR TITLE
fix(tui): stats panel borders use $primary for consistency

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/styles/components.tcss
+++ b/packages/taskdog-ui/src/taskdog/tui/styles/components.tcss
@@ -180,7 +180,7 @@ StatsScreen {
 }
 
 .stats-panel {
-    border: round $primary-darken-2;
+    border: round $primary;
     border-title-color: $primary;
     padding: 0 1;
     width: 100%;
@@ -205,7 +205,7 @@ StatsScreen {
 }
 
 .stats-chart {
-    border: round $primary-darken-2;
+    border: round $primary;
     border-title-color: $primary;
     height: 1fr;
 }


### PR DESCRIPTION
## Summary

Stats screen panel/chart borders used `$primary-darken-2`, making them look dimmer than every other bordered panel in the app (task table, footer filter chain, audit log), which use plain `$primary`. Switch `.stats-panel` and `.stats-chart` to `$primary` for visual consistency.

## Screenshots

Before (dim `$primary-darken-2` borders) vs after (`$primary`, matching the panel titles and the column divider):

| Before | After |
|--------|-------|
| borders dimmer than titles | borders match `$primary` |

## Acceptance criteria

- [x] `.stats-panel` border uses `$primary`.
- [x] `.stats-chart` border uses `$primary`.
- [x] Stats panel borders match the primary color used by the task table and other panels.

Closes #1083