### PR TITLE
feat(tui): add Vi-style navigation to the stats screen

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/screens/stats_screen.py
+++ b/packages/taskdog-ui/src/taskdog/tui/screens/stats_screen.py
@@ -16,11 +16,12 @@ from taskdog.tui.widgets.stats_panels import (
     build_overview_panel,
     build_reschedule_panel,
 )
+from taskdog.tui.widgets.vi_navigation_mixin import ViNavigationMixin
 
 _PERIODS = ("all", "7d", "30d")
 
 
-class StatsScreen(ModalScreen[None]):
+class StatsScreen(ViNavigationMixin, ModalScreen[None]):
     """Full-page btop-style statistics dashboard.
 
     Uses ModalScreen to block App-level bindings (add, start, done, etc.)
@@ -35,6 +36,8 @@ class StatsScreen(ModalScreen[None]):
     BINDINGS: ClassVar = [
         Binding("q", "pop_screen", "Back", tooltip="Close the statistics screen"),
         Binding("escape", "pop_screen", "Back", show=False),
+        *ViNavigationMixin.VI_VERTICAL_BINDINGS,
+        *ViNavigationMixin.VI_PAGE_BINDINGS,
     ]
 
     def __init__(self, api_client: TaskdogApiClient) -> None:
@@ -65,6 +68,10 @@ class StatsScreen(ModalScreen[None]):
                     yield Static("")
 
             yield Vertical(id="stats-right")
+
+    def _get_active_scroll_widget(self) -> VerticalScroll | None:
+        """Return the scrollable left column for Vi-style navigation."""
+        return self.query_one("#stats-left", VerticalScroll)
 
     def on_mount(self) -> None:
         """Fetch all periods after the screen is mounted."""

--- a/packages/taskdog-ui/tests/tui/screens/test_stats_screen_navigation.py
+++ b/packages/taskdog-ui/tests/tui/screens/test_stats_screen_navigation.py
@@ -1,0 +1,130 @@
+"""Tests for Vi-style navigation on the TUI stats screen."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from textual.binding import Binding
+from textual.containers import VerticalScroll
+
+from taskdog.tui.app import TaskdogTUI
+from taskdog.tui.screens.stats_screen import StatsScreen
+from taskdog_core.application.dto.statistics_output import (
+    ActivityPatternStatistics,
+    PriorityDistributionStatistics,
+    StatisticsOutput,
+    TaskStatistics,
+    TimeStatistics,
+)
+
+
+def _bindings_by_key() -> dict[str, Binding]:
+    return {b.key: b for b in StatsScreen.BINDINGS if isinstance(b, Binding)}
+
+
+class TestStatsScreenViBindings:
+    """The stats screen exposes Vi-style scroll bindings via the mixin."""
+
+    def test_j_scrolls_down(self) -> None:
+        assert _bindings_by_key()["j"].action == "vi_down"
+
+    def test_k_scrolls_up(self) -> None:
+        assert _bindings_by_key()["k"].action == "vi_up"
+
+    def test_g_jumps_to_top(self) -> None:
+        assert _bindings_by_key()["g"].action == "vi_home"
+
+    def test_capital_g_jumps_to_bottom(self) -> None:
+        assert _bindings_by_key()["G"].action == "vi_end"
+
+    def test_half_page_bindings_present(self) -> None:
+        keys = _bindings_by_key()
+        assert keys["ctrl+d"].action == "vi_page_down"
+        assert keys["ctrl+u"].action == "vi_page_up"
+
+    def test_close_bindings_preserved(self) -> None:
+        keys = _bindings_by_key()
+        assert keys["q"].action == "pop_screen"
+        assert keys["escape"].action == "pop_screen"
+
+
+def _fake_output(period: str) -> StatisticsOutput:
+    return StatisticsOutput(
+        task_stats=TaskStatistics(
+            total_tasks=142,
+            pending_count=30,
+            in_progress_count=4,
+            completed_count=100,
+            canceled_count=8,
+            completion_rate=0.92,
+        ),
+        time_stats=TimeStatistics(
+            total_work_hours=240.5,
+            average_work_hours=2.4,
+            median_work_hours=1.8,
+            longest_task=None,
+            shortest_task=None,
+            tasks_with_time_tracking=100,
+        ),
+        estimation_stats=None,
+        deadline_stats=None,
+        priority_stats=PriorityDistributionStatistics(
+            high_priority_count=20,
+            medium_priority_count=50,
+            low_priority_count=30,
+            high_priority_completion_rate=0.8,
+            priority_completion_map={90: 10, 50: 30, 10: 20},
+        ),
+        trend_stats=None,
+        activity_stats=ActivityPatternStatistics(
+            hourly_completions={h: (h % 6) for h in range(24)},
+            daily_completions={d: d + 1 for d in range(7)},
+            heatmap={d: {h: (d + h) % 5 for h in range(24)} for d in range(7)},
+            total_completed_with_time=100,
+        ),
+        reschedule_stats=None,
+    )
+
+
+def _make_app() -> TaskdogTUI:
+    api_client = MagicMock()
+    api_client.client_id = "test"
+    api_client.calculate_statistics.side_effect = lambda period: _fake_output(period)
+    ws = MagicMock()
+    ws.connect = AsyncMock()
+    ws.disconnect = AsyncMock()
+    return TaskdogTUI(api_client=api_client, websocket_client=ws)
+
+
+class TestStatsScreenScrolling:
+    """Vi keys actually move the #stats-left scroll offset."""
+
+    @pytest.mark.asyncio
+    async def test_j_k_g_capital_g_scroll_left_column(self) -> None:
+        app = _make_app()
+        # Small height forces the stacked panels to overflow and become scrollable.
+        async with app.run_test(size=(120, 20)) as pilot:
+            await pilot.pause()
+            app.push_screen(StatsScreen(api_client=app.api_client))
+            await pilot.pause()
+            await pilot.pause()
+
+            left = app.screen.query_one("#stats-left", VerticalScroll)
+            assert left.max_scroll_y > 0, "content should overflow to be scrollable"
+
+            assert left.scroll_offset.y == 0
+
+            await pilot.press("j")
+            await pilot.pause()
+            assert left.scroll_offset.y > 0
+
+            await pilot.press("k")
+            await pilot.pause()
+            assert left.scroll_offset.y == 0
+
+            await pilot.press("G")
+            await pilot.pause()
+            assert left.scroll_offset.y == left.max_scroll_y
+
+            await pilot.press("g")
+            await pilot.pause()
+            assert left.scroll_offset.y == 0


