### PR TITLE
style(tui): balance gantt widget height with task table

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/styles/main.tcss
+++ b/packages/taskdog-ui/src/taskdog/tui/styles/main.tcss
@@ -19,7 +19,7 @@ MainScreen {
 /* Gantt chart - main display area */
 #gantt-widget {
     width: 100%;
-    height: 3fr;
+    height: 2.5fr;
     background: transparent;
     border: round $primary;
     margin-bottom: 1;


### PR DESCRIPTION
## Summary

Reduce the TUI gantt widget height from `3fr` to `2.5fr` so it sits closer to the task table (`2fr`), giving the two panes a more balanced layout.

## Changes

- `main.tcss`: `#gantt-widget` height `3fr` → `2.5fr`

## Test plan

- Launch the TUI and confirm the gantt and task-table panes are more evenly sized.