### PR TITLE
feat: transparent 'next executable task' primitive in core

### DIFF
--- a/packages/taskdog-client/src/taskdog_client/converters/__init__.py
+++ b/packages/taskdog-client/src/taskdog_client/converters/__init__.py
@@ -11,6 +11,7 @@ from .statistics_converters import convert_to_statistics_output
 from .tag_converters import convert_to_tag_statistics_output
 from .task_converters import (
     convert_to_get_task_detail_output,
+    convert_to_next_tasks_output,
     convert_to_task_list_output,
     convert_to_task_operation_output,
     convert_to_update_task_output,
@@ -20,6 +21,7 @@ __all__ = [
     "ConversionError",
     "convert_to_gantt_overlay",
     "convert_to_get_task_detail_output",
+    "convert_to_next_tasks_output",
     "convert_to_optimization_output",
     "convert_to_statistics_output",
     "convert_to_tag_statistics_output",

--- a/packages/taskdog-client/src/taskdog_client/converters/task_converters.py
+++ b/packages/taskdog-client/src/taskdog_client/converters/task_converters.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from pydantic import BaseModel, ValidationError
 
+from taskdog_core.application.dto.next_tasks_output import NextTasksOutput
 from taskdog_core.application.dto.task_detail_output import TaskDetailOutput
 from taskdog_core.application.dto.task_dto import TaskDetailDto, TaskRowDto
 from taskdog_core.application.dto.task_list_output import TaskListOutput
@@ -111,6 +112,21 @@ def convert_to_task_list_output(data: dict[str, Any]) -> TaskListOutput:
         total_count=require_key(data, "total_count"),
         filtered_count=require_key(data, "filtered_count"),
         gantt_data=gantt_data,
+    )
+
+
+def convert_to_next_tasks_output(data: dict[str, Any]) -> NextTasksOutput:
+    """Convert API response to NextTasksOutput.
+
+    Args:
+        data: API response data
+
+    Returns:
+        NextTasksOutput with ranked executable tasks
+    """
+    tasks = [_model_validate(TaskRowDto, task) for task in require_key(data, "tasks")]
+    return NextTasksOutput(
+        tasks=tasks, ranking_basis=require_key(data, "ranking_basis")
     )
 
 

--- a/packages/taskdog-client/src/taskdog_client/query_client.py
+++ b/packages/taskdog-client/src/taskdog_client/query_client.py
@@ -6,9 +6,11 @@ from typing import Any
 from taskdog_client.base_client import BaseApiClient
 from taskdog_client.converters import (
     convert_to_get_task_detail_output,
+    convert_to_next_tasks_output,
     convert_to_tag_statistics_output,
     convert_to_task_list_output,
 )
+from taskdog_core.application.dto.next_tasks_output import NextTasksOutput
 from taskdog_core.application.dto.tag_statistics_output import TagStatisticsOutput
 from taskdog_core.application.dto.task_detail_output import TaskDetailOutput
 from taskdog_core.application.dto.task_list_output import TaskListOutput
@@ -215,3 +217,23 @@ class QueryClient:
         """
         data = self._base._request_json("get", "/api/v1/tags/statistics")
         return convert_to_tag_statistics_output(data)
+
+    def get_executable_tasks(
+        self, tags: list[str] | None = None, limit: int = 10
+    ) -> NextTasksOutput:
+        """Get executable tasks ranked by what to work on next.
+
+        Args:
+            tags: Filter by tags (OR logic)
+            limit: Maximum number of tasks to return
+
+        Returns:
+            NextTasksOutput with ranked executable tasks
+        """
+        params: dict[str, Any] = {"limit": limit}
+        if tags:
+            params["tags"] = tags
+        data = self._base._request_json(
+            "get", "/api/v1/tasks/executable", params=params
+        )
+        return convert_to_next_tasks_output(data)

--- a/packages/taskdog-client/src/taskdog_client/taskdog_api_client.py
+++ b/packages/taskdog-client/src/taskdog_client/taskdog_api_client.py
@@ -26,6 +26,7 @@ from taskdog_core.application.dto.audit_log_dto import (
 )
 from taskdog_core.application.dto.bulk_operation_output import BulkOperationOutput
 from taskdog_core.application.dto.delete_tag_output import DeleteTagOutput
+from taskdog_core.application.dto.next_tasks_output import NextTasksOutput
 from taskdog_core.application.dto.optimization_output import OptimizationOutput
 from taskdog_core.application.dto.restore_result import RestoreResultDTO
 from taskdog_core.application.dto.statistics_output import StatisticsOutput
@@ -363,6 +364,12 @@ class TaskdogApiClient:
     def get_tag_statistics(self) -> TagStatisticsOutput:
         """Get tag statistics."""
         return self._queries.get_tag_statistics()
+
+    def get_executable_tasks(
+        self, tags: list[str] | None = None, limit: int = 10
+    ) -> NextTasksOutput:
+        """Get executable tasks ranked by what to work on next."""
+        return self._queries.get_executable_tasks(tags, limit)
 
     # Notes methods - delegate to NotesClient
 

--- a/packages/taskdog-client/tests/test_query_client.py
+++ b/packages/taskdog-client/tests/test_query_client.py
@@ -6,6 +6,8 @@ from unittest.mock import Mock, patch
 import pytest
 from taskdog_client.query_client import QueryClient
 
+from taskdog_core.application.dto.task_dto import TaskRowDto
+
 
 class TestQueryClient:
     """Test cases for QueryClient."""
@@ -149,17 +151,41 @@ class TestQueryClient:
         )
         assert result == mock_output
 
-    @patch("taskdog_client.query_client.convert_to_next_tasks_output")
-    def test_get_executable_tasks(self, mock_convert):
-        """Test get_executable_tasks makes correct API call."""
+    def test_get_executable_tasks(self):
+        """Test get_executable_tasks makes correct API call and parses the response."""
         mock_json = {
-            "tasks": [{"id": 1}],
-            "ranking_basis": ["in_progress_first", "deadline_asc"],
+            "tasks": [
+                {
+                    "id": 1,
+                    "name": "Task 1",
+                    "priority": 50,
+                    "status": "PENDING",
+                    "planned_start": None,
+                    "planned_end": None,
+                    "deadline": "2025-12-31T23:59:00",
+                    "actual_start": None,
+                    "actual_end": None,
+                    "estimated_duration": 5.0,
+                    "actual_duration_hours": None,
+                    "is_fixed": False,
+                    "depends_on": [],
+                    "tags": [],
+                    "is_archived": False,
+                    "is_finished": False,
+                    "created_at": "2025-01-01T00:00:00",
+                    "updated_at": "2025-01-01T00:00:00",
+                    "has_notes": False,
+                }
+            ],
+            "ranking_basis": [
+                "in_progress_first",
+                "deadline_asc",
+                "priority_desc",
+                "estimate_asc",
+                "id_asc",
+            ],
         }
         self.mock_base._request_json.return_value = mock_json
-
-        mock_output = Mock()
-        mock_convert.return_value = mock_output
 
         result = self.client.get_executable_tasks(tags=["urgent"], limit=5)
 
@@ -168,5 +194,6 @@ class TestQueryClient:
             "/api/v1/tasks/executable",
             params={"limit": 5, "tags": ["urgent"]},
         )
-        assert result == mock_output
-        mock_convert.assert_called_once_with(mock_json)
+        assert result.ranking_basis[0] == "in_progress_first"
+        assert isinstance(result.tasks[0], TaskRowDto)
+        assert result.tasks[0].id == 1

--- a/packages/taskdog-client/tests/test_query_client.py
+++ b/packages/taskdog-client/tests/test_query_client.py
@@ -148,3 +148,25 @@ class TestQueryClient:
             "get", "/api/v1/tags/statistics"
         )
         assert result == mock_output
+
+    @patch("taskdog_client.query_client.convert_to_next_tasks_output")
+    def test_get_executable_tasks(self, mock_convert):
+        """Test get_executable_tasks makes correct API call."""
+        mock_json = {
+            "tasks": [{"id": 1}],
+            "ranking_basis": ["in_progress_first", "deadline_asc"],
+        }
+        self.mock_base._request_json.return_value = mock_json
+
+        mock_output = Mock()
+        mock_convert.return_value = mock_output
+
+        result = self.client.get_executable_tasks(tags=["urgent"], limit=5)
+
+        self.mock_base._request_json.assert_called_once_with(
+            "get",
+            "/api/v1/tasks/executable",
+            params={"limit": 5, "tags": ["urgent"]},
+        )
+        assert result == mock_output
+        mock_convert.assert_called_once_with(mock_json)

--- a/packages/taskdog-core/src/taskdog_core/application/dto/next_tasks_output.py
+++ b/packages/taskdog-core/src/taskdog_core/application/dto/next_tasks_output.py
@@ -1,0 +1,22 @@
+"""Output DTO for the executable-task ranking query."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from taskdog_core.application.dto.task_dto import TaskRowDto
+
+RANKING_BASIS: list[str] = [
+    "in_progress_first",
+    "deadline_asc",
+    "priority_desc",
+    "estimate_asc",
+    "id_asc",
+]
+
+
+class NextTasksOutput(BaseModel):
+    """Ranked executable tasks. Index 0 is the next task to work on."""
+
+    tasks: list[TaskRowDto]
+    ranking_basis: list[str] = Field(default_factory=lambda: list(RANKING_BASIS))

--- a/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
@@ -96,6 +96,8 @@ class TaskQueryService(QueryService):
         Order: IN_PROGRESS before PENDING; then deadline asc (None last);
         then priority desc; then estimated_duration asc (None last); then id asc.
         """
+        # Load the full task universe (incl. archived/completed) so a dependency's
+        # status can be resolved even after it was archived post-completion.
         all_tasks = self.get_filtered_tasks()
         status_by_id = {t.id: t.status for t in all_tasks}
 

--- a/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
@@ -7,9 +7,6 @@ from typing import TYPE_CHECKING, Any
 
 from taskdog_core.application.dto.gantt_overlay import GanttDateRange, GanttOverlay
 from taskdog_core.application.queries.base import QueryService
-from taskdog_core.application.queries.filters.non_archived_filter import (
-    NonArchivedFilter,
-)
 from taskdog_core.application.sorters.task_sorter import TaskSorter
 from taskdog_core.domain.entities.task import TaskStatus
 
@@ -99,7 +96,7 @@ class TaskQueryService(QueryService):
         Order: IN_PROGRESS before PENDING; then deadline asc (None last);
         then priority desc; then estimated_duration asc (None last); then id asc.
         """
-        all_tasks = self.get_filtered_tasks(NonArchivedFilter())
+        all_tasks = self.get_filtered_tasks()
         status_by_id = {t.id: t.status for t in all_tasks}
 
         def deps_met(task: Task) -> bool:
@@ -111,6 +108,7 @@ class TaskQueryService(QueryService):
             t
             for t in all_tasks
             if t.status in (TaskStatus.PENDING, TaskStatus.IN_PROGRESS)
+            and not t.is_archived
             and (not tags or any(tag in t.tags for tag in tags))
             and deps_met(t)
         ]

