### PR TITLE
feat(tui): show a loading indicator on the stats screen

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/screens/stats_screen.py
+++ b/packages/taskdog-ui/src/taskdog/tui/screens/stats_screen.py
@@ -56,22 +56,26 @@ class StatsScreen(ModalScreen[None]):
                     id="stats-overview-panel", classes="stats-panel"
                 ) as overview:
                     overview.border_title = "Overview"
-                    yield Static("[dim]Loading statistics...[/dim]")
 
                 with Vertical(
                     id="stats-reschedule-panel", classes="stats-panel"
                 ) as reschedule:
                     reschedule.border_title = "Reschedule"
-                    yield Static("")
 
             yield Vertical(id="stats-right")
 
     def on_mount(self) -> None:
         """Fetch all periods after the screen is mounted."""
+        # Overlay a LoadingIndicator on each column until the fetch resolves,
+        # matching the .loading pattern used by the gantt/task table.
+        self.query_one("#stats-left", VerticalScroll).loading = True
+        self.query_one("#stats-right", Vertical).loading = True
         self.app.run_worker(self._fetch_statistics())
 
     async def _fetch_statistics(self) -> None:
         """Fetch statistics for all periods concurrently and render panels."""
+        left = self.query_one("#stats-left", VerticalScroll)
+        right = self.query_one("#stats-right", Vertical)
         try:
             outputs = await asyncio.gather(
                 *(
@@ -83,27 +87,29 @@ class StatsScreen(ModalScreen[None]):
             )
         except Exception as e:
             self.notify(f"Failed to load statistics: {e}", severity="error")
+            left.loading = False
+            right.loading = False
             return
 
         presenter = StatisticsPresenter()
         vms = [presenter.present(output) for output in outputs]
 
         overview_panel = self.query_one("#stats-overview-panel", Vertical)
-        await overview_panel.remove_children()
         await overview_panel.mount(*build_overview_panel(vms))
 
         reschedule_panel = self.query_one("#stats-reschedule-panel", Vertical)
-        await reschedule_panel.remove_children()
         await reschedule_panel.mount(*build_reschedule_panel(vms))
 
-        right = self.query_one("#stats-right", Vertical)
         charts = build_activity_charts(vms[0])
         if charts:
-            right.mount(*charts)
+            await right.mount(*charts)
         else:
-            right.mount(
+            await right.mount(
                 Static("[dim]No completed tasks with time data available.[/dim]")
             )
+
+        left.loading = False
+        right.loading = False
 
     def action_pop_screen(self) -> None:
         """Go back to the main screen."""

--- a/packages/taskdog-ui/tests/tui/screens/test_stats_screen_loading.py
+++ b/packages/taskdog-ui/tests/tui/screens/test_stats_screen_loading.py
@@ -1,0 +1,105 @@
+"""Tests for the loading indicator on the TUI stats screen."""
+
+import threading
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from textual.containers import Vertical, VerticalScroll
+
+from taskdog.tui.app import TaskdogTUI
+from taskdog.tui.screens.stats_screen import StatsScreen
+from taskdog_core.application.dto.statistics_output import (
+    PriorityDistributionStatistics,
+    StatisticsOutput,
+    TaskStatistics,
+)
+
+
+def _fake_output(period: str) -> StatisticsOutput:
+    return StatisticsOutput(
+        task_stats=TaskStatistics(
+            total_tasks=10,
+            pending_count=2,
+            in_progress_count=1,
+            completed_count=6,
+            canceled_count=1,
+            completion_rate=0.86,
+        ),
+        time_stats=None,
+        estimation_stats=None,
+        deadline_stats=None,
+        priority_stats=PriorityDistributionStatistics(
+            high_priority_count=1,
+            medium_priority_count=2,
+            low_priority_count=3,
+            high_priority_completion_rate=1.0,
+            priority_completion_map={},
+        ),
+        trend_stats=None,
+        activity_stats=None,
+        reschedule_stats=None,
+    )
+
+
+def _make_app(gate: threading.Event | None = None) -> TaskdogTUI:
+    api_client = MagicMock()
+    api_client.client_id = "test"
+
+    def _calc(period: str) -> StatisticsOutput:
+        if gate is not None:
+            gate.wait(timeout=5)
+        return _fake_output(period)
+
+    api_client.calculate_statistics.side_effect = _calc
+    ws = MagicMock()
+    ws.connect = AsyncMock()
+    ws.disconnect = AsyncMock()
+    return TaskdogTUI(api_client=api_client, websocket_client=ws)
+
+
+class TestStatsLoadingIndicator:
+    @pytest.mark.asyncio
+    async def test_columns_show_loading_while_fetching_then_clear(self) -> None:
+        gate = threading.Event()
+        app = _make_app(gate=gate)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            app.push_screen(StatsScreen(api_client=app.api_client))
+            await pilot.pause()
+
+            left = app.screen.query_one("#stats-left", VerticalScroll)
+            right = app.screen.query_one("#stats-right", Vertical)
+
+            # Fetch is blocked on the gate: indicators must be visible.
+            assert left.loading is True
+            assert right.loading is True
+
+            # Release the fetch and let the worker render the panels.
+            gate.set()
+            for _ in range(20):
+                await pilot.pause()
+                if not left.loading and not right.loading:
+                    break
+
+            assert left.loading is False
+            assert right.loading is False
+            overview = app.screen.query_one("#stats-overview-panel", Vertical)
+            assert len(overview.children) > 0
+
+    @pytest.mark.asyncio
+    async def test_loading_cleared_on_fetch_error(self) -> None:
+        app = _make_app()
+        app.api_client.calculate_statistics.side_effect = RuntimeError("boom")
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            app.push_screen(StatsScreen(api_client=app.api_client))
+            for _ in range(20):
+                await pilot.pause()
+                left = app.screen.query_one("#stats-left", VerticalScroll)
+                if not left.loading:
+                    break
+
+            left = app.screen.query_one("#stats-left", VerticalScroll)
+            right = app.screen.query_one("#stats-right", Vertical)
+            assert left.loading is False
+            assert right.loading is False


### PR DESCRIPTION
## Summary

The stats screen fetches three periods (all / 7d / 30d) concurrently on mount. While loading, the Overview panel showed a static `[dim]Loading statistics...[/dim]` and the rest stayed blank — a weak progress signal that can look frozen on slower connections.

This replaces the static placeholder with Textual's `LoadingIndicator`, driven by the `.loading` reactive on the `#stats-left` and `#stats-right` columns — the same pattern the gantt widget and task table already use. The indicator is cleared once panels are mounted, and also on fetch failure so the screen never spins forever.

## Screenshots

| Loading | Loaded |
|---------|--------|
| animated `LoadingIndicator` on both columns | full dashboard |

## Notes

- Followed the app-wide `.loading` reactive convention rather than manually mounting/removing a `LoadingIndicator`, for consistency with `main_screen.py`.
- Both columns are `height: 1fr`, so the overlay has room without any CSS change.
- The issue mentioned an optional show-after-delay to avoid flicker on fast local fetches; kept it simple/consistent with gantt & task table, which show immediately.

## Verification

New `tests/tui/screens/test_stats_screen_loading.py`:
- Gate the fetch on a `threading.Event`, assert both columns' `.loading is True` while blocked, then `False` with panel content after release.
- Assert `.loading` is cleared on a fetch error.

```
2 passed
361 passed  (full tests/tui suite)
```
ruff + mypy clean.

Closes #1082