### PR TITLE
fix(mcp): get_executable_tasks excludes tasks with unmet dependencies

### DIFF
--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_query.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_query.py
@@ -8,11 +8,57 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from taskdog_core.domain.entities.task import TaskStatus
+from taskdog_core.domain.exceptions.task_exceptions import TaskNotFoundException
 from taskdog_mcp.tools.serializers import iso, str_list
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
     from taskdog_client import TaskdogApiClient
+
+
+def _dependencies_met(
+    depends_on: list[int],
+    client: TaskdogApiClient,
+    dep_status_cache: dict[int, TaskStatus | None],
+) -> bool:
+    """Check whether all dependency ids are COMPLETED.
+
+    A missing dependency (e.g. its task was deleted) counts as unmet,
+    matching DependencyValidator.validate_dependencies_met semantics.
+    Statuses are memoized in dep_status_cache so a dep shared across
+    multiple tasks is only fetched once per get_executable_tasks call.
+    """
+    for dep_id in depends_on:
+        if dep_id not in dep_status_cache:
+            try:
+                dep_status_cache[dep_id] = client.get_task_by_id(dep_id).task.status
+            except TaskNotFoundException:
+                dep_status_cache[dep_id] = None
+        if dep_status_cache[dep_id] != TaskStatus.COMPLETED:
+            return False
+    return True
+
+
+def _select_executable_pending(
+    pending_tasks: list[Any],
+    client: TaskdogApiClient,
+    max_count: int,
+) -> list[Any]:
+    """Filter pending tasks down to those whose dependencies are met.
+
+    Stops scanning once max_count executable tasks have been found, so
+    dependency lookups for tasks beyond the eventual limit are skipped.
+    """
+    dep_status_cache: dict[int, TaskStatus | None] = {}
+    executable_pending: list[Any] = []
+    for t in pending_tasks:
+        if len(executable_pending) >= max_count:
+            break
+        if not t.depends_on or _dependencies_met(
+            t.depends_on, client, dep_status_cache
+        ):
+            executable_pending.append(t)
+    return executable_pending
 
 
 def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
@@ -99,18 +145,12 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
             reverse=True,
         )
 
-        # Filter out pending tasks with unmet dependencies
-        executable_pending = []
-        for t in pending.tasks:
-            if not t.depends_on:
-                executable_pending.append(t)
-                continue
-            deps_met = all(
-                client.get_task_by_id(dep_id).task.status == TaskStatus.COMPLETED
-                for dep_id in t.depends_on
-            )
-            if deps_met:
-                executable_pending.append(t)
+        # Filter out pending tasks with unmet dependencies, stopping once
+        # enough executable tasks are found to fill the remaining limit.
+        remaining_slots = max(limit - len(in_progress.tasks), 0)
+        executable_pending = _select_executable_pending(
+            pending.tasks, client, remaining_slots
+        )
 
         # Combine and limit
         all_tasks = list(in_progress.tasks) + executable_pending

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_query.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_query.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from taskdog_core.domain.entities.task import TaskStatus
 from taskdog_mcp.tools.serializers import iso, str_list
 
 if TYPE_CHECKING:
@@ -98,8 +99,21 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
             reverse=True,
         )
 
+        # Filter out pending tasks with unmet dependencies
+        executable_pending = []
+        for t in pending.tasks:
+            if not t.depends_on:
+                executable_pending.append(t)
+                continue
+            deps_met = all(
+                client.get_task_by_id(dep_id).task.status == TaskStatus.COMPLETED
+                for dep_id in t.depends_on
+            )
+            if deps_met:
+                executable_pending.append(t)
+
         # Combine and limit
