### PR TITLE
fix(server): prevent broadcast crash on concurrent WebSocket disconnect

### DIFF
--- a/packages/taskdog-server/src/taskdog_server/websocket/connection_manager.py
+++ b/packages/taskdog-server/src/taskdog_server/websocket/connection_manager.py
@@ -60,9 +60,10 @@ class ConnectionManager:
         Args:
             message: The message dictionary to broadcast
         """
-        # Remove disconnected clients while broadcasting
+        # Snapshot the connections: sends yield control, so a concurrent
+        # disconnect must not mutate the dict we are iterating.
         disconnected = []
-        for client_id, connection in self.active_connections.items():
+        for client_id, connection in list(self.active_connections.items()):
             try:
                 await connection.send_json(message)
             except Exception as e:
@@ -85,11 +86,12 @@ class ConnectionManager:
             message: The message dictionary to send
             client_id: The target client identifier
         """
-        if client_id not in self.active_connections:
+        connection = self.active_connections.get(client_id)
+        if connection is None:
             return
 
         try:
-            await self.active_connections[client_id].send_json(message)
+            await connection.send_json(message)
         except Exception as e:
             # Connection is broken, remove it
             logger.warning(

--- a/packages/taskdog-server/tests/websocket/test_connection_manager.py
+++ b/packages/taskdog-server/tests/websocket/test_connection_manager.py
@@ -121,6 +121,38 @@ class TestConnectionManager:
         assert "client-1" in self.manager.active_connections
         assert "client-3" in self.manager.active_connections
 
+    async def test_broadcast_survives_concurrent_disconnect(self):
+        """A client disconnecting mid-broadcast must not abort the broadcast.
+
+        Reproduces the "dictionary changed size during iteration" bug: while
+        awaiting send_json for one client, another coroutine (the /ws endpoint
+        handling a WebSocketDisconnect) removes a different client.
+        """
+        # Arrange
+        mock_websocket1 = AsyncMock(spec=WebSocket)
+        mock_websocket2 = AsyncMock(spec=WebSocket)
+        mock_websocket3 = AsyncMock(spec=WebSocket)
+
+        await self.manager.connect("client-1", mock_websocket1)
+        await self.manager.connect("client-2", mock_websocket2)
+        await self.manager.connect("client-3", mock_websocket3)
+
+        # While sending to client-1, simulate client-3 disconnecting concurrently.
+        async def disconnect_other(_message):
+            self.manager.disconnect("client-3")
+
+        mock_websocket1.send_json.side_effect = disconnect_other
+
+        message = {"type": "task_updated", "task_id": 123}
+
+        # Act - must not raise RuntimeError
+        await self.manager.broadcast(message)
+
+        # Assert - remaining clients still received the message
+        mock_websocket1.send_json.assert_called_once_with(message)
+        mock_websocket2.send_json.assert_called_once_with(message)
+        assert "client-3" not in self.manager.active_connections
+
     async def test_send_personal_message_to_existing_client(self):
         """Test sending personal message to existing client."""
         # Arrange


### PR DESCRIPTION
## Problem

`ConnectionManager.broadcast` iterated `active_connections` directly while `await`ing `send_json`. Because the send yields control, a concurrent disconnect — e.g. the `/ws` endpoint handling `WebSocketDisconnect` during that await — mutates the dict mid-loop and raises `RuntimeError: dictionary changed size during iteration`. That aborts the broadcast, so every remaining client silently misses the event.

## Fix

- `broadcast`: iterate over a snapshot (`list(self.active_connections.items())`) so a concurrent disconnect can't mutate the dict being iterated.
- `send_personal_message`: replace the membership-check-then-index pattern with a single `dict.get()`, closing a `KeyError` window when a client disconnects between the check and the access.

## Test

Added `test_broadcast_survives_concurrent_disconnect`, which disconnects a different client from within a `send_json` side effect. It fails with `RuntimeError` before the fix and passes after. All 49 websocket tests pass; ruff and mypy are clean.