### PR TITLE
fix(core): raise on invalid status filter instead of silently dropping it

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/queries/task_filter_builder.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/task_filter_builder.py
@@ -16,6 +16,7 @@ from taskdog_core.application.queries.filters.non_archived_filter import (
 from taskdog_core.application.queries.filters.status_filter import StatusFilter
 from taskdog_core.application.queries.filters.tag_filter import TagFilter
 from taskdog_core.domain.entities.task import TaskStatus
+from taskdog_core.domain.exceptions.task_exceptions import TaskValidationError
 
 if TYPE_CHECKING:
     from taskdog_core.application.dto.query_inputs import ListTasksInput
@@ -58,13 +59,15 @@ class TaskFilterBuilder:
         # Status filter
         if input_dto.status:
             try:
-                status_filter = StatusFilter(
-                    status=TaskStatus[input_dto.status.upper()]
-                )
-                filter_obj = TaskFilterBuilder._compose(filter_obj, status_filter)
+                status = TaskStatus[input_dto.status.upper()]
             except KeyError:
-                # Invalid status value - skip status filter
-                pass
+                valid = ", ".join(s.name for s in TaskStatus)
+                raise TaskValidationError(
+                    f"Invalid status filter '{input_dto.status}'. "
+                    f"Valid values are: {valid}"
+                ) from None
+            status_filter = StatusFilter(status=status)
+            filter_obj = TaskFilterBuilder._compose(filter_obj, status_filter)
 
         # Tag filter
         if input_dto.tags:

--- a/packages/taskdog-core/tests/application/queries/test_task_filter_builder.py
+++ b/packages/taskdog-core/tests/application/queries/test_task_filter_builder.py
@@ -2,9 +2,12 @@
 
 from datetime import date, datetime, timedelta
 
+import pytest
+
 from taskdog_core.application.dto.query_inputs import ListTasksInput
 from taskdog_core.application.queries.task_filter_builder import TaskFilterBuilder
 from taskdog_core.domain.entities.task import Task, TaskStatus
+from taskdog_core.domain.exceptions.task_exceptions import TaskValidationError
 
 
 class TestTaskFilterBuilder:
@@ -44,6 +47,23 @@ class TestTaskFilterBuilder:
 
         assert self._matches(result, pending_task) is True
         assert self._matches(result, completed_task) is False
+
+    def test_build_raises_on_invalid_status(self):
+        """An unrecognized status value raises instead of being silently dropped.
+
+        Regression for #1097: a typo such as ``IN_PROGERSS`` must not fall through
+        to returning all tasks with no status filter applied.
+        """
+        input_dto = ListTasksInput(include_archived=True, status="IN_PROGERSS")
+
+        with pytest.raises(TaskValidationError) as exc_info:
+            TaskFilterBuilder.build(input_dto)
+
+        message = str(exc_info.value)
+        assert "IN_PROGERSS" in message
+        # The error lists the valid values so clients/agents can self-correct.
+        for valid in ("PENDING", "IN_PROGRESS", "COMPLETED", "CANCELED"):
+            assert valid in message
 
     def test_build_creates_tag_filter(self):
         """Test build creates TagFilter when tags are specified."""


### PR DESCRIPTION
## Summary

`TaskFilterBuilder` caught an unrecognized `status` string with `except KeyError: pass`, so a malformed status filter (a typo such as `status=IN_PROGERSS`) was **silently ignored** and the query returned **all** tasks instead of erroring. Programmatic clients/agents received a wrong-but-plausible result set with zero diagnostic.

This raises `TaskValidationError` (already mapped to **HTTP 400** by the server's app-level exception handler) listing the valid status values, so callers can distinguish an invalid filter from other failures and self-correct.

## Changes

- `task_filter_builder.py`: on unknown status, raise `TaskValidationError` with the offending value and the list of valid values instead of swallowing the `KeyError`
- Added `test_build_raises_on_invalid_status` regression test

## Verification

- `pytest tests/` (core) — 1150 passed
- `ruff check` / `mypy` — clean
- **Live server**: `GET /api/v1/tasks?status=IN_PROGERSS` → `400 {"detail":"Invalid status filter 'IN_PROGERSS'. Valid values are: PENDING, IN_PROGRESS, COMPLETED, CANCELED"}`; `status=PENDING` → `200`

Fixes #1097

🤖 Generated with [Claude Code](https://claude.com/claude-code)