### PR TITLE
refactor(core): delegate TaskRowDto.to_dict to model_dump

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/dto/task_dto.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/task_dto.py
@@ -127,34 +127,7 @@ class TaskRowDto(BaseModel):
         Returns:
             Dictionary with all task fields, using string values for enums and ISO format for datetimes.
         """
-        return {
-            "id": self.id,
-            "name": self.name,
-            "priority": self.priority,
-            "status": self.status.value,
-            "planned_start": self.planned_start.isoformat()
-            if self.planned_start
-            else None,
-            "planned_end": self.planned_end.isoformat() if self.planned_end else None,
-            "deadline": self.deadline.isoformat() if self.deadline else None,
-            "actual_start": self.actual_start.isoformat()
-            if self.actual_start
-            else None,
-            "actual_end": self.actual_end.isoformat() if self.actual_end else None,
-            "estimated_duration": self.estimated_duration,
-            "actual_duration_hours": self.actual_duration_hours,
-            "is_fixed": self.is_fixed,
-            "depends_on": self.depends_on,
-            "tags": self.tags,
-            "daily_allocations": {
-                k.isoformat(): v for k, v in self.daily_allocations.items()
-            },
-            "is_archived": self.is_archived,
-            "is_finished": self.is_finished,
-            "created_at": self.created_at.isoformat(),
-            "updated_at": self.updated_at.isoformat(),
-            "has_notes": self.has_notes,
-        }
+        return self.model_dump(mode="json")
 
 
 class TaskDetailDto(BaseModel):


### PR DESCRIPTION
## Summary

`TaskRowDto.to_dict()` hand-mapped all 20 fields, reproducing exactly what Pydantic's `model_dump(mode="json")` already does: enums → `.value`, datetimes and `date` keys → ISO strings, primitives untouched. Replaced the 28-line body with a one-line delegation.

Verified byte-for-byte equal (keys **and** values) on a fully populated row before changing, so exporters (CSV/JSON/Markdown) see identical output.

**Net -27 LOC**, no behavior change.

## Context

This was scoped as part of a broader "collapse `from_entity`/`to_dict` mapping" cleanup. On inspection the `from_entity`/`from_task` methods can **not** be safely reduced to `model_validate`: they carry a domain `id is None` guard (contract-tested), a `date → isoformat` key transform for `daily_allocations`, and a `is_schedulable(force_override=...)` **method** call that attribute-based validation can't express. Only `to_dict` was a genuine 1:1 duplication, so only that is touched here.

## Verification

- `ruff check` / `mypy` (core): pass
- `pytest`: core 1144 passed; UI exporters + presenters 105 passed
- Pre-change equality check: `to_dict() == model_dump(mode="json")` (keys and values identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)