-        all_tasks = list(in_progress.tasks) + list(pending.tasks)
+        all_tasks = list(in_progress.tasks) + executable_pending
         limited_tasks = all_tasks[:limit]
 
         return {

--- a/packages/taskdog-mcp/tests/test_tools.py
+++ b/packages/taskdog-mcp/tests/test_tools.py
@@ -1050,6 +1050,67 @@ class TestTaskQueryTools:
         assert result["tasks"][0]["id"] == 2
         assert result["total"] == 1
 
+    def test_get_executable_tasks_excludes_pending_with_missing_dependency(
+        self,
+    ) -> None:
+        """Pending task depending on a deleted/missing task must be excluded, not raise."""
+        from mcp.server.fastmcp import FastMCP
+        from taskdog_mcp.tools import task_query
+
+        from taskdog_core.domain.exceptions.task_exceptions import (
+            TaskNotFoundException,
+        )
+
+        client = create_mock_client()
+        pending_task = create_mock_task_row(
+            task_id=2, name="Pending", status=TaskStatus.PENDING, depends_on=[99]
+        )
+        client.list_tasks.side_effect = [
+            TaskListOutput(tasks=[pending_task], total_count=1, filtered_count=1),
+            TaskListOutput(tasks=[], total_count=0, filtered_count=0),
+        ]
+        client.get_task_by_id.side_effect = TaskNotFoundException(99)
+
+        mcp = FastMCP("test")
+        task_query.register_tools(mcp, client)
+
+        get_executable_fn = mcp._tool_manager._tools["get_executable_tasks"].fn
+        result = get_executable_fn(limit=5)
+
+        assert result["tasks"] == []
+        assert result["total"] == 0
+
+    def test_get_executable_tasks_excludes_pending_with_mixed_dependencies(
+        self,
+    ) -> None:
+        """Pending task with one completed and one pending dep must be excluded."""
+        from mcp.server.fastmcp import FastMCP
+        from taskdog_mcp.tools import task_query
+
+        client = create_mock_client()
+        pending_task = create_mock_task_row(
+            task_id=2, name="Pending", status=TaskStatus.PENDING, depends_on=[97, 98]
+        )
+        client.list_tasks.side_effect = [
+            TaskListOutput(tasks=[pending_task], total_count=1, filtered_count=1),
+            TaskListOutput(tasks=[], total_count=0, filtered_count=0),
+        ]
+
+        def get_task_by_id(task_id: int) -> TaskDetailOutput:
+            status = TaskStatus.COMPLETED if task_id == 97 else TaskStatus.PENDING
+            return create_mock_task_detail_output(task_id=task_id, status=status)
+
+        client.get_task_by_id.side_effect = get_task_by_id
+
+        mcp = FastMCP("test")
+        task_query.register_tools(mcp, client)
+
+        get_executable_fn = mcp._tool_manager._tools["get_executable_tasks"].fn
+        result = get_executable_fn(limit=5)
+
+        assert result["tasks"] == []
+        assert result["total"] == 0
+
 
 class TestTaskDecompositionTools:
     """Test task decomposition MCP tools."""

--- a/packages/taskdog-mcp/tests/test_tools.py
+++ b/packages/taskdog-mcp/tests/test_tools.py
@@ -25,6 +25,7 @@ def create_mock_task_row(
     name: str = "Test Task",
     status: TaskStatus = TaskStatus.PENDING,
     priority: int = 50,
+    depends_on: list[int] | None = None,
 ) -> TaskRowDto:
     """Create a mock TaskRowDto for testing."""
     return TaskRowDto(
@@ -40,7 +41,7 @@ def create_mock_task_row(
         estimated_duration=2.0,
         actual_duration_hours=None,
         is_fixed=False,
-        depends_on=[],
+        depends_on=depends_on or [],
         tags=["test"],
         is_archived=False,
         is_finished=False,
@@ -991,6 +992,63 @@ class TestTaskQueryTools:
 
         assert len(result["tasks"]) == 3
         assert result["total"] == 3
+
+    def test_get_executable_tasks_excludes_pending_with_unmet_dependency(
+        self,
+    ) -> None:
+        """Pending task depending on a non-completed task must be excluded."""
+        from mcp.server.fastmcp import FastMCP
+        from taskdog_mcp.tools import task_query
+
+        client = create_mock_client()
+        pending_task = create_mock_task_row(
+            task_id=2, name="Pending", status=TaskStatus.PENDING, depends_on=[99]
+        )
+        client.list_tasks.side_effect = [
+            TaskListOutput(tasks=[pending_task], total_count=1, filtered_count=1),
+            TaskListOutput(tasks=[], total_count=0, filtered_count=0),
+        ]
+        client.get_task_by_id.return_value = create_mock_task_detail_output(
+            task_id=99, status=TaskStatus.PENDING
+        )
+
+        mcp = FastMCP("test")
+        task_query.register_tools(mcp, client)
+
+        get_executable_fn = mcp._tool_manager._tools["get_executable_tasks"].fn
+        result = get_executable_fn(limit=5)
+
+        assert result["tasks"] == []
+        assert result["total"] == 0
+
+    def test_get_executable_tasks_includes_pending_with_met_dependency(
+        self,
+    ) -> None:
+        """Pending task depending on a completed task must be included."""
+        from mcp.server.fastmcp import FastMCP
+        from taskdog_mcp.tools import task_query
+
+        client = create_mock_client()
+        pending_task = create_mock_task_row(
+            task_id=2, name="Pending", status=TaskStatus.PENDING, depends_on=[99]
+        )
+        client.list_tasks.side_effect = [
+            TaskListOutput(tasks=[pending_task], total_count=1, filtered_count=1),
+            TaskListOutput(tasks=[], total_count=0, filtered_count=0),
+        ]
+        client.get_task_by_id.return_value = create_mock_task_detail_output(
+            task_id=99, status=TaskStatus.COMPLETED
+        )
+
+        mcp = FastMCP("test")
+        task_query.register_tools(mcp, client)
+
+        get_executable_fn = mcp._tool_manager._tools["get_executable_tasks"].fn
+        result = get_executable_fn(limit=5)
+
+        assert len(result["tasks"]) == 1
+        assert result["tasks"][0]["id"] == 2
+        assert result["total"] == 1
 
 
 class TestTaskDecompositionTools:


### PR DESCRIPTION
## Background

`get_executable_tasks` returned PENDING/IN_PROGRESS tasks sorted by priority but had **no dependency-resolution filter**. A PENDING task whose dependencies were not yet COMPLETED was still returned as executable, so dispatch flows could pick up tasks with unmet dependencies. The business rule already exists in core as `DependencyValidator.validate_dependencies_met` (all dependencies must be COMPLETED; a missing dependency counts as unmet), but `get_executable_tasks` never applied it.

Surfaced during real use (verifying an A/R/B task decomposition): task B was returned as executable even though its dependency R was still incomplete.

## Changes

- Add a dependency filter to the PENDING branch of `get_executable_tasks`: only return pending tasks whose dependencies are **all COMPLETED** (IN_PROGRESS tasks pass through — they are already started).
- **A missing dependency counts as unmet** (matching `DependencyValidator`). `depends_on` is stored as JSON TEXT and is not scrubbed when a dependency task is deleted, so dangling ids occur in normal use; `TaskNotFoundException` from `get_task_by_id` is caught per-dependency so the whole call never crashes.
- Reduce dependency-status lookups via per-call memoization + early stop once enough executable tasks fill `limit` (N+1 mitigation — no bulk read API exists on the client, so batching was not available).

## Verification

- taskdog-mcp package tests: **97 passed** (existing + new: unmet dep excluded / met dep included / missing dep excluded without crash / mixed deps excluded).
- ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dps99ripMmjR32rC7QoyYn