### PR TITLE
fix: use SCHEDULING_EPSILON in greedy/backward scheduling loops

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/services/optimization/backward_optimization_strategy.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/optimization/backward_optimization_strategy.py
@@ -2,6 +2,7 @@
 
 from datetime import date, datetime, timedelta
 
+from taskdog_core.application.constants.optimization import SCHEDULING_EPSILON
 from taskdog_core.application.dto.optimize_params import OptimizeParams
 from taskdog_core.application.dto.optimize_result import OptimizeResult
 from taskdog_core.application.services.optimization.allocation_helpers import (
@@ -84,7 +85,7 @@ class BackwardOptimizationStrategy(OptimizationStrategy):
         schedule_end = None
         temp_allocations: list[tuple[date, float, datetime]] = []
 
-        while remaining_hours > 0:
+        while remaining_hours > SCHEDULING_EPSILON:
             if not params.include_all_days and not is_workday(
                 current_date, params.holiday_checker
             ):
@@ -103,7 +104,7 @@ class BackwardOptimizationStrategy(OptimizationStrategy):
                 params.max_hours_per_day,
             )
 
-            if available_hours > 0:
+            if available_hours > SCHEDULING_EPSILON:
                 allocated = min(remaining_hours, available_hours)
                 temp_allocations.append((date_obj, allocated, current_date))
                 remaining_hours -= allocated

--- a/packages/taskdog-core/src/taskdog_core/application/services/optimization/greedy_based_optimization_strategy.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/optimization/greedy_based_optimization_strategy.py
@@ -2,6 +2,7 @@
 
 from datetime import date, datetime, timedelta
 
+from taskdog_core.application.constants.optimization import SCHEDULING_EPSILON
 from taskdog_core.application.dto.optimize_params import OptimizeParams
 from taskdog_core.application.dto.optimize_result import OptimizeResult
 from taskdog_core.application.services.optimization.allocation_helpers import (
@@ -116,7 +117,7 @@ class GreedyBasedOptimizationStrategy(OptimizationStrategy):
         schedule_end = None
         task_daily_allocations: dict[date, float] = {}
 
-        while remaining_hours > 0:
+        while remaining_hours > SCHEDULING_EPSILON:
             if not params.include_all_days and not is_workday(
                 current_date, params.holiday_checker
             ):
@@ -137,7 +138,7 @@ class GreedyBasedOptimizationStrategy(OptimizationStrategy):
                 params.max_hours_per_day,
             )
 
-            if available_hours > 0:
+            if available_hours > SCHEDULING_EPSILON:
                 if schedule_start is None:
                     schedule_start = current_date
 

--- a/packages/taskdog-core/tests/application/services/optimization/test_backward_optimization_strategy.py
+++ b/packages/taskdog-core/tests/application/services/optimization/test_backward_optimization_strategy.py
@@ -201,3 +201,55 @@ class TestBackwardOptimizationStrategy(BaseOptimizationStrategyTest):
         updated_task = self.repository.get_by_id(task.id)
         assert updated_task is not None
         assert date(2025, 10, 20) in updated_task.daily_allocations
