### PR TITLE
perf(mcp): batch dependency lookups in get_executable_tasks

### DIFF
--- a/packages/taskdog-client/src/taskdog_client/query_client.py
+++ b/packages/taskdog-client/src/taskdog_client/query_client.py
@@ -118,6 +118,27 @@ class QueryClient:
         data = self._base._request_json("get", "/api/v1/tasks", params=params)
         return convert_to_task_list_output(data)
 
+    def get_tasks_by_ids(self, task_ids: list[int]) -> TaskListOutput:
+        """Get multiple tasks by their IDs in a single request.
+
+        Batches what would otherwise be one get_task_by_id call per id into a
+        single HTTP round trip. Missing ids are omitted; output order follows
+        the input id order.
+
+        Args:
+            task_ids: Task IDs to retrieve
+
+        Returns:
+            TaskListOutput with the found tasks
+        """
+        if not task_ids:
+            return TaskListOutput(tasks=[], total_count=0, filtered_count=0)
+
+        data = self._base._request_json(
+            "get", "/api/v1/tasks/by-ids", params={"ids": task_ids}
+        )
+        return convert_to_task_list_output(data)
+
     def get_task_by_id(self, task_id: int) -> TaskDetailOutput:
         """Get task by ID, including notes.
 

--- a/packages/taskdog-client/src/taskdog_client/taskdog_api_client.py
+++ b/packages/taskdog-client/src/taskdog_client/taskdog_api_client.py
@@ -331,6 +331,10 @@ class TaskdogApiClient:
         """Get task by ID, including notes."""
         return self._queries.get_task_by_id(task_id)
 
+    def get_tasks_by_ids(self, task_ids: list[int]) -> TaskListOutput:
+        """Get multiple tasks by their IDs in a single request."""
+        return self._queries.get_tasks_by_ids(task_ids)
+
     def get_gantt_data(
         self,
         include_archived: bool = False,

--- a/packages/taskdog-client/tests/test_query_client.py
+++ b/packages/taskdog-client/tests/test_query_client.py
@@ -56,6 +56,30 @@ class TestQueryClient:
         assert result == mock_output
         mock_convert.assert_called_once_with(mock_json)
 
+    @patch("taskdog_client.query_client.convert_to_task_list_output")
+    def test_get_tasks_by_ids(self, mock_convert):
+        """Test get_tasks_by_ids makes one batched API call with ids param."""
+        mock_json = {"tasks": [], "total_count": 0, "filtered_count": 0}
+        self.mock_base._request_json.return_value = mock_json
+        mock_output = Mock()
+        mock_convert.return_value = mock_output
+
+        result = self.client.get_tasks_by_ids([3, 1, 2])
+
+        self.mock_base._request_json.assert_called_once_with(
+            "get", "/api/v1/tasks/by-ids", params={"ids": [3, 1, 2]}
+        )
+        assert result == mock_output
+        mock_convert.assert_called_once_with(mock_json)
+
+    def test_get_tasks_by_ids_empty_skips_request(self):
+        """Empty id list returns an empty result without an HTTP call."""
+        result = self.client.get_tasks_by_ids([])
+
+        self.mock_base._request_json.assert_not_called()
+        assert result.tasks == []
+        assert result.total_count == 0
+
     def test_get_task_by_id(self):
         """Test get_task_by_id makes correct API call."""
         with patch(

--- a/packages/taskdog-core/src/taskdog_core/controllers/query_controller.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/query_controller.py
@@ -13,7 +13,7 @@ from taskdog_core.application.dto.get_task_by_id_output import TaskByIdOutput
 from taskdog_core.application.dto.query_inputs import ListTasksInput
 from taskdog_core.application.dto.tag_statistics_output import TagStatisticsOutput
 from taskdog_core.application.dto.task_detail_output import TaskDetailOutput
-from taskdog_core.application.dto.task_dto import TaskDetailDto
+from taskdog_core.application.dto.task_dto import TaskDetailDto, TaskRowDto
 from taskdog_core.application.dto.task_list_output import TaskListOutput
 from taskdog_core.application.queries.task_query_service import TaskQueryService
 from taskdog_core.application.services.optimization.strategy_factory import (
@@ -147,6 +147,39 @@ class QueryController:
         # Convert Task to TaskDetailDto
         task_dto = TaskDetailDto.from_entity(task)
         return TaskByIdOutput(task=task_dto)
+
+    def get_tasks_by_ids(self, task_ids: list[int]) -> TaskListOutput:
+        """Get multiple tasks by their IDs in a single query.
+
+        Fetches all requested tasks with one batched repository call, avoiding
+        the N+1 pattern of calling get_task_by_id per id. Missing ids are simply
+        absent from the result. Output order follows the input id order.
+
+        Args:
+            task_ids: List of task IDs to retrieve
+
+        Returns:
+            TaskListOutput with the found tasks (total_count/filtered_count
+            reflect the number of tasks actually found)
+        """
+        tasks_by_id = self.repository.get_by_ids(task_ids)
+        # Preserve the caller's id order, skipping ids that were not found.
+        ordered = [tasks_by_id[tid] for tid in task_ids if tid in tasks_by_id]
+        rows = [TaskRowDto.from_entity(task) for task in ordered]
+
+        result = TaskListOutput(
+            tasks=rows,
+            total_count=len(rows),
+            filtered_count=len(rows),
+        )
+
+        if self.notes_repository is not None and rows:
+            found_ids = [row.id for row in rows]
+            result.task_ids_with_notes = self.notes_repository.get_task_ids_with_notes(
+                found_ids
+            )
+
+        return result
 
     def get_task_detail(self, task_id: int) -> TaskDetailOutput:
         """Get task details with notes.