--- a/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from taskdog_core.application.dto.gantt_overlay import GanttDateRange, GanttOverlay
 from taskdog_core.application.queries.base import QueryService
+from taskdog_core.application.queries.filters.non_archived_filter import (
+    NonArchivedFilter,
+)
 from taskdog_core.application.sorters.task_sorter import TaskSorter
+from taskdog_core.domain.entities.task import TaskStatus
 
 if TYPE_CHECKING:
     from datetime import date
@@ -84,6 +89,49 @@ class TaskQueryService(QueryService):
 
         # Sort tasks
         return self.sorter.sort(tasks, sort_by, reverse)
+
+    def get_executable_tasks(
+        self, tags: list[str] | None = None, limit: int = 10
+    ) -> list[Task]:
+        """Return dependency-resolved executable tasks in canonical order.
+
+        Executable = PENDING/IN_PROGRESS, not archived, every dependency COMPLETED.
+        Order: IN_PROGRESS before PENDING; then deadline asc (None last);
+        then priority desc; then estimated_duration asc (None last); then id asc.
+        """
+        all_tasks = self.get_filtered_tasks(NonArchivedFilter())
+        status_by_id = {t.id: t.status for t in all_tasks}
+
+        def deps_met(task: Task) -> bool:
+            return all(
+                status_by_id.get(dep) == TaskStatus.COMPLETED for dep in task.depends_on
+            )
+
+        candidates = [
+            t
+            for t in all_tasks
+            if t.status in (TaskStatus.PENDING, TaskStatus.IN_PROGRESS)
+            and (not tags or any(tag in t.tags for tag in tags))
+            and deps_met(t)
+        ]
+        candidates.sort(key=self._executable_sort_key)
+        return candidates[:limit]
+
+    @staticmethod
+    def _executable_sort_key(
+        task: Task,
+    ) -> tuple[int, bool, datetime, int, bool, float, int | None]:
+        status_tier = 0 if task.status == TaskStatus.IN_PROGRESS else 1
+        has_deadline = task.deadline is None  # False (0) sorts before True (1)
+        deadline = task.deadline or datetime.max
+        priority = -(task.priority or 0)  # higher priority first
+        has_est = task.estimated_duration is None
+        est = (
+            task.estimated_duration
+            if task.estimated_duration is not None
+            else float("inf")
+        )
+        return (status_tier, has_deadline, deadline, priority, has_est, est, task.id)
 
     def _extract_sql_params(self, filter_obj: TaskFilter | None) -> dict[str, Any]:
         """Extract SQL-compatible filter parameters from filter object.

--- a/packages/taskdog-core/src/taskdog_core/controllers/query_controller.py
+++ b/packages/taskdog-core/src/taskdog_core/controllers/query_controller.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 from taskdog_core.application.dto.base import SingleTaskInput
 from taskdog_core.application.dto.get_task_by_id_output import TaskByIdOutput
+from taskdog_core.application.dto.next_tasks_output import NextTasksOutput
 from taskdog_core.application.dto.query_inputs import ListTasksInput
 from taskdog_core.application.dto.tag_statistics_output import TagStatisticsOutput
 from taskdog_core.application.dto.task_detail_output import TaskDetailOutput
@@ -205,6 +206,21 @@ class QueryController:
 
         use_case = GetTaskDetailUseCase(self.repository, self.notes_repository)
         return use_case.execute(SingleTaskInput(task_id=task_id))
+
+    def get_executable_tasks(
+        self, tags: list[str] | None = None, limit: int = 10
+    ) -> NextTasksOutput:
+        """Return ranked executable tasks as an output DTO.
+
+        Args:
+            tags: Optional tag filter
+            limit: Maximum number of tasks to return
+
+        Returns:
+            NextTasksOutput with ranked tasks (index 0 is the next task to work on)
+        """
+        tasks = self.query_service.get_executable_tasks(tags=tags, limit=limit)
+        return NextTasksOutput(tasks=[TaskRowDto.from_entity(t) for t in tasks])
 
     def get_algorithm_metadata(self) -> list[tuple[str, str, str]]:
         """Get metadata for all available optimization algorithms.