+
+    def test_backward_exact_multiple_of_fractional_max_hours(self):
+        """Fractional hours that divide evenly must not spill onto an extra day.
+
+        20.1h at 6.7h/day is exactly 3 days, but the subtraction leaves ~1.8e-15
+        rather than 0.0, so a bare `remaining_hours > 0` check walks back one day
+        too far and allocates the residue there.
+        """
+        task = self.create_task(
+            "Fractional Task",
+            estimated_duration=20.1,
+            deadline=datetime(2025, 10, 22, 18, 0, 0),
+        )
+
+        result = self.optimize_schedule(
+            start_date=datetime(2025, 10, 20, 9, 0, 0),
+            max_hours_per_day=6.7,
+        )
+
+        assert len(result.successful_tasks) == 1
+        assert len(result.failed_tasks) == 0
+
+        # Mon-Wed, working back from the Wednesday deadline
+        self.assert_task_scheduled(
+            task, expected_end=datetime(2025, 10, 22, 23, 59, 59)
+        )
+
+        updated_task = self.repository.get_by_id(task.id)
+        assert updated_task is not None
+        assert len(updated_task.daily_allocations) == 3
+        assert date(2025, 10, 17) not in updated_task.daily_allocations
+
+    def test_backward_exact_fit_against_start_date_is_schedulable(self):
+        """A task that exactly fills the days from start_date to deadline must schedule.
+
+        20.1h at 6.7h/day needs Mon-Wed and start_date is Monday. The float residue
+        makes the loop reach back to the previous Friday, before start_date, so the
+        task is wrongly reported unschedulable.
+        """
+        self.create_task(
+            "Exact Fit Task",
+            estimated_duration=20.1,
+            deadline=datetime(2025, 10, 22, 18, 0, 0),
+        )
+
+        result = self.optimize_schedule(
+            start_date=datetime(2025, 10, 20, 9, 0, 0),
+            max_hours_per_day=6.7,
+        )
+
+        assert len(result.failed_tasks) == 0
+        assert len(result.successful_tasks) == 1

--- a/packages/taskdog-core/tests/application/services/optimization/test_greedy_optimization_strategy.py
+++ b/packages/taskdog-core/tests/application/services/optimization/test_greedy_optimization_strategy.py
@@ -197,3 +197,57 @@ class TestGreedyOptimizationStrategy(BaseOptimizationStrategyTest):
         updated_task = self.repository.get_by_id(task.id)
         assert updated_task is not None
         assert date(2025, 10, 20) in updated_task.daily_allocations
+
+    def test_greedy_exact_multiple_of_fractional_max_hours(self):
+        """Fractional hours that divide evenly must not spill onto an extra day.
+
+        20.1h at 6.7h/day is exactly 3 days, but 20.1 - 6.7 - 6.7 - 6.7 leaves
+        ~1.8e-15 rather than 0.0, so a bare `remaining_hours > 0` check runs a
+        fourth day and allocates the residue there.
+        """
+        task = self.create_task(
+            "Fractional Task",
+            estimated_duration=20.1,
+            deadline=datetime(2025, 10, 31, 18, 0, 0),
+        )
+
+        result = self.optimize_schedule(
+            start_date=datetime(2025, 10, 20, 9, 0, 0),
+            max_hours_per_day=6.7,
+        )
+
+        assert len(result.successful_tasks) == 1
+        assert len(result.failed_tasks) == 0
+
+        # Mon-Wed, not Mon-Thu
+        self.assert_task_scheduled(
+            task,
+            expected_start=datetime(2025, 10, 20, 0, 0, 0),
+            expected_end=datetime(2025, 10, 22, 23, 59, 59),
+        )
+
+        updated_task = self.repository.get_by_id(task.id)
+        assert updated_task is not None
+        assert len(updated_task.daily_allocations) == 3
+        assert date(2025, 10, 23) not in updated_task.daily_allocations
+
+    def test_greedy_exact_fit_against_deadline_is_schedulable(self):
+        """A task that exactly fills the days up to its deadline must schedule.
+
+        20.1h at 6.7h/day needs Mon-Wed and the deadline is Wednesday. The float
+        residue pushes allocation to Thursday, past the deadline, so the task is
+        wrongly reported unschedulable.
+        """
+        self.create_task(
+            "Exact Fit Task",
+            estimated_duration=20.1,
+            deadline=datetime(2025, 10, 22, 18, 0, 0),
+        )
+
+        result = self.optimize_schedule(
+            start_date=datetime(2025, 10, 20, 9, 0, 0),
+            max_hours_per_day=6.7,
+        )
+
+        assert len(result.failed_tasks) == 0
+        assert len(result.successful_tasks) == 1


### PR DESCRIPTION
Closes #1089.

Greedy and backward optimizers compared accumulated float hours against `0`, leaving ~1e-14 residue, so a task whose duration is an exact multiple of `max_hours_per_day` got one extra day and could be wrongly reported unschedulable against a tight deadline. Balanced already uses `SCHEDULING_EPSILON`; this makes greedy and backward match. Adds tests for the exact-fit cases.