### PR TITLE
test(e2e): concurrent-write consistency contract

### DIFF
--- a/tests/e2e/test_concurrency.py
+++ b/tests/e2e/test_concurrency.py
@@ -1,0 +1,60 @@
+"""E2E: concurrent writes stay consistent through the real server + SQLite.
+
+Taskdog is used de-facto multi-writer (one person driving several AI agents at
+once), so these lock in the contract that concurrent HTTP writes neither error
+nor lose/corrupt data. It holds today because the engine runs SQLite in WAL mode
+with a 30s busy_timeout (see engine_factory.py); these tests would fail if that
+serialization guarantee regressed.
+
+Each thread uses its own TaskdogApiClient because a client wraps a single
+httpx.Client that must not be shared across threads.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+from taskdog_client.taskdog_api_client import TaskdogApiClient
+
+_WRITERS = 20
+
+
+def test_concurrent_updates_to_same_task_stay_consistent(
+    client: TaskdogApiClient, live_server: str
+) -> None:
+    task = client.create_task(name="contended", priority=1)
+    priorities = list(range(2, 2 + _WRITERS))
+
+    def update_priority(priority: int) -> None:
+        api = TaskdogApiClient(base_url=live_server)
+        try:
+            api.update_task(task.id, priority=priority)
+        finally:
+            api.close()
+
+    with ThreadPoolExecutor(max_workers=_WRITERS) as pool:
+        list(pool.map(update_priority, priorities))
+
+    fetched = client.get_task_by_id(task.id)
+    # Last-writer-wins: the final value is exactly one of the submitted ones,
+    # never a torn/garbage value, and unrelated fields are untouched.
+    assert fetched.task.priority in priorities
+    assert fetched.task.status == task.status
+
+
+def test_concurrent_creates_all_persist(
+    client: TaskdogApiClient, live_server: str
+) -> None:
+    def create(index: int) -> int:
+        api = TaskdogApiClient(base_url=live_server)
+        try:
+            return api.create_task(name=f"concurrent-{index}").id
+        finally:
+            api.close()
+
+    with ThreadPoolExecutor(max_workers=_WRITERS) as pool:
+        ids = list(pool.map(create, range(_WRITERS)))
+
+    # No lost writes and no id collisions under concurrent inserts.
+    assert len(set(ids)) == _WRITERS
+    assert client.list_tasks().total_count == _WRITERS

--- a/tests/e2e/test_concurrency.py
+++ b/tests/e2e/test_concurrency.py
@@ -55,6 +55,9 @@ def test_concurrent_creates_all_persist(
     with ThreadPoolExecutor(max_workers=_WRITERS) as pool:
         ids = list(pool.map(create, range(_WRITERS)))
 
-    # No lost writes and no id collisions under concurrent inserts.
+    # No lost writes and no id collisions under concurrent inserts. Checked as a
+    # subset of the listing so the assertion verifies "every one of my creates
+    # persisted" without assuming the DB is globally empty.
     assert len(set(ids)) == _WRITERS
-    assert client.list_tasks().total_count == _WRITERS
+    persisted = {task.id for task in client.list_tasks().tasks}
+    assert set(ids) <= persisted


### PR DESCRIPTION
## Summary

Adds two E2E tests that lock in taskdog's concurrent-write contract. Taskdog is used de-facto multi-writer (one person driving several AI agents at once), yet nothing exercised simultaneous writers against the real server + SQLite. These fill that gap.

- **`test_concurrent_updates_to_same_task_stay_consistent`** — 20 threads update the same task's priority concurrently; the final value is exactly one of the submitted ones (last-writer-wins, never torn/garbage) and unrelated fields (status) are untouched.
- **`test_concurrent_creates_all_persist`** — 20 threads create tasks concurrently; all persist with unique ids and no lost writes.

Each thread uses its own `TaskdogApiClient` (a client wraps a single `httpx.Client`, which must not be shared across threads).

## Why it holds

The engine runs SQLite in **WAL mode with a 30s `busy_timeout`** (`engine_factory.py`), so concurrent writers serialize and wait out the lock rather than surfacing `SQLITE_BUSY`. Verified empirically: 40 concurrent writers/creators produce 0 errors. These tests would fail if that serialization guarantee regressed.

Kept modest (20 writers) so they run in ~1.5s and are non-flaky (confirmed across repeated runs). Full e2e suite: 10 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)