### PR TITLE
refactor(core): collapse lifecycle controller pass-throughs into execute_lifecycle

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/services/bulk_operation_service.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/bulk_operation_service.py
@@ -11,16 +11,9 @@ from taskdog_core.application.dto.bulk_operation_output import (
     BulkTaskResultOutput,
 )
 from taskdog_core.application.use_cases.archive_task import ArchiveTaskUseCase
-from taskdog_core.application.use_cases.cancel_task import CancelTaskUseCase
-from taskdog_core.application.use_cases.complete_task import CompleteTaskUseCase
-from taskdog_core.application.use_cases.pause_task import PauseTaskUseCase
+from taskdog_core.application.use_cases.lifecycle_registry import LIFECYCLE_USE_CASES
 from taskdog_core.application.use_cases.remove_task import RemoveTaskUseCase
-from taskdog_core.application.use_cases.reopen_task import ReopenTaskUseCase
 from taskdog_core.application.use_cases.restore_task import RestoreTaskUseCase
-from taskdog_core.application.use_cases.start_task import StartTaskUseCase
-from taskdog_core.application.use_cases.status_change_use_case import (
-    StatusChangeUseCase,
-)
 from taskdog_core.domain.exceptions.task_exceptions import (
     TaskAlreadyFinishedError,
     TaskNotFoundException,
@@ -35,14 +28,6 @@ _TASK_ERRORS = (
     TaskAlreadyFinishedError,
     TaskNotStartedError,
 )
-
-_LIFECYCLE_USE_CASES: dict[str, type[StatusChangeUseCase[SingleTaskInput]]] = {
-    "start": StartTaskUseCase,
-    "complete": CompleteTaskUseCase,
-    "pause": PauseTaskUseCase,
-    "cancel": CancelTaskUseCase,
-    "reopen": ReopenTaskUseCase,
-}
 
 
 class BulkOperationService:
@@ -71,7 +56,7 @@ class BulkOperationService:
         Raises:
             ValueError: If operation is not a valid lifecycle operation.
         """
-        use_case_cls = _LIFECYCLE_USE_CASES.get(operation)
+        use_case_cls = LIFECYCLE_USE_CASES.get(operation)
         if use_case_cls is None:
             raise ValueError(f"Invalid lifecycle operation: {operation}")
 

--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/lifecycle_registry.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/lifecycle_registry.py
@@ -1,0 +1,19 @@
+"""Registry mapping lifecycle operation names to their status-change use cases."""
+
+from taskdog_core.application.dto.base import SingleTaskInput
+from taskdog_core.application.use_cases.cancel_task import CancelTaskUseCase
+from taskdog_core.application.use_cases.complete_task import CompleteTaskUseCase
+from taskdog_core.application.use_cases.pause_task import PauseTaskUseCase
+from taskdog_core.application.use_cases.reopen_task import ReopenTaskUseCase
+from taskdog_core.application.use_cases.start_task import StartTaskUseCase
+from taskdog_core.application.use_cases.status_change_use_case import (
+    StatusChangeUseCase,
+)
+
+LIFECYCLE_USE_CASES: dict[str, type[StatusChangeUseCase[SingleTaskInput]]] = {
+    "start": StartTaskUseCase,
+    "complete": CompleteTaskUseCase,
+    "pause": PauseTaskUseCase,
+    "cancel": CancelTaskUseCase,
+    "reopen": ReopenTaskUseCase,
+}

--- a/packages/taskdog-core/src/taskdog_core/controllers/task_lifecycle_controller.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/task_lifecycle_controller.py
@@ -8,7 +8,6 @@ This controller handles all task lifecycle operations (status changes with time 
 - reopen_task: Reset finished task to PENDING, clear timestamps
 """
 
-from collections.abc import Callable
 from datetime import datetime
 from types import EllipsisType
 
@@ -16,22 +15,9 @@ from taskdog_core.application.dto.base import SingleTaskInput
 from taskdog_core.application.dto.fix_actual_times_input import FixActualTimesInput
 from taskdog_core.application.dto.status_change_output import StatusChangeOutput
 from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
-from taskdog_core.application.use_cases.cancel_task import CancelTaskUseCase
-from taskdog_core.application.use_cases.complete_task import CompleteTaskUseCase
 from taskdog_core.application.use_cases.fix_actual_times import FixActualTimesUseCase
-from taskdog_core.application.use_cases.pause_task import PauseTaskUseCase
-from taskdog_core.application.use_cases.reopen_task import ReopenTaskUseCase
-from taskdog_core.application.use_cases.start_task import StartTaskUseCase
-from taskdog_core.application.use_cases.status_change_use_case import (
-    StatusChangeUseCase,
-)
+from taskdog_core.application.use_cases.lifecycle_registry import LIFECYCLE_USE_CASES
 from taskdog_core.controllers.base_controller import BaseTaskController
-from taskdog_core.domain.repositories.task_repository import TaskRepository
-
-# Type alias for use case factory function
-type StatusChangeUseCaseFactory = Callable[
-    [TaskRepository], StatusChangeUseCase[SingleTaskInput]
-]
 
 
 class TaskLifecycleController(BaseTaskController):
@@ -51,107 +37,26 @@ class TaskLifecycleController(BaseTaskController):
         config: Application configuration (inherited from BaseTaskController)
     """
 
-    def _execute_status_change(
-        self,
-        use_case_factory: StatusChangeUseCaseFactory,
-        task_id: int,
-    ) -> StatusChangeOutput:
-        """Execute a status change use case.
+    def execute_lifecycle(self, operation: str, task_id: int) -> StatusChangeOutput:
+        """Execute a lifecycle status change on a task.
 
         Args:
-            use_case_factory: Factory function (use case class) to instantiate
-            task_id: ID of the task to modify
+            operation: One of start, complete, pause, cancel, reopen.
+            task_id: ID of the task to modify.
 
         Returns:
-            StatusChangeOutput containing the updated task and old status
+            StatusChangeOutput containing the updated task and old status.
+
+        Raises:
+            ValueError: If operation is not a valid lifecycle operation.
+            TaskNotFoundException: If task not found.
+            TaskValidationError: If the transition is not allowed.
         """
-        use_case = use_case_factory(self.repository)
+        use_case_cls = LIFECYCLE_USE_CASES.get(operation)
+        if use_case_cls is None:
+            raise ValueError(f"Invalid lifecycle operation: {operation}")
+        use_case = use_case_cls(self.repository)
         return use_case.execute(SingleTaskInput(task_id=task_id))
-
-    def start_task(self, task_id: int) -> StatusChangeOutput:
-        """Start a task.
-
-        Changes task status to IN_PROGRESS and records actual start time.
-
-        Args:
-            task_id: ID of the task to start
-
-        Returns:
-            StatusChangeOutput containing the updated task and old status
-
-        Raises:
-            TaskNotFoundException: If task not found
-            TaskValidationError: If task cannot be started
-        """
-        return self._execute_status_change(StartTaskUseCase, task_id)
-
-    def complete_task(self, task_id: int) -> StatusChangeOutput:
-        """Complete a task.
-
-        Changes task status to COMPLETED and records actual end time.
-
-        Args:
-            task_id: ID of the task to complete
-
-        Returns:
-            StatusChangeOutput containing the updated task and old status
-
-        Raises:
-            TaskNotFoundException: If task not found
-            TaskValidationError: If task cannot be completed
-        """
-        return self._execute_status_change(CompleteTaskUseCase, task_id)
-
-    def pause_task(self, task_id: int) -> StatusChangeOutput:
-        """Pause a task.
-
-        Changes task status to PENDING and clears actual start/end times.
-
-        Args:
-            task_id: ID of the task to pause
-
-        Returns:
-            StatusChangeOutput containing the updated task and old status
-
-        Raises:
-            TaskNotFoundException: If task not found
-            TaskValidationError: If task cannot be paused
-        """
-        return self._execute_status_change(PauseTaskUseCase, task_id)
-
-    def cancel_task(self, task_id: int) -> StatusChangeOutput:
-        """Cancel a task.
-
-        Changes task status to CANCELED and records actual end time.
-
-        Args:
-            task_id: ID of the task to cancel
-
-        Returns:
-            StatusChangeOutput containing the updated task and old status
-
-        Raises:
-            TaskNotFoundException: If task not found
-            TaskValidationError: If task cannot be canceled
-        """
-        return self._execute_status_change(CancelTaskUseCase, task_id)
-
-    def reopen_task(self, task_id: int) -> StatusChangeOutput:
-        """Reopen a task.
-
-        Changes task status to PENDING and clears actual start/end times.
-
-        Args:
-            task_id: ID of the task to reopen
-
-        Returns:
-            StatusChangeOutput containing the updated task and old status
-
-        Raises:
-            TaskNotFoundException: If task not found
-            TaskValidationError: If task cannot be reopened
-        """
-        return self._execute_status_change(ReopenTaskUseCase, task_id)
 
     def fix_actual_times(
         self,

--- a/packages/taskdog-core/tests/controllers/test_task_lifecycle_controller.py
+++ b/packages/taskdog-core/tests/controllers/test_task_lifecycle_controller.py
@@ -26,39 +26,34 @@ class TestTaskLifecycleController:
         )
 
     @pytest.mark.parametrize(
-        "operation_name,method_name,initial_status,actual_start,actual_end",
+        "operation,initial_status,actual_start,actual_end",
         [
             (
-                "start_task",
-                "start_task",
+                "start",
                 TaskStatus.PENDING,
                 None,
                 None,
             ),
             (
-                "complete_task",
-                "complete_task",
+                "complete",
                 TaskStatus.IN_PROGRESS,
                 datetime(2025, 1, 1, 9, 0, 0),
                 None,
             ),
             (
-                "pause_task",
-                "pause_task",
+                "pause",
                 TaskStatus.IN_PROGRESS,
                 datetime(2025, 1, 1, 9, 0, 0),
                 None,
             ),
             (
-                "cancel_task",
-                "cancel_task",
+                "cancel",
                 TaskStatus.IN_PROGRESS,
                 datetime(2025, 1, 1, 9, 0, 0),
                 None,
             ),
             (
-                "reopen_task",
-                "reopen_task",
+                "reopen",
                 TaskStatus.COMPLETED,
                 datetime(2025, 1, 1, 9, 0, 0),
                 datetime(2025, 1, 1, 17, 0, 0),
@@ -66,7 +61,7 @@ class TestTaskLifecycleController:
         ],
     )
     def test_lifecycle_operation_returns_status_change_output(
-        self, operation_name, method_name, initial_status, actual_start, actual_end
+        self, operation, initial_status, actual_start, actual_end
     ):
         """Test that lifecycle operations return StatusChangeOutput."""
         # Arrange
@@ -83,14 +78,18 @@ class TestTaskLifecycleController:
         self.repository.save.return_value = None
 
         # Act
-        method = getattr(self.controller, method_name)
-        result = method(task_id)
+        result = self.controller.execute_lifecycle(operation, task_id)
 
         # Assert
         assert result is not None
         assert result.task.id == task_id
         assert result.task.name == "Test Task"
         assert result.old_status == initial_status
+
+    def test_invalid_operation_raises_value_error(self):
+        """Test that an unknown lifecycle operation raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid lifecycle operation"):
+            self.controller.execute_lifecycle("bogus", 1)
 
     def test_controller_inherits_from_base_controller(self):
         """Test that controller has repository and config from base class."""

--- a/packages/taskdog-server/src/taskdog_server/api/routers/lifecycle.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/lifecycle.py
@@ -55,8 +55,7 @@ def _create_lifecycle_endpoint(op: LifecycleOperation) -> None:
         audit_controller: AuditLogControllerDep,
         client_name: AuthenticatedClientDep,
     ) -> TaskOperationResponse:
-        controller_method = getattr(controller, f"{op.name}_task")
-        result = controller_method(task_id)
+        result = controller.execute_lifecycle(op.name, task_id)
         broadcaster.task_status_changed(
             result.task, result.old_status.value, client_name
         )


### PR DESCRIPTION
## Summary

`TaskLifecycleController` had five pure pass-through methods (`start_task`/`complete_task`/`pause_task`/`cancel_task`/`reopen_task`), each just forwarding to `_execute_status_change(XxxUseCase, task_id)`. This mirrored a name→use-case dict that already existed in `BulkOperationService` and a loop-generated set of routes in the server — the controller was the only place still hand-writing each operation.

This collapses them into a single `execute_lifecycle(operation, task_id)` backed by a shared `LIFECYCLE_USE_CASES` registry:

- New `application/use_cases/lifecycle_registry.py` holds the single name→use-case mapping.
- `BulkOperationService` now imports that registry instead of duplicating the dict.
- The lifecycle router calls the typed `controller.execute_lifecycle(op.name, task_id)` instead of `getattr(controller, f"{op.name}_task")`, improving type safety.

No behavior change. **Net -93 LOC** (142 deleted / 49 added).

## Verification

- `ruff check` / `ruff format`: pass
- `mypy` (core, server): pass
- `pytest`: core 1144 / server 329 passed
- Smoke test against the real FastAPI app + SQLite: `start → complete → reopen → cancel` all transition correctly; invalid transition (canceled → start) rejected with 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)