--- a/packages/taskdog-core/tests/application/queries/test_executable_tasks.py
+++ b/packages/taskdog-core/tests/application/queries/test_executable_tasks.py
@@ -19,7 +19,16 @@ class _FixedTime:
         return datetime(2026, 7, 18, 9, 0, 0)
 
 
-def _task(task_id, status, deadline=None, priority=1, est=None, deps=None):
+def _task(
+    task_id,
+    status,
+    deadline=None,
+    priority=1,
+    est=None,
+    deps=None,
+    is_archived=False,
+    tags=None,
+):
     return Task(
         id=task_id,
         name=f"t{task_id}",
@@ -28,6 +37,8 @@ def _task(task_id, status, deadline=None, priority=1, est=None, deps=None):
         deadline=deadline,
         estimated_duration=est,
         depends_on=deps or [],
+        is_archived=is_archived,
+        tags=tags or [],
     )
 
 
@@ -80,3 +91,50 @@ def test_ranking_precedence_within_tier():
 def test_limit_caps_results():
     tasks = [_task(i, TaskStatus.PENDING) for i in range(1, 6)]
     assert len(_svc(tasks).get_executable_tasks(limit=2)) == 2
+
+
+def test_archived_completed_dependency_stays_executable():
+    tasks = [
+        _task(1, TaskStatus.COMPLETED, is_archived=True),
+        _task(2, TaskStatus.PENDING, deps=[1]),
+    ]
+    ids = [t.id for t in _svc(tasks).get_executable_tasks()]
+    assert ids == [2]  # archived-but-completed dep still satisfies the dependent
+
+
+def test_archived_task_is_not_returned():
+    tasks = [
+        _task(1, TaskStatus.PENDING, is_archived=True),
+        _task(2, TaskStatus.PENDING),
+    ]
+    ids = [t.id for t in _svc(tasks).get_executable_tasks()]
+    assert ids == [2]
+
+
+def test_tags_filter_restricts_candidates():
+    tasks = [
+        _task(1, TaskStatus.PENDING, tags=["work"]),
+        _task(2, TaskStatus.PENDING, tags=["home"]),
+    ]
+    ids = [t.id for t in _svc(tasks).get_executable_tasks(tags=["work"])]
+    assert ids == [1]
+
+
+def test_estimate_tie_break():
+    tasks = [
+        _task(1, TaskStatus.PENDING, est=None),
+        _task(2, TaskStatus.PENDING, est=3.0),
+        _task(3, TaskStatus.PENDING, est=1.0),
+    ]
+    ids = [t.id for t in _svc(tasks).get_executable_tasks()]
+    assert ids == [3, 2, 1]  # shorter estimate first; None-estimate last
+
+
+def test_id_tie_break():
+    tasks = [
+        _task(3, TaskStatus.PENDING),
+        _task(1, TaskStatus.PENDING),
+        _task(2, TaskStatus.PENDING),
+    ]
+    ids = [t.id for t in _svc(tasks).get_executable_tasks()]
+    assert ids == [1, 2, 3]