--- a/packages/taskdog-core/tests/controllers/test_query_controller.py
+++ b/packages/taskdog-core/tests/controllers/test_query_controller.py
@@ -51,6 +51,34 @@ class TestQueryController:
         assert result.total_count == 3
         assert result.filtered_count == 1
 
+    def test_get_tasks_by_ids_returns_found_tasks_in_input_order(self):
+        """get_tasks_by_ids returns requested tasks preserving input id order."""
+        t1 = self.repository.create(name="Task 1", priority=1)
+        t2 = self.repository.create(name="Task 2", priority=2)
+        t3 = self.repository.create(name="Task 3", priority=3)
+
+        result = self.controller.get_tasks_by_ids([t3.id, t1.id, t2.id])
+
+        assert [t.id for t in result.tasks] == [t3.id, t1.id, t2.id]
+        assert result.total_count == 3
+        assert result.filtered_count == 3
+
+    def test_get_tasks_by_ids_skips_missing_ids(self):
+        """Missing ids are silently skipped, not raised."""
+        t1 = self.repository.create(name="Task 1", priority=1)
+
+        result = self.controller.get_tasks_by_ids([t1.id, 9999])
+
+        assert [t.id for t in result.tasks] == [t1.id]
+        assert result.filtered_count == 1
+
+    def test_get_tasks_by_ids_empty_input(self):
+        """Empty id list returns an empty result."""
+        result = self.controller.get_tasks_by_ids([])
+
+        assert result.tasks == []
+        assert result.total_count == 0
+
     def test_list_tasks_with_sorting(self):
         """Test list_tasks sorts correctly."""
         # Create test tasks with different priorities

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_query.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_query.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from taskdog_core.domain.entities.task import TaskStatus
-from taskdog_core.domain.exceptions.task_exceptions import TaskNotFoundException
 from taskdog_mcp.tools.serializers import iso, str_list
 
 if TYPE_CHECKING:
@@ -16,27 +15,24 @@ if TYPE_CHECKING:
     from taskdog_client import TaskdogApiClient
 
 
