### PR TITLE
feat(core,ui): add created_at/updated_at task sort keys

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
@@ -62,7 +62,8 @@ class TaskQueryService(QueryService):
 
         Args:
             filter_obj: Optional filter object to apply. If None, returns all tasks.
-            sort_by: Sort key (id, priority, deadline, name, status, planned_start)
+            sort_by: Sort key (id, priority, deadline, name, status, planned_start,
+                estimated_duration, created_at, updated_at)
             reverse: Reverse sort order (default: False)
 
         Returns:

--- a/packages/taskdog-core/src/taskdog_core/application/sorters/task_sorter.py
+++ b/packages/taskdog-core/src/taskdog_core/application/sorters/task_sorter.py
@@ -103,10 +103,10 @@ class TaskSorter:
             return lambda task: self._parse_numeric_for_sort(task.estimated_duration)
 
         if sort_by == "created_at":
-            return lambda task: task.created_at
+            return lambda task: self._parse_date_for_sort(task.created_at)
 
         if sort_by == "updated_at":
-            return lambda task: task.updated_at
+            return lambda task: self._parse_date_for_sort(task.updated_at)
 
         # This should never happen due to validation in sort(), but required for type checking
         raise ValueError(f"Unsupported sort_by value: {sort_by}")

--- a/packages/taskdog-core/src/taskdog_core/application/sorters/task_sorter.py
+++ b/packages/taskdog-core/src/taskdog_core/application/sorters/task_sorter.py
@@ -19,6 +19,8 @@ class TaskSorter:
     - status: Task status (alphabetical, ascending by default)
     - planned_start: Planned start date (ascending by default)
     - estimated_duration: Estimated duration in hours (ascending by default - shorter tasks first)