--- a/packages/taskdog-core/tests/application/queries/test_executable_tasks.py
+++ b/packages/taskdog-core/tests/application/queries/test_executable_tasks.py
@@ -130,6 +130,16 @@ def test_estimate_tie_break():
     assert ids == [3, 2, 1]  # shorter estimate first; None-estimate last
 
 
+def test_tags_filter_is_or_across_multiple_tags():
+    tasks = [
+        _task(1, TaskStatus.PENDING, tags=["a"]),
+        _task(2, TaskStatus.PENDING, tags=["b"]),
+        _task(3, TaskStatus.PENDING, tags=["c"]),
+    ]
+    ids = [t.id for t in _svc(tasks).get_executable_tasks(tags=["a", "b"])]
+    assert ids == [1, 2]
+
+
 def test_id_tie_break():
     tasks = [
         _task(3, TaskStatus.PENDING),

--- a/packages/taskdog-core/tests/application/queries/test_executable_tasks.py
+++ b/packages/taskdog-core/tests/application/queries/test_executable_tasks.py
@@ -1,0 +1,82 @@
+from datetime import datetime
+
+from taskdog_core.application.queries.task_query_service import TaskQueryService
+from taskdog_core.domain.entities.task import Task, TaskStatus
+
+
+class _StubRepo:
+    """Minimal repository: get_filtered returns all tasks (filters applied in Python)."""
+
+    def __init__(self, tasks):
+        self._tasks = tasks
+
+    def get_filtered(self, **kwargs):
+        return list(self._tasks)
+
+
+class _FixedTime:
+    def now(self):
+        return datetime(2026, 7, 18, 9, 0, 0)
+
+
+def _task(task_id, status, deadline=None, priority=1, est=None, deps=None):
+    return Task(
+        id=task_id,
+        name=f"t{task_id}",
+        priority=priority,
+        status=status,
+        deadline=deadline,
+        estimated_duration=est,
+        depends_on=deps or [],
+    )
+
+
+def _svc(tasks):
+    return TaskQueryService(_StubRepo(tasks), _FixedTime())
+
+
+def test_blocked_by_incomplete_dependency_is_excluded():
+    tasks = [
+        _task(1, TaskStatus.PENDING),  # dep target, not completed
+        _task(2, TaskStatus.PENDING, deps=[1]),  # blocked
+    ]
+    ids = [t.id for t in _svc(tasks).get_executable_tasks()]
+    assert ids == [1]
+
+
+def test_completed_dependency_unblocks():
+    tasks = [
+        _task(1, TaskStatus.COMPLETED),
+        _task(2, TaskStatus.PENDING, deps=[1]),
+    ]
+    ids = [t.id for t in _svc(tasks).get_executable_tasks()]
+    assert ids == [2]  # completed dep-target is not itself executable
+
+
+def test_missing_dependency_target_excludes_task():
+    tasks = [_task(2, TaskStatus.PENDING, deps=[99])]
+    assert _svc(tasks).get_executable_tasks() == []
+
+
+def test_in_progress_ranks_before_pending():
+    tasks = [
+        _task(1, TaskStatus.PENDING, deadline=datetime(2026, 7, 19)),
+        _task(2, TaskStatus.IN_PROGRESS, deadline=datetime(2026, 7, 25)),
+    ]
+    ids = [t.id for t in _svc(tasks).get_executable_tasks()]
+    assert ids == [2, 1]  # in-progress first despite later deadline
+
+
+def test_ranking_precedence_within_tier():
+    tasks = [
+        _task(1, TaskStatus.PENDING, deadline=None, priority=9),
+        _task(2, TaskStatus.PENDING, deadline=datetime(2026, 7, 20), priority=1),
+        _task(3, TaskStatus.PENDING, deadline=datetime(2026, 7, 19), priority=1),
+    ]
+    ids = [t.id for t in _svc(tasks).get_executable_tasks()]
+    assert ids == [3, 2, 1]  # earliest deadline first; None-deadline last
+
+
+def test_limit_caps_results():
+    tasks = [_task(i, TaskStatus.PENDING) for i in range(1, 6)]
+    assert len(_svc(tasks).get_executable_tasks(limit=2)) == 2

--- a/packages/taskdog-core/tests/controllers/test_query_controller_executable.py
+++ b/packages/taskdog-core/tests/controllers/test_query_controller_executable.py
@@ -1,0 +1,29 @@
+from taskdog_core.application.dto.next_tasks_output import RANKING_BASIS
+from taskdog_core.controllers.query_controller import QueryController
+from taskdog_core.domain.entities.task import Task, TaskStatus
+
+
+class _Repo:
+    def __init__(self, tasks):
+        self._tasks = tasks
+
+    def get_filtered(self, **kwargs):
+        return list(self._tasks)
+
+
+class _Time:
+    def now(self):
+        from datetime import datetime
+
+        return datetime(2026, 7, 18)
+
+
+def test_get_executable_tasks_returns_ranked_dto():
+    tasks = [
+        Task(id=1, name="a", priority=1, status=TaskStatus.PENDING),
+        Task(id=2, name="b", priority=1, status=TaskStatus.IN_PROGRESS),
+    ]
+    controller = QueryController(_Repo(tasks), None, _Time())
+    out = controller.get_executable_tasks()
+    assert [t.id for t in out.tasks] == [2, 1]  # in-progress first
+    assert out.ranking_basis == RANKING_BASIS

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_query.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_query.py
@@ -7,55 +7,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from taskdog_core.domain.entities.task import TaskStatus
 from taskdog_mcp.tools.serializers import iso, str_list
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
     from taskdog_client import TaskdogApiClient
-
-
-def _fetch_dependency_statuses(
-    pending_tasks: list[Any],
-    client: TaskdogApiClient,
-) -> dict[int, TaskStatus]:
-    """Fetch the status of every distinct dependency in one batched call.
-
-    Collapses what used to be one get_task_by_id request per dependency id
-    into a single get_tasks_by_ids round trip. A dependency absent from the
-    result (e.g. its task was deleted) is simply not in the map, which
-    callers treat as unmet.
-    """
-    distinct_dep_ids = {
-        dep_id for t in pending_tasks for dep_id in (t.depends_on or [])
-    }
-    if not distinct_dep_ids:
-        return {}
-    result = client.get_tasks_by_ids(list(distinct_dep_ids))
-    return {t.id: t.status for t in result.tasks}
-
-
-def _select_executable_pending(
-    pending_tasks: list[Any],
-    client: TaskdogApiClient,
-    max_count: int,
-) -> list[Any]:
-    """Filter pending tasks down to those whose dependencies are met.
-
-    A dependency is met only when its status is COMPLETED; a missing
-    dependency counts as unmet, matching
-    DependencyValidator.validate_dependencies_met semantics.
-    """
-    status_by_id = _fetch_dependency_statuses(pending_tasks, client)
-    executable_pending: list[Any] = []
-    for t in pending_tasks:
-        if len(executable_pending) >= max_count:
-            break
-        if not t.depends_on or all(
-            status_by_id.get(dep_id) == TaskStatus.COMPLETED for dep_id in t.depends_on
-        ):
-            executable_pending.append(t)
-    return executable_pending
 
 
 def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
@@ -127,31 +83,8 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
         Returns:
             List of executable tasks with details
         """
-        # Get pending and in-progress tasks
-        pending = client.list_tasks(
-            status="pending",
-            tags=tags,
-            sort_by="priority",
-            reverse=True,  # Higher priority first
-        )
-
-        in_progress = client.list_tasks(
-            status="in_progress",
-            tags=tags,
-            sort_by="priority",
-            reverse=True,
-        )
-
-        # Filter out pending tasks with unmet dependencies, stopping once
-        # enough executable tasks are found to fill the remaining limit.
-        remaining_slots = max(limit - len(in_progress.tasks), 0)
-        executable_pending = _select_executable_pending(
-            pending.tasks, client, remaining_slots
-        )
-
-        # Combine and limit
-        all_tasks = list(in_progress.tasks) + executable_pending
-        limited_tasks = all_tasks[:limit]
+        result = client.get_executable_tasks(tags=tags, limit=limit)
+        tasks = result.tasks
 
         return {
             "tasks": [
@@ -165,8 +98,8 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
                     "tags": str_list(t.tags),
                     "depends_on": str_list(t.depends_on),
                 }
-                for t in limited_tasks
+                for t in tasks
             ],
-            "total": len(limited_tasks),
-            "message": f"Found {len(limited_tasks)} executable tasks (IN_PROGRESS tasks shown first)",
+            "total": len(tasks),
+            "message": f"Found {len(tasks)} executable tasks (IN_PROGRESS tasks shown first)",
         }

--- a/packages/taskdog-mcp/tests/test_tools.py
+++ b/packages/taskdog-mcp/tests/test_tools.py
@@ -148,6 +148,7 @@ def create_mock_client() -> MagicMock:
     # Query methods
     client.get_tag_statistics = MagicMock()
     client.calculate_statistics = MagicMock()
+    client.get_executable_tasks = MagicMock()
     # Optimization methods
     client.optimize_schedule = MagicMock()
     client.get_algorithm_metadata = MagicMock()
@@ -972,21 +973,23 @@ class TestTaskQueryTools:
         assert "personal" in tag_names
 
     def test_get_executable_tasks(self) -> None:
-        """Test get_executable_tasks returns pending and in_progress tasks."""
+        """Test get_executable_tasks delegates to the client and shapes the result."""
         from mcp.server.fastmcp import FastMCP
         from taskdog_mcp.tools import task_query
 
+        from taskdog_core.application.dto.next_tasks_output import NextTasksOutput
+
         client = create_mock_client()
+        client.get_executable_tasks = MagicMock()
         in_progress_task = create_mock_task_row(
             task_id=1, name="In Progress", status=TaskStatus.IN_PROGRESS
         )
         pending_task = create_mock_task_row(
             task_id=2, name="Pending", status=TaskStatus.PENDING
         )
-        client.list_tasks.side_effect = [
-            TaskListOutput(tasks=[pending_task], total_count=1, filtered_count=1),
-            TaskListOutput(tasks=[in_progress_task], total_count=1, filtered_count=1),
-        ]
+        client.get_executable_tasks.return_value = NextTasksOutput(
+            tasks=[in_progress_task, pending_task]
+        )
 
         mcp = FastMCP("test")
         task_query.register_tools(mcp, client)
@@ -994,161 +997,48 @@ class TestTaskQueryTools:
         get_executable_fn = mcp._tool_manager._tools["get_executable_tasks"].fn
         result = get_executable_fn(tags=["coding"], limit=5)
 
-        assert client.list_tasks.call_count == 2
+        client.get_executable_tasks.assert_called_once_with(tags=["coding"], limit=5)
         assert len(result["tasks"]) == 2
         assert result["total"] == 2
-        # IN_PROGRESS should be first
+        # Ordering from the client is preserved (IN_PROGRESS first).
+        assert result["tasks"][0]["id"] == 1
         assert result["tasks"][0]["status"] == "IN_PROGRESS"
+        assert result["tasks"][1]["id"] == 2
         assert result["tasks"][1]["status"] == "PENDING"
         assert "executable tasks" in result["message"]
 
-    def test_get_executable_tasks_with_limit(self) -> None:
-        """Test get_executable_tasks respects limit parameter."""
+    def test_get_executable_tasks_with_default_args(self) -> None:
+        """Test get_executable_tasks passes through default tags/limit."""
         from mcp.server.fastmcp import FastMCP
         from taskdog_mcp.tools import task_query
 
+        from taskdog_core.application.dto.next_tasks_output import NextTasksOutput
+
         client = create_mock_client()
-        tasks = [create_mock_task_row(task_id=i, name=f"Task {i}") for i in range(1, 6)]
-        client.list_tasks.side_effect = [
-            TaskListOutput(tasks=tasks, total_count=5, filtered_count=5),
-            TaskListOutput(tasks=[], total_count=0, filtered_count=0),
-        ]
+        client.get_executable_tasks = MagicMock()
+        tasks = [create_mock_task_row(task_id=i, name=f"Task {i}") for i in range(1, 4)]
+        client.get_executable_tasks.return_value = NextTasksOutput(tasks=tasks)
 
         mcp = FastMCP("test")
         task_query.register_tools(mcp, client)
 
         get_executable_fn = mcp._tool_manager._tools["get_executable_tasks"].fn
-        result = get_executable_fn(limit=3)
+        result = get_executable_fn()
 
+        client.get_executable_tasks.assert_called_once_with(tags=None, limit=10)
         assert len(result["tasks"]) == 3
         assert result["total"] == 3
 
-    def test_get_executable_tasks_excludes_pending_with_unmet_dependency(
-        self,
-    ) -> None:
-        """Pending task depending on a non-completed task must be excluded."""
+    def test_get_executable_tasks_empty_result(self) -> None:
+        """Test get_executable_tasks handles an empty ranked list."""
         from mcp.server.fastmcp import FastMCP
         from taskdog_mcp.tools import task_query
 
-        client = create_mock_client()
-        pending_task = create_mock_task_row(
-            task_id=2, name="Pending", status=TaskStatus.PENDING, depends_on=[99]
-        )
-        client.list_tasks.side_effect = [
-            TaskListOutput(tasks=[pending_task], total_count=1, filtered_count=1),
-            TaskListOutput(tasks=[], total_count=0, filtered_count=0),
-        ]
-        client.get_tasks_by_ids.return_value = TaskListOutput(
-            tasks=[
-                create_mock_task_row(task_id=99, name="Dep", status=TaskStatus.PENDING)
-            ],
-            total_count=1,
-            filtered_count=1,
-        )
-
-        mcp = FastMCP("test")
-        task_query.register_tools(mcp, client)
-
-        get_executable_fn = mcp._tool_manager._tools["get_executable_tasks"].fn
-        result = get_executable_fn(limit=5)
-
-        assert result["tasks"] == []
-        assert result["total"] == 0
-        # Dependency statuses are fetched in a single batched call.
-        client.get_tasks_by_ids.assert_called_once()
-
-    def test_get_executable_tasks_includes_pending_with_met_dependency(
-        self,
-    ) -> None:
-        """Pending task depending on a completed task must be included."""
-        from mcp.server.fastmcp import FastMCP
-        from taskdog_mcp.tools import task_query
+        from taskdog_core.application.dto.next_tasks_output import NextTasksOutput
 
         client = create_mock_client()
-        pending_task = create_mock_task_row(
-            task_id=2, name="Pending", status=TaskStatus.PENDING, depends_on=[99]
-        )
-        client.list_tasks.side_effect = [
-            TaskListOutput(tasks=[pending_task], total_count=1, filtered_count=1),
-            TaskListOutput(tasks=[], total_count=0, filtered_count=0),
-        ]
-        client.get_tasks_by_ids.return_value = TaskListOutput(
-            tasks=[
-                create_mock_task_row(
-                    task_id=99, name="Dep", status=TaskStatus.COMPLETED
-                )
-            ],
-            total_count=1,
-            filtered_count=1,
-        )
-
-        mcp = FastMCP("test")
-        task_query.register_tools(mcp, client)
-
-        get_executable_fn = mcp._tool_manager._tools["get_executable_tasks"].fn
-        result = get_executable_fn(limit=5)
-
-        assert len(result["tasks"]) == 1
-        assert result["tasks"][0]["id"] == 2
-        assert result["total"] == 1
-
-    def test_get_executable_tasks_excludes_pending_with_missing_dependency(
-        self,
-    ) -> None:
-        """Pending task depending on a deleted/missing task must be excluded, not raise."""
-        from mcp.server.fastmcp import FastMCP
-        from taskdog_mcp.tools import task_query
-
-        client = create_mock_client()
-        pending_task = create_mock_task_row(
-            task_id=2, name="Pending", status=TaskStatus.PENDING, depends_on=[99]
-        )
-        client.list_tasks.side_effect = [
-            TaskListOutput(tasks=[pending_task], total_count=1, filtered_count=1),
-            TaskListOutput(tasks=[], total_count=0, filtered_count=0),
-        ]
-        # A missing dependency is simply absent from the batched result.
-        client.get_tasks_by_ids.return_value = TaskListOutput(
-            tasks=[], total_count=0, filtered_count=0
-        )
-
-        mcp = FastMCP("test")
-        task_query.register_tools(mcp, client)
-
-        get_executable_fn = mcp._tool_manager._tools["get_executable_tasks"].fn
-        result = get_executable_fn(limit=5)
-
-        assert result["tasks"] == []
-        assert result["total"] == 0
-
-    def test_get_executable_tasks_excludes_pending_with_mixed_dependencies(
-        self,
-    ) -> None:
-        """Pending task with one completed and one pending dep must be excluded."""
-        from mcp.server.fastmcp import FastMCP
-        from taskdog_mcp.tools import task_query
-
-        client = create_mock_client()
-        pending_task = create_mock_task_row(
-            task_id=2, name="Pending", status=TaskStatus.PENDING, depends_on=[97, 98]
-        )
-        client.list_tasks.side_effect = [
-            TaskListOutput(tasks=[pending_task], total_count=1, filtered_count=1),
-            TaskListOutput(tasks=[], total_count=0, filtered_count=0),
-        ]
-
-        client.get_tasks_by_ids.return_value = TaskListOutput(
-            tasks=[
-                create_mock_task_row(
-                    task_id=97, name="Dep 97", status=TaskStatus.COMPLETED
-                ),
-                create_mock_task_row(
-                    task_id=98, name="Dep 98", status=TaskStatus.PENDING
-                ),
-            ],
-            total_count=2,
-            filtered_count=2,
-        )
+        client.get_executable_tasks = MagicMock()
+        client.get_executable_tasks.return_value = NextTasksOutput(tasks=[])
 
         mcp = FastMCP("test")
         task_query.register_tools(mcp, client)

--- a/packages/taskdog-server/src/taskdog_server/api/models/responses.py
+++ b/packages/taskdog-server/src/taskdog_server/api/models/responses.py
@@ -143,6 +143,13 @@ class BulkOperationResponse(BaseModel):
     results: list[BulkTaskResult]
 
 
+class NextTasksResponse(BaseModel):
+    """Response model for the ranked executable-tasks query."""
+
+    tasks: list[TaskResponse]
+    ranking_basis: list[str]
+
+
 class TaskListResponse(BaseModel):
     """Response model for task list queries."""
 

--- a/packages/taskdog-server/src/taskdog_server/api/routers/tasks.py
+++ b/packages/taskdog-server/src/taskdog_server/api/routers/tasks.py
@@ -20,6 +20,7 @@ from taskdog_server.api.dependencies import (
 )
 from taskdog_server.api.models.requests import CreateTaskRequest, UpdateTaskRequest
 from taskdog_server.api.models.responses import (
+    NextTasksResponse,
     TaskDetailResponse,
     TaskListResponse,
     TaskOperationResponse,
@@ -182,6 +183,29 @@ def get_tasks_by_ids(
     """
     result = controller.get_tasks_by_ids(ids)
     return TaskListResponse.from_dto(result)
+
+
+@router.get("/executable", response_model=NextTasksResponse)
+def get_executable_tasks(
+    controller: QueryControllerDep,
+    _client_name: AuthenticatedClientDep,
+    tags: Annotated[
+        list[str] | None, Query(description="Filter by tags (OR logic)")
+    ] = None,
+    limit: Annotated[int, Query(ge=1, description="Maximum tasks to return")] = 10,
+) -> NextTasksResponse:
+    """List executable tasks ranked by what to work on next.
+
+    Args:
+        controller: Query controller dependency
+        tags: Optional tag filter
+        limit: Maximum number of tasks to return
+
+    Returns:
+        Ranked tasks with the ranking basis used
+    """
+    result = controller.get_executable_tasks(tags=tags, limit=limit)
+    return NextTasksResponse.model_validate(result, from_attributes=True)
 
 
 @router.get("/{task_id}", response_model=TaskDetailResponse)

--- a/packages/taskdog-server/tests/api/routers/test_executable.py
+++ b/packages/taskdog-server/tests/api/routers/test_executable.py
@@ -1,0 +1,15 @@
+"""Tests for GET /api/v1/tasks/executable."""
+
+from taskdog_core.domain.entities.task import Task, TaskStatus
+
+
+def test_executable_endpoint_ranks_in_progress_first(client, repository):
+    repository.save(Task(id=1, name="p", priority=1, status=TaskStatus.PENDING))
+    repository.save(Task(id=2, name="ip", priority=1, status=TaskStatus.IN_PROGRESS))
+
+    resp = client.get("/api/v1/tasks/executable")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [t["id"] for t in body["tasks"]] == [2, 1]
+    assert body["ranking_basis"][0] == "in_progress_first"

--- a/scripts/vulture_whitelist.py
+++ b/scripts/vulture_whitelist.py
@@ -20,3 +20,4 @@ _.show_header  # Rich Table attribute set to suppress repeated period headers
 reschedule  # StatisticsPayload / StatisticsResponse field (used by API serialization)
 first_deadline  # ChronicSlipperTask DTO field (API-only; not yet in the TUI)
 latest_deadline  # ChronicSlipperTask DTO field (API-only; not yet in the TUI)
+ranking_basis  # NextTasksOutput / NextTasksResponse field (used by API serialization)

--- a/tests/e2e/test_executable.py
+++ b/tests/e2e/test_executable.py
@@ -1,0 +1,24 @@
+"""E2E: the executable endpoint ranks tasks through the real server + SQLite."""
+
+from taskdog_client.taskdog_api_client import TaskdogApiClient
+
+
+def test_executable_ranking_end_to_end(client: TaskdogApiClient) -> None:
+    from datetime import datetime
+
+    pending_soon = client.create_task(
+        name="pending soon", deadline=datetime(2026, 7, 20, 18, 0)
+    )
+    pending_later = client.create_task(
+        name="pending later", deadline=datetime(2026, 7, 30, 18, 0)
+    )
+    started = client.create_task(name="started")
+    client.start_task(started.id)
+
+    out = client.get_executable_tasks(limit=10)
+
+    ids = [t.id for t in out.tasks]
+    # in-progress first, then earliest deadline
+    assert ids[0] == started.id
+    assert ids.index(pending_soon.id) < ids.index(pending_later.id)
+    assert out.ranking_basis[0] == "in_progress_first"

--- a/tests/e2e/test_executable.py
+++ b/tests/e2e/test_executable.py
@@ -22,3 +22,21 @@ def test_executable_ranking_end_to_end(client: TaskdogApiClient) -> None:
     assert ids[0] == started.id
     assert ids.index(pending_soon.id) < ids.index(pending_later.id)
     assert out.ranking_basis[0] == "in_progress_first"
+
+
+def test_archived_completed_dependency_keeps_dependent_executable(
+    client: TaskdogApiClient,
+) -> None:
+    task_a = client.create_task(name="dependency task")
+    task_b = client.create_task(name="dependent task")
+    client.add_dependency(task_b.id, task_a.id)
+
+    blocked = client.get_executable_tasks(limit=10)
+    assert task_b.id not in [t.id for t in blocked.tasks]
+
+    client.start_task(task_a.id)
+    client.complete_task(task_a.id)
+    client.archive_task(task_a.id)
+
+    unblocked = client.get_executable_tasks(limit=10)
+    assert task_b.id in [t.id for t in unblocked.tasks]


### PR DESCRIPTION
## Summary

Adds a `get_executable_tasks` primitive to **taskdog-core**: it returns dependency-resolved executable tasks in a transparent, deterministic order, and is surfaced through the server, client, and MCP. This moves logic that previously lived (priority-only, opaque) in the MCP glue layer down into core, where every frontend can reuse it.

Motivation: the "taskloop" self-driving workflow needs a trustworthy answer to *"which task now, and why"* — the dispatch loop currently can't explain its selection. This gives it a canonical, explainable ordering while keeping judgment (final override, human-readable reason phrasing) in taskdog-cc.

## Ranking (deterministic)

1. `IN_PROGRESS` before `PENDING` — resume started work first, so in-progress tasks are never neglected by the loop.
2. `deadline` ascending, `None` last (overdue sorts first naturally).
3. `priority` descending.
4. `estimated_duration` ascending, `None` last.
5. `id` ascending (stable tie-break).

Executable = `PENDING`/`IN_PROGRESS`, not archived, and every dependency `COMPLETED`. A completed dependency **stays satisfied even after it is archived** (dependency statuses are resolved from the full task universe, not just non-archived tasks) — covered by a real-SQLite e2e test.

Core emits data only: each row carries its ranking-key values and the response carries a fixed `ranking_basis` factor list. No human "reason" NLG in core — that stays in taskdog-cc.

## Changes

- **core**: `TaskQueryService.get_executable_tasks(tags, limit)`, `NextTasksOutput` DTO, `QueryController.get_executable_tasks`.
- **server**: `GET /api/v1/tasks/executable` (registered before `/{task_id}`).
- **client**: `TaskdogApiClient.get_executable_tasks` + converter.
- **mcp**: the `get_executable_tasks` tool now delegates to the core-backed client — **name, signature, and output dict shape unchanged**, so taskdog-cc's dispatch loop is unaffected. Hand-rolled dependency-filtering helpers deleted.

## Testing

- Core unit: full ranking precedence (in-progress tier, `None` placements, tie-breaks), dependency resolution (met/unmet/missing/archived-completed), tag OR filtering, limit.
- Server endpoint, client converter, MCP delegation (shape-stable), and an e2e ranking + archived-dependency journey.
- `make test` (99% coverage), `make check`, and the e2e suite all pass.

## Out of scope (follow-up)

CLI `taskdog next`, a singular `get_next_task` tool, and selectable ranking strategies — intentionally deferred (YAGNI; the loop reaches taskdog via MCP/client, and "what's next now" needs one stable answer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)