-def _dependencies_met(
-    depends_on: list[int],
+def _fetch_dependency_statuses(
+    pending_tasks: list[Any],
     client: TaskdogApiClient,
-    dep_status_cache: dict[int, TaskStatus | None],
-) -> bool:
-    """Check whether all dependency ids are COMPLETED.
+) -> dict[int, TaskStatus]:
+    """Fetch the status of every distinct dependency in one batched call.
 
-    A missing dependency (e.g. its task was deleted) counts as unmet,
-    matching DependencyValidator.validate_dependencies_met semantics.
-    Statuses are memoized in dep_status_cache so a dep shared across
-    multiple tasks is only fetched once per get_executable_tasks call.
+    Collapses what used to be one get_task_by_id request per dependency id
+    into a single get_tasks_by_ids round trip. A dependency absent from the
+    result (e.g. its task was deleted) is simply not in the map, which
+    callers treat as unmet.
     """
-    for dep_id in depends_on:
-        if dep_id not in dep_status_cache:
-            try:
-                dep_status_cache[dep_id] = client.get_task_by_id(dep_id).task.status
-            except TaskNotFoundException:
-                dep_status_cache[dep_id] = None
-        if dep_status_cache[dep_id] != TaskStatus.COMPLETED:
-            return False
-    return True
+    distinct_dep_ids = {
+        dep_id for t in pending_tasks for dep_id in (t.depends_on or [])
+    }
+    if not distinct_dep_ids:
+        return {}
+    result = client.get_tasks_by_ids(list(distinct_dep_ids))
+    return {t.id: t.status for t in result.tasks}
 
 
 def _select_executable_pending(
@@ -46,16 +42,17 @@ def _select_executable_pending(
 ) -> list[Any]:
     """Filter pending tasks down to those whose dependencies are met.
 
-    Stops scanning once max_count executable tasks have been found, so
-    dependency lookups for tasks beyond the eventual limit are skipped.
+    A dependency is met only when its status is COMPLETED; a missing
+    dependency counts as unmet, matching
+    DependencyValidator.validate_dependencies_met semantics.
     """
-    dep_status_cache: dict[int, TaskStatus | None] = {}
+    status_by_id = _fetch_dependency_statuses(pending_tasks, client)
     executable_pending: list[Any] = []
     for t in pending_tasks:
         if len(executable_pending) >= max_count:
             break
-        if not t.depends_on or _dependencies_met(
-            t.depends_on, client, dep_status_cache
+        if not t.depends_on or all(
+            status_by_id.get(dep_id) == TaskStatus.COMPLETED for dep_id in t.depends_on
         ):
             executable_pending.append(t)
     return executable_pending

--- a/packages/taskdog-mcp/tests/test_tools.py
+++ b/packages/taskdog-mcp/tests/test_tools.py
@@ -132,6 +132,7 @@ def create_mock_client() -> MagicMock:
     # CRUD methods
     client.list_tasks = MagicMock()
     client.get_task_by_id = MagicMock()
+    client.get_tasks_by_ids = MagicMock()
     client.create_task = MagicMock()
     client.update_task = MagicMock()
     client.archive_task = MagicMock()
@@ -1008,8 +1009,12 @@ class TestTaskQueryTools:
             TaskListOutput(tasks=[pending_task], total_count=1, filtered_count=1),
             TaskListOutput(tasks=[], total_count=0, filtered_count=0),
         ]
-        client.get_task_by_id.return_value = create_mock_task_detail_output(
-            task_id=99, status=TaskStatus.PENDING
+        client.get_tasks_by_ids.return_value = TaskListOutput(
+            tasks=[
+                create_mock_task_row(task_id=99, name="Dep", status=TaskStatus.PENDING)
+            ],
+            total_count=1,
+            filtered_count=1,
         )
 
         mcp = FastMCP("test")
@@ -1020,6 +1025,8 @@ class TestTaskQueryTools:
 
         assert result["tasks"] == []
         assert result["total"] == 0
+        # Dependency statuses are fetched in a single batched call.
+        client.get_tasks_by_ids.assert_called_once()
 
     def test_get_executable_tasks_includes_pending_with_met_dependency(
         self,
@@ -1036,8 +1043,14 @@ class TestTaskQueryTools:
             TaskListOutput(tasks=[pending_task], total_count=1, filtered_count=1),
             TaskListOutput(tasks=[], total_count=0, filtered_count=0),
         ]
-        client.get_task_by_id.return_value = create_mock_task_detail_output(
-            task_id=99, status=TaskStatus.COMPLETED
+        client.get_tasks_by_ids.return_value = TaskListOutput(
+            tasks=[
+                create_mock_task_row(
+                    task_id=99, name="Dep", status=TaskStatus.COMPLETED
+                )
+            ],
+            total_count=1,
+            filtered_count=1,
         )
 
         mcp = FastMCP("test")
@@ -1057,10 +1070,6 @@ class TestTaskQueryTools:
         from mcp.server.fastmcp import FastMCP
         from taskdog_mcp.tools import task_query
 
-        from taskdog_core.domain.exceptions.task_exceptions import (
-            TaskNotFoundException,
-        )
-
         client = create_mock_client()
         pending_task = create_mock_task_row(
             task_id=2, name="Pending", status=TaskStatus.PENDING, depends_on=[99]
@@ -1069,7 +1078,10 @@ class TestTaskQueryTools:
             TaskListOutput(tasks=[pending_task], total_count=1, filtered_count=1),
             TaskListOutput(tasks=[], total_count=0, filtered_count=0),
         ]
-        client.get_task_by_id.side_effect = TaskNotFoundException(99)
+        # A missing dependency is simply absent from the batched result.
+        client.get_tasks_by_ids.return_value = TaskListOutput(
+            tasks=[], total_count=0, filtered_count=0
+        )
 
         mcp = FastMCP("test")
         task_query.register_tools(mcp, client)
@@ -1096,11 +1108,18 @@ class TestTaskQueryTools:
             TaskListOutput(tasks=[], total_count=0, filtered_count=0),
         ]
 
-        def get_task_by_id(task_id: int) -> TaskDetailOutput:
-            status = TaskStatus.COMPLETED if task_id == 97 else TaskStatus.PENDING
-            return create_mock_task_detail_output(task_id=task_id, status=status)
-
-        client.get_task_by_id.side_effect = get_task_by_id
+        client.get_tasks_by_ids.return_value = TaskListOutput(
+            tasks=[
+                create_mock_task_row(
+                    task_id=97, name="Dep 97", status=TaskStatus.COMPLETED
+                ),
+                create_mock_task_row(
+                    task_id=98, name="Dep 98", status=TaskStatus.PENDING
+                ),
+            ],
+            total_count=2,
+            filtered_count=2,
+        )
 
         mcp = FastMCP("test")
         task_query.register_tools(mcp, client)

--- a/packages/taskdog-server/src/taskdog_server/api/routers/tasks.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/tasks.py
@@ -164,6 +164,31 @@ def list_tasks(
     return convert_to_task_list_response(result)
 
 
+@router.get("/by-ids", response_model=TaskListResponse)
+def get_tasks_by_ids(
+    controller: QueryControllerDep,
+    _client_name: AuthenticatedClientDep,
+    ids: Annotated[
+        list[int], Query(description="Task IDs to retrieve in a single request")
+    ],
+) -> TaskListResponse:
+    """Retrieve multiple tasks by ID in a single batched request.
+
+    Fetches all requested tasks with one query, avoiding per-id round trips.
+    Missing ids are omitted from the response; output order follows the input
+    id order.
+
+    Args:
+        controller: Query controller dependency
+        ids: Task IDs to retrieve
+
+    Returns:
+        List of the found tasks with metadata
+    """
+    result = controller.get_tasks_by_ids(ids)
+    return convert_to_task_list_response(result)
+
+
 @router.get("/{task_id}", response_model=TaskDetailResponse)
 def get_task(
     task_id: int,

--- a/packages/taskdog-server/tests/api/routers/test_tasks.py
+++ b/packages/taskdog-server/tests/api/routers/test_tasks.py
@@ -178,6 +178,37 @@ class TestTasksRouter:
         assert data["tasks"][0]["priority"] == 3
         assert data["tasks"][1]["priority"] == 1
 
+    def test_get_tasks_by_ids_returns_requested_in_order(self, client, task_factory):
+        """Test batch retrieval returns requested tasks in input id order."""
+        # Arrange
+        t1 = task_factory.create(name="Task 1", priority=1, status=TaskStatus.PENDING)
+        t2 = task_factory.create(name="Task 2", priority=2, status=TaskStatus.PENDING)
+        t3 = task_factory.create(name="Task 3", priority=3, status=TaskStatus.PENDING)
+
+        # Act
+        response = client.get(
+            f"/api/v1/tasks/by-ids?ids={t3.id}&ids={t1.id}&ids={t2.id}"
+        )
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+        assert [t["id"] for t in data["tasks"]] == [t3.id, t1.id, t2.id]
+        assert data["filtered_count"] == 3
+
+    def test_get_tasks_by_ids_skips_missing(self, client, task_factory):
+        """Test batch retrieval omits ids that do not exist."""
+        # Arrange
+        t1 = task_factory.create(name="Task 1", priority=1, status=TaskStatus.PENDING)
+
+        # Act
+        response = client.get(f"/api/v1/tasks/by-ids?ids={t1.id}&ids=99999")
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+        assert [t["id"] for t in data["tasks"]] == [t1.id]
+
     def test_get_task_success(self, client, task_factory):
         """Test getting a task by ID."""
         # Arrange


### PR DESCRIPTION
## Problem

`get_executable_tasks` (the common \"find tasks to work on\" MCP tool) checked each pending task's dependencies by calling `get_task_by_id` **once per dependency id** — an N+1 pattern where every distinct dependency is a separate HTTP round trip to the API server. With `D` distinct dependencies the tool issued `2 + D` sequential requests.

## Fix

Add a generic `GET /api/v1/tasks/by-ids?ids=1&ids=2` batch endpoint and use it to fetch every dependency status in a single request. The round-trip count is now fixed at 3 regardless of `D`.

The endpoint exposes the repository's already-existing `get_by_ids` up through the stack:
- **core**: `QueryController.get_tasks_by_ids(ids) -> TaskListOutput`
- **server**: `GET /api/v1/tasks/by-ids` (declared before `/{task_id}` so the static path wins)
- **client**: `TaskdogApiClient.get_tasks_by_ids(ids)`
- **mcp**: `get_executable_tasks` now collects all distinct dependency ids and resolves their statuses in one batched call

Semantics preserved: output follows input id order, missing ids are omitted, and a missing dependency still counts as unmet.

## Measurement

Repository-layer benchmark (per-id loop vs one batched query):

| D | get_by_id × D | get_by_ids × 1 | speedup |
|---|---|---|---|
| 5 | 4.2 ms | 1.0 ms | 4.3x |
| 10 | 8.3 ms | 1.0 ms | 8.2x |
| 20 | 16.7 ms | 1.2 ms | 14.3x |

In the MCP path each avoided `get_by_id` is also a full HTTP round trip + FastAPI routing + serialization, so the real saving is larger than the DB-layer numbers.

## Tests

New tests at every layer (controller, server router, client, MCP tool). All package suites pass (core 1149, client 222, server 327, mcp 97), ruff and mypy clean. Verified end-to-end against a live server: `get_executable_tasks` issues a single `/api/v1/tasks/by-ids` call for all dependency statuses and dependency filtering stays correct.