### PR DESCRIPTION
## Summary

The stats screen (`StatsScreen`) only bound `q`/`escape` to close. Its content lives in a scrollable `#stats-left` `VerticalScroll`, but there were no Vi-style keys to move through it. This wires `StatsScreen` to the existing `ViNavigationMixin`:

- `j` / `k` — scroll down / up one line
- `g` / `G` — jump to top / bottom
- `ctrl+d` / `ctrl+u` — half-page down / up

The screen implements `_get_active_scroll_widget()` to return `#stats-left`; the mixin's `action_vi_*` methods do the scrolling.

## Design note

The issue suggested optional `d`/`u` for half-page. I used `ctrl+d`/`ctrl+u` to match the app-wide `ViNavigationMixin` convention (task table, gantt, audit log all use ctrl+d/ctrl+u). Vi keys stay `show=False`, consistent with every other widget.

## Verification

New `tests/tui/screens/test_stats_screen_navigation.py`: binding-registration tests plus a functional pilot test that mounts the screen with overflowing content and asserts j/k/g/G move `#stats-left.scroll_offset.y` (down, back to 0, to `max_scroll_y`, back to top). 7 passed; ruff + mypy clean.

## Acceptance criteria

- [x] `j`/`k` scroll the stats content line by line.
- [x] `g`/`G` jump to top / bottom.
- [x] Existing `q`/`escape` close behavior is unchanged.
- [x] Bindings registered on the screen (kept `show=False` per app convention for Vi keys).

Closes #1084