### PR TITLE
fix(server): run sync endpoints off the event loop (#962)

### DIFF
--- a/packages/taskdog-server/src/taskdog_server/api/routers/analytics.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/analytics.py
@@ -51,7 +51,7 @@ router = APIRouter()
 
 
 @router.get("/statistics", response_model=StatisticsResponse)
-async def get_statistics(
+def get_statistics(
     controller: AnalyticsControllerDep,
     _client_name: AuthenticatedClientDep,
     period: str = Query(VALID_PERIODS[0], description="Time period: all, 7d, or 30d"),
@@ -199,7 +199,7 @@ async def get_statistics(
 
 
 @router.get("/tags/statistics", response_model=TagStatisticsResponse)
-async def get_tag_statistics(
+def get_tag_statistics(
     controller: QueryControllerDep,
     _client_name: AuthenticatedClientDep,
 ) -> TagStatisticsResponse:
@@ -225,7 +225,7 @@ async def get_tag_statistics(
 
 
 @router.get("/gantt", response_model=TaskListResponse)
-async def get_gantt_chart(
+def get_gantt_chart(
     controller: QueryControllerDep,
     holiday_checker: HolidayCheckerDep,
     _client_name: AuthenticatedClientDep,
@@ -295,7 +295,7 @@ async def get_gantt_chart(
 
 
 @router.post("/optimize", response_model=OptimizationResponse)
-async def optimize_schedule(
+def optimize_schedule(
     request: OptimizeScheduleRequest,
     controller: AnalyticsControllerDep,
     broadcaster: EventBroadcasterDep,
@@ -408,7 +408,7 @@ async def optimize_schedule(
 
 
 @router.get("/algorithms", response_model=list[dict[str, str]])
-async def list_algorithms(
+def list_algorithms(
     controller: QueryControllerDep,
     _client_name: AuthenticatedClientDep,
 ) -> list[dict[str, str]]:

--- a/packages/taskdog-server/src/taskdog_server/api/routers/audit.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/audit.py
@@ -16,7 +16,7 @@ router = APIRouter()
 
 
 @router.get("", response_model=AuditLogListResponse)
-async def list_audit_logs(
+def list_audit_logs(
     controller: AuditLogControllerDep,
     _client_name: AuthenticatedClientDep,
     client_filter: Annotated[
@@ -109,7 +109,7 @@ async def list_audit_logs(
 
 
 @router.get("/{log_id}", response_model=AuditLogResponse)
-async def get_audit_log(
+def get_audit_log(
     log_id: int,
     controller: AuditLogControllerDep,
     _client_name: AuthenticatedClientDep,

--- a/packages/taskdog-server/src/taskdog_server/api/routers/backup.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/backup.py
@@ -20,7 +20,7 @@ _CHUNK_SIZE = 1024 * 1024
 
 
 @router.get("/backup")
-async def backup(
+def backup(
     controller: BackupControllerDep,
     _client_name: AuthenticatedClientDep,
 ) -> StreamingResponse:
@@ -35,7 +35,7 @@ async def backup(
 
 
 @router.post("/restore", response_model=RestoreResultDTO)
-async def restore(
+def restore(
     controller: BackupControllerDep,
     _client_name: AuthenticatedClientDep,
     file: Annotated[UploadFile, File()],

--- a/packages/taskdog-server/src/taskdog_server/api/routers/bulk.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/bulk.py
@@ -96,7 +96,7 @@ def _create_bulk_lifecycle_endpoint(op: BulkLifecycleOperation) -> None:
         response_model=BulkOperationResponse,
         summary=op.description,
     )
-    async def endpoint(
+    def endpoint(
         request: BulkTaskIdsRequest,
         bulk_controller: BulkTaskControllerDep,
         broadcaster: EventBroadcasterDep,
@@ -130,7 +130,7 @@ def _create_bulk_crud_endpoint(op: BulkCrudOperation) -> None:
         response_model=BulkOperationResponse,
         summary=op.description,
     )
-    async def endpoint(
+    def endpoint(
         request: BulkTaskIdsRequest,
         bulk_controller: BulkTaskControllerDep,
         broadcaster: EventBroadcasterDep,

--- a/packages/taskdog-server/src/taskdog_server/api/routers/lifecycle.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/lifecycle.py
@@ -48,7 +48,7 @@ def _create_lifecycle_endpoint(op: LifecycleOperation) -> None:
     """
 
     @router.post(f"/{{task_id}}/{op.name}", response_model=TaskOperationResponse)
-    async def endpoint(
+    def endpoint(
         task_id: int,
         controller: LifecycleControllerDep,
         broadcaster: EventBroadcasterDep,
@@ -79,7 +79,7 @@ for _op in OPERATIONS:
 
 
 @router.post("/{task_id}/fix-actual", response_model=TaskOperationResponse)
-async def fix_actual_times(
+def fix_actual_times(
     task_id: int,
     request: FixActualTimesRequest,
     controller: LifecycleControllerDep,

--- a/packages/taskdog-server/src/taskdog_server/api/routers/notes.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/notes.py
@@ -15,7 +15,7 @@ router = APIRouter()
 
 
 @router.get("/{task_id}/notes", response_model=NotesResponse)
-async def get_task_notes(
+def get_task_notes(
     task_id: int,
     controller: NotesControllerDep,
     _client_name: AuthenticatedClientDep,
@@ -39,7 +39,7 @@ async def get_task_notes(
 
 
 @router.put("/{task_id}/notes", response_model=NotesResponse)
-async def update_task_notes(
+def update_task_notes(
     task_id: int,
     request: UpdateNotesRequest,
     controller: NotesControllerDep,
@@ -84,7 +84,7 @@ async def update_task_notes(
 
 
 @router.delete("/{task_id}/notes", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_task_notes(
+def delete_task_notes(
     task_id: int,
     controller: NotesControllerDep,
     broadcaster: EventBroadcasterDep,

--- a/packages/taskdog-server/src/taskdog_server/api/routers/relationships.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/relationships.py
@@ -19,7 +19,7 @@ router = APIRouter()
 
 
 @router.post("/{task_id}/dependencies", response_model=TaskOperationResponse)
-async def add_dependency(
+def add_dependency(
     task_id: int,
     request: AddDependencyRequest,
     controller: RelationshipControllerDep,
@@ -62,7 +62,7 @@ async def add_dependency(
 @router.delete(
     "/{task_id}/dependencies/{depends_on_id}", response_model=TaskOperationResponse
 )
-async def remove_dependency(
+def remove_dependency(
     task_id: int,
     depends_on_id: int,
     controller: RelationshipControllerDep,
@@ -103,7 +103,7 @@ async def remove_dependency(
 
 
 @router.put("/{task_id}/tags", response_model=TaskOperationResponse)
-async def set_task_tags(
+def set_task_tags(
     task_id: int,
     request: SetTaskTagsRequest,
     controller: RelationshipControllerDep,

--- a/packages/taskdog-server/src/taskdog_server/api/routers/tags.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/tags.py
@@ -13,7 +13,7 @@ router = APIRouter()
 
 
 @router.delete("/{tag_name}", response_model=DeleteTagResponse)
-async def delete_tag(
+def delete_tag(
     tag_name: str,
     controller: RelationshipControllerDep,
     audit_controller: AuditLogControllerDep,

--- a/packages/taskdog-server/src/taskdog_server/api/routers/tasks.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/tasks.py
@@ -38,7 +38,7 @@ router = APIRouter()
 @router.post(
     "", response_model=TaskOperationResponse, status_code=status.HTTP_201_CREATED
 )
-async def create_task(
+def create_task(
     request: CreateTaskRequest,
     controller: CrudControllerDep,
     broadcaster: EventBroadcasterDep,
@@ -90,7 +90,7 @@ async def create_task(
 
 
 @router.get("", response_model=TaskListResponse)
-async def list_tasks(
+def list_tasks(
     controller: QueryControllerDep,
     holiday_checker: HolidayCheckerDep,
     _client_name: AuthenticatedClientDep,
@@ -165,7 +165,7 @@ async def list_tasks(
 
 
 @router.get("/{task_id}", response_model=TaskDetailResponse)
-async def get_task(
+def get_task(
     task_id: int,
     controller: QueryControllerDep,
     _client_name: AuthenticatedClientDep,
@@ -187,7 +187,7 @@ async def get_task(
 
 
 @router.patch("/{task_id}", response_model=UpdateTaskResponse)
-async def update_task(
+def update_task(
     task_id: int,
     request: UpdateTaskRequest,
     controller: CrudControllerDep,
@@ -249,7 +249,7 @@ async def update_task(
 
 
 @router.post("/{task_id}/archive", response_model=TaskOperationResponse)
-async def archive_task(
+def archive_task(
     task_id: int,
     controller: CrudControllerDep,
     broadcaster: EventBroadcasterDep,
@@ -289,7 +289,7 @@ async def archive_task(
 
 
 @router.post("/{task_id}/restore", response_model=TaskOperationResponse)
-async def restore_task(
+def restore_task(
     task_id: int,
     controller: CrudControllerDep,
     broadcaster: EventBroadcasterDep,
@@ -329,7 +329,7 @@ async def restore_task(
 
 
 @router.delete("/{task_id}")
-async def delete_task(
+def delete_task(
     task_id: int,
     controller: CrudControllerDep,
     broadcaster: EventBroadcasterDep,


### PR DESCRIPTION
## Problem

Fixes #962.

Every HTTP endpoint is declared `async def`, but the controllers and repositories they call are fully synchronous SQLAlchemy/sqlite3 (no async engine, no `aiosqlite`, no offloading anywhere in the server). FastAPI runs `async def` endpoints **directly on the event loop**, so each request's blocking DB work stalls every other request — and every WebSocket send — on the same worker until it completes.

## Fix

None of these endpoints actually `await` anything — the WebSocket router is the only genuine async handler (broadcasts are already dispatched via `BackgroundTask`). Declaring them plain `def` lets FastAPI run them in the threadpool, moving the blocking I/O off the event loop.

- `async def` → `def` on all 27 endpoints across every router **except** `websocket.py`.
- No controller/logic/DB changes. Same synchronous layer underneath.

## Verification

Injected a 0.4s delay into `query_controller.list_tasks` and fired 5 concurrent `GET /api/v1/tasks` requests against the real ASGI app (with lifespan):

| | endpoint | 5 concurrent requests | result |
|---|---|---|---|
| **before (main)** | `async def` | **~2.07s** (≈ 5 × 0.4s) | serialized — event loop blocked |
| **after (this PR)** | `def` | **~0.48s** (≈ 0.4s) | parallel — event loop free |

`ruff`, `mypy` (strict), and the full server test suite (325 passed) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)