+    - created_at: Creation timestamp (ascending by default - oldest first)
+    - updated_at: Last update timestamp (ascending by default - oldest first)
 
     Tasks with None values are sorted last for date/time/numeric fields.
     """
@@ -47,6 +49,8 @@ class TaskSorter:
             "status",
             "planned_start",
             "estimated_duration",
+            "created_at",
+            "updated_at",
         ]
         if sort_by not in valid_keys:
             raise ValueError(f"Invalid sort_by: {sort_by}. Must be one of {valid_keys}")
@@ -97,6 +101,12 @@ class TaskSorter:
 
         if sort_by == "estimated_duration":
             return lambda task: self._parse_numeric_for_sort(task.estimated_duration)
+
+        if sort_by == "created_at":
+            return lambda task: task.created_at
+
+        if sort_by == "updated_at":
+            return lambda task: task.updated_at
 
         # This should never happen due to validation in sort(), but required for type checking
         raise ValueError(f"Unsupported sort_by value: {sort_by}")

--- a/packages/taskdog-core/tests/application/sorters/test_task_sorter.py
+++ b/packages/taskdog-core/tests/application/sorters/test_task_sorter.py
@@ -129,6 +129,28 @@ class TestTaskSorter:
         for i, expected_name in enumerate(expected_names):
             assert sorted_tasks[i].name == expected_name
 
+    @pytest.mark.parametrize(
+        "field",
+        ["created_at", "updated_at"],
+        ids=["created_at", "updated_at"],
+    )
+    def test_sort_by_timestamp_fields(self, field):
+        """Test sorting by timestamp fields (created_at, updated_at), oldest first."""
+        task_old = Task(name="Old", priority=1)
+        task_old.id = 1
+        setattr(task_old, field, self.yesterday_str)
+        task_mid = Task(name="Mid", priority=1)
+        task_mid.id = 2
+        setattr(task_mid, field, self.today_str)
+        task_new = Task(name="New", priority=1)
+        task_new.id = 3
+        setattr(task_new, field, self.tomorrow_str)
+
+        tasks = [task_new, task_old, task_mid]
+        sorted_tasks = self.sorter.sort(tasks, sort_by=field)
+
+        assert [t.name for t in sorted_tasks] == ["Old", "Mid", "New"]
+
     def test_sort_by_status(self):
         """Test sorting by status."""
         task1 = Task(name="Task 1", priority=1, status=TaskStatus.PENDING)

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_crud.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_crud.py
@@ -41,7 +41,8 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
             include_archived: Include archived tasks (default: False)
             status: Filter by status (PENDING, IN_PROGRESS, COMPLETED, CANCELED)
             tags: Filter by tags (OR logic)
-            sort_by: Sort field (id, name, priority, deadline, status)
+            sort_by: Sort field (id, name, priority, deadline, status,
+                planned_start, estimated_duration, created_at, updated_at)
             reverse: Reverse sort order
 
         Returns:

--- a/packages/taskdog-ui/src/taskdog/cli/commands/common_options.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/common_options.py
@@ -68,7 +68,16 @@ def sort_options(
         @click.option(
             "--sort",
             type=click.Choice(
-                ["id", "priority", "deadline", "name", "status", "planned_start"]
+                [
+                    "id",
+                    "priority",
+                    "deadline",
+                    "name",
+                    "status",
+                    "planned_start",
+                    "created_at",
+                    "updated_at",
+                ]
             ),
             default=default_sort,
             help=f"Sort tasks by specified field (default: {default_sort})",

--- a/packages/taskdog-ui/src/taskdog/tui/palette/providers/sort_providers.py
+++ b/packages/taskdog-ui/src/taskdog/tui/palette/providers/sort_providers.py
@@ -34,6 +34,8 @@ class SortOptionsProvider(BaseListProvider):
         ("priority", "Priority", "Importance-based (higher priority first)"),
         ("estimated_duration", "Duration", "Effort-based (shorter tasks first)"),
         ("id", "ID", "Creation order (lower ID first)"),
+        ("created_at", "Created", "Staleness-based (oldest capture first)"),
+        ("updated_at", "Updated", "Recency-based (least recently updated first)"),
         ("name", "Name", "Alphabetically (A-Z)"),
         (
             "status",

--- a/packages/taskdog-ui/tests/tui/palette/providers/test_sort_providers.py
+++ b/packages/taskdog-ui/tests/tui/palette/providers/test_sort_providers.py
@@ -20,10 +20,10 @@ class TestSortOptionsProvider:
         self.provider = SortOptionsProvider(screen=self.mock_screen, match_style=None)
 
     def test_get_options_returns_all_sort_options(self):
-        """Test that get_options returns all 7 sort options."""
+        """Test that get_options returns all 9 sort options."""
         options = self.provider.get_options(self.mock_app)
 
-        assert len(options) == 7
+        assert len(options) == 9
 
         # Verify option names
         option_names = [opt[0] for opt in options]
@@ -32,6 +32,8 @@ class TestSortOptionsProvider:
         assert "Priority" in option_names
         assert "Duration" in option_names
         assert "ID" in option_names
+        assert "Created" in option_names
+        assert "Updated" in option_names
         assert "Name" in option_names
         assert "Status" in option_names
 
@@ -43,6 +45,8 @@ class TestSortOptionsProvider:
             ("priority", "Priority"),
             ("estimated_duration", "Duration"),
             ("id", "ID"),
+            ("created_at", "Created"),
+            ("updated_at", "Updated"),
             ("name", "Name"),
             ("status", "Status"),
         ],
@@ -52,6 +56,8 @@ class TestSortOptionsProvider:
             "priority",
             "estimated_duration",
             "id",
+            "created_at",
+            "updated_at",
             "name",
             "status",
         ],


### PR DESCRIPTION
## Why

`TaskSorter` supported `id/priority/deadline/name/status/planned_start/estimated_duration`. Tasks with no `deadline` map to a far-future sentinel and sink to the bottom of the default deadline sort, so captured-but-untracked tasks silently get lost.

Analysis of a real backup DB (772 tasks, 9 months) confirmed the pain:

- Active backlog (PENDING/IN_PROGRESS): **57% have no deadline** and **100% have no priority** — literally unrankable, they sink.
- The oldest undated task had been buried **36 days**.
- `updated_at` is useless as a staleness signal: `optimize_schedule` (586 ops) and `update_notes` (682 ops) flatten it — the 36-day-buried task showed `updated_at` = yesterday.

So `created_at` is the honest, ungameable capture-age signal for resurfacing undated tasks.

## What

- Add `created_at` and `updated_at` as sort keys in `TaskSorter` (both non-null, no sentinel needed).
- Expose them through the CLI `--sort` choices and the TUI sort palette (`Created` / `Updated`).
- The `sort` param already flows as a free string through server/client/MCP, so no changes needed there beyond docstrings.

Sorting `created_at` ascending resurfaces the oldest captured tasks first.

## Verification

- `TaskSorter` + query-service tests: pass (new parametrized timestamp tests).
- UI CLI/TUI palette tests: 285 pass.
- lint + format clean.
- **Live**: ran the server against a copy of the real backup DB; `list --status pending --sort created_at` surfaces the 36-day-buried task (id 717) into the top 3, where the default deadline sort had it at the tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)