### PR TITLE
style(tui): brighten task table background on focus

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/styles/main.tcss
+++ b/packages/taskdog-ui/src/taskdog/tui/styles/main.tcss
@@ -71,4 +71,5 @@ MainScreen {
 
 #task-table:focus {
     border: round $accent;
+    background: $surface;
 }


### PR DESCRIPTION
## Summary

The task table gave no visible focus feedback on its background, unlike the gantt table and the footer search input which both brighten when focused.

## Cause

Textual brightens a focused widget via `background-tint: $foreground 5%`, which blends a tint into the widget's **existing** background color. `#task-table` was set to `background: transparent`, so there was no base color to tint and focusing it produced no background change. The gantt table (`#gantt-table`) and the search `Input` keep the default `$surface` background, so their tint is visible.

## Fix

Add `background: $surface` to `#task-table:focus`. The table stays transparent when idle (preserving the overall transparent theme) and brightens to `$surface` when focused, matching the other focusable widgets.

## Verification

Confirmed visually in the running TUI.