### PR TITLE
feat(nix): add uv2nix flake for reproducible install and dev shells

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,99 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1784120854,
+        "narHash": "sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "753cc8a3a87467296ddd1fa93f0cc3e81120ee46",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-build-systems": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "pyproject-nix"
+        ],
+        "uv2nix": [
+          "uv2nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782093830,
+        "narHash": "sha256-6gmEVe69+KlRkZD4PEEV5xAlB9CB0Y9TiuEgQjDrKTQ=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "430680a19bc85a3bda55f12e4cc1a1aadcf2e478",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782905613,
+        "narHash": "sha256-SvXJcAemihifkTn4BGvyE5K1FJX9bl4U8DQ5pqKvD0s=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "7af23cfe91064865ecf2e835da28b45b3c6f49fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "pyproject-build-systems": "pyproject-build-systems",
+        "pyproject-nix": "pyproject-nix",
+        "uv2nix": "uv2nix"
+      }
+    },
+    "uv2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783511944,
+        "narHash": "sha256-Z/Ss9rWw9QYcRK+Qqkmty7PB1pIik5XGbrtit+ad2qs=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "83995ef5e4ece3c9c704aa645bbff439e15a0ac3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,167 @@
+{
+  description = "Taskdog - individual task management (CLI/TUI + REST API), packaged with uv2nix";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+    pyproject-nix = {
+      url = "github:pyproject-nix/pyproject.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    uv2nix = {
+      url = "github:pyproject-nix/uv2nix";
+      inputs.pyproject-nix.follows = "pyproject-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    pyproject-build-systems = {
+      url = "github:pyproject-nix/build-system-pkgs";
+      inputs.pyproject-nix.follows = "pyproject-nix";
+      inputs.uv2nix.follows = "uv2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      uv2nix,
+      pyproject-nix,
+      pyproject-build-systems,
+      ...
+    }:
+    let
+      inherit (nixpkgs) lib;
+
+      # Load the uv workspace from the repo root (reads pyproject.toml + uv.lock).
+      workspace = uv2nix.lib.workspace.loadWorkspace { workspaceRoot = ./.; };
+
+      # Overlay translating the uv.lock into a pyproject.nix package set.
+      # Prefer wheels — fewer packages need to be compiled from source.
+      overlay = workspace.mkPyprojectOverlay {
+        sourcePreference = "wheel";
+      };
+
+      # Project-specific overrides. Empty for now; add entries here if a
+      # dependency fails to build (e.g. missing native build inputs).
+      pyprojectOverrides = _final: _prev: { };
+
+      # Supported systems.
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+      forAllSystems = lib.genAttrs systems;
+
+      pkgsFor = system: nixpkgs.legacyPackages.${system};
+
+      # Match the project's pinned interpreter (.python-version = 3.13).
+      pythonFor = system: (pkgsFor system).python313;
+
+      # Fully-resolved python package set for a given system.
+      pythonSetFor =
+        system:
+        let
+          pkgs = pkgsFor system;
+          python = pythonFor system;
+        in
+        (pkgs.callPackage pyproject-nix.build.packages {
+          inherit python;
+        }).overrideScope
+          (
+            lib.composeManyExtensions [
+              pyproject-build-systems.overlays.default
+              overlay
+              pyprojectOverrides
+            ]
+          );
+
+      # A virtualenv containing every workspace package + its runtime deps.
+      # Tagged with meta so `nix profile install` and `nix run` behave nicely.
+      venvFor =
+        system:
+        ((pythonSetFor system).mkVirtualEnv "taskdog-env" workspace.deps.default).overrideAttrs
+          (old: {
+            meta = (old.meta or { }) // {
+              description = "Taskdog - individual task management (CLI/TUI + REST API)";
+              homepage = "https://github.com/Kohei-Wada/taskdog";
+              license = lib.licenses.mit;
+              mainProgram = "taskdog";
+              platforms = systems;
+            };
+          });
+    in
+    {
+      # `nix build` / `nix build .#taskdog` -> a venv exposing the CLI, server, MCP.
+      # Install with: nix profile install github:Kohei-Wada/taskdog
+      packages = forAllSystems (
+        system:
+        let
+          venv = venvFor system;
+        in
+        {
+          default = venv;
+          taskdog = venv;
+        }
+      );
+
+      # `nix run .#taskdog` (CLI/TUI), `.#taskdog-server`, `.#taskdog-mcp`.
+      apps = forAllSystems (
+        system:
+        let
+          venv = venvFor system;
+        in
+        {
+          default = self.apps.${system}.taskdog;
+          taskdog = {
+            type = "app";
+            program = "${venv}/bin/taskdog";
+          };
+          taskdog-server = {
+            type = "app";
+            program = "${venv}/bin/taskdog-server";
+          };
+          taskdog-mcp = {
+            type = "app";
+            program = "${venv}/bin/taskdog-mcp";
+          };
+        }
+      );
+
+      # Dev shells.
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+          python = pythonFor system;
+        in
+        {
+          # Impure shell: uses uv directly to manage the .venv (editable installs,
+          # matches the Makefile workflow). Run `uv sync` inside, then `make test`.
+          default = pkgs.mkShell {
+            packages = [
+              python
+              pkgs.uv
+            ];
+            env = {
+              # Force uv to use the nixpkgs interpreter, never download one.
+              UV_PYTHON_DOWNLOADS = "never";
+              UV_PYTHON = python.interpreter;
+            };
+            shellHook = ''
+              unset PYTHONPATH
+            '';
+          };
+
+          # Pure shell: the fully Nix-built venv on PATH, no uv/network needed.
+          pure = pkgs.mkShell {
+            packages = [ (venvFor system) ];
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
## Summary

Adds a Nix flake (`flake.nix` + `flake.lock`) that packages the taskdog UV workspace with [uv2nix](https://github.com/pyproject-nix/uv2nix), giving reproducible installs and dev shells straight from `pyproject.toml` + `uv.lock`.

## What it provides

- **Packages** — `nix build` / `nix profile install github:Kohei-Wada/taskdog` builds a venv exposing the CLI, server, and MCP entry points (`default` / `taskdog`).
- **Apps** — `nix run .#taskdog` (CLI/TUI), `.#taskdog-server`, `.#taskdog-mcp`.
- **Dev shells**:
  - `default` (impure): `python313` + `uv` on PATH, `UV_PYTHON_DOWNLOADS=never` so uv reuses the nixpkgs interpreter — matches the existing Makefile workflow.
  - `pure`: the fully Nix-built venv on PATH, no uv/network needed.

## Details

- Pins the interpreter to `python313` to match `.python-version`.
- `sourcePreference = "wheel"` to minimize source builds; `pyprojectOverrides` left empty as a hook for future native-build fixes.
- Supported systems: `x86_64-linux`, `aarch64-linux`, `aarch64-darwin`, `x86_64-darwin`.
- Package metadata (license MIT, homepage, `mainProgram = "taskdog"`) set for clean `nix run` / `nix profile install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)