### PR TITLE
fix(server): add optimistic locking to prevent lost task updates (#961)

### DIFF
--- a/packages/taskdog-client/src/taskdog_client/base_client.py
+++ b/packages/taskdog-client/src/taskdog_client/base_client.py
@@ -14,6 +14,7 @@ import httpx  # type: ignore[import-not-found]
 
 from taskdog_core.domain.exceptions.task_exceptions import (
     AuthenticationError,
+    ConcurrencyConflictError,
     ServerConnectionError,
     ServerError,
     TaskNotFoundException,
@@ -117,6 +118,7 @@ class BaseApiClient:
         Raises:
             TaskNotFoundException: If status is 404
             TaskValidationError: If status is 400 or 422
+            ConcurrencyConflictError: If status is 409
             Exception: For other errors
         """
         if response.status_code == 404:
@@ -127,6 +129,11 @@ class BaseApiClient:
             raise TaskValidationError(detail)
         if response.status_code == 401:
             raise AuthenticationError("Authentication failed. Check your API key.")
+        if response.status_code == 409:
+            detail = "Task was modified by another operation. Re-read and retry."
+            with contextlib.suppress(Exception):
+                detail = response.json().get("detail", detail)
+            raise ConcurrencyConflictError(detail)
         if response.status_code >= 500:
             detail = "Server error occurred"
             with contextlib.suppress(Exception):

--- a/packages/taskdog-client/tests/test_base_client.py
+++ b/packages/taskdog-client/tests/test_base_client.py
@@ -8,6 +8,7 @@ from taskdog_client.base_client import BaseApiClient
 
 from taskdog_core.domain.exceptions.task_exceptions import (
     AuthenticationError,
+    ConcurrencyConflictError,
     ServerConnectionError,
     ServerError,
     TaskNotFoundException,
@@ -85,6 +86,18 @@ class TestBaseApiClient:
             client._handle_error(response)
 
         assert "Authentication failed" in str(exc_info.value)
+
+    def test_handle_error_409_conflict(self):
+        """Test _handle_error raises ConcurrencyConflictError for 409."""
+        client = BaseApiClient(self.base_url, self.timeout)
+        response = Mock()
+        response.status_code = 409
+        response.json.return_value = {"detail": "Task 1 was modified by another op"}
+
+        with pytest.raises(ConcurrencyConflictError) as exc_info:
+            client._handle_error(response)
+
+        assert "Task 1 was modified by another op" in str(exc_info.value)
 
     def test_handle_error_5xx_status(self):
         """Test _handle_error raises ServerError for 5xx errors."""

--- a/packages/taskdog-core/src/taskdog_core/domain/entities/task.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/entities/task.py
@@ -75,6 +75,9 @@ class Task:
     tags: list[str] = field(default_factory=list)
     # Archive flag: True = soft deleted, preserves original status
     is_archived: bool = False
+    # Optimistic-lock version, carried from the read so a concurrent write can
+    # be detected on save (see #961).
+    version: int = 1
 
     def __post_init__(self) -> None:
         """Validate entity invariants after initialization.

--- a/packages/taskdog-core/src/taskdog_core/domain/exceptions/task_exceptions.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/exceptions/task_exceptions.py
@@ -5,6 +5,27 @@ class TaskError(Exception):
     """Base exception for all task-related errors."""
 
 
+class ConcurrencyConflictError(TaskError):
+    """Raised when a task is saved against a stale version.
+
+    Signals that another writer modified the same task between the read and the
+    save (optimistic-lock conflict). Not a validation error: the caller should
+    re-read and retry rather than fix its input, so this maps to HTTP 409.
+    """
+
+    def __init__(
+        self, task_id: int, expected_version: int, actual_version: int
+    ) -> None:
+        self.task_id = task_id
+        self.expected_version = expected_version
+        self.actual_version = actual_version
+        super().__init__(
+            f"Cannot save task {task_id}: it was modified by another operation "
+            f"(expected version {expected_version}, found {actual_version}). "
+            "Re-read the task and try again."
+        )
+
+
 class TaskNotFoundException(TaskError):
     """Raised when a task with given ID is not found."""
 

--- a/packages/taskdog-core/src/taskdog_core/domain/exceptions/task_exceptions.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/exceptions/task_exceptions.py
@@ -14,16 +14,25 @@ class ConcurrencyConflictError(TaskError):
     """
 
     def __init__(
-        self, task_id: int, expected_version: int, actual_version: int
+        self,
+        task_id: int | str,
+        expected_version: int | None = None,
+        actual_version: int | None = None,
     ) -> None:
-        self.task_id = task_id
         self.expected_version = expected_version
         self.actual_version = actual_version
-        super().__init__(
-            f"Cannot save task {task_id}: it was modified by another operation "
-            f"(expected version {expected_version}, found {actual_version}). "
-            "Re-read the task and try again."
-        )
+        if isinstance(task_id, str):
+            # Pre-formatted detail message (e.g. surfaced from an HTTP 409 body
+            # on the client side, where the version numbers aren't available).
+            self.task_id = None
+            super().__init__(task_id)
+        else:
+            self.task_id = task_id
+            super().__init__(
+                f"Cannot save task {task_id}: it was modified by another operation "
+                f"(expected version {expected_version}, found {actual_version}). "
+                "Re-read the task and try again."
+            )
 
 
 class TaskNotFoundException(TaskError):

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/migrations/versions/007_add_task_version.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/migrations/versions/007_add_task_version.py
@@ -1,0 +1,53 @@
+"""Add optimistic-lock version column to tasks.
+
+Revision ID: 007_add_task_version
+Revises: 006_remove_daily_allocations_json
+Create Date: 2026-07-20
+
+Adds an integer ``version`` column (default 1) used for optimistic locking so
+concurrent read-modify-write updates raise a conflict instead of silently
+overwriting each other (see #961). Existing rows are backfilled to version 1
+via the server default.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "007_add_task_version"
+down_revision: str | None = "006_remove_daily_allocations_json"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the ``version`` column if it is not already present.
+
+    Uses batch mode for SQLite compatibility and a server default of 1 so
+    pre-existing rows are backfilled.
+    """
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    columns = {col["name"] for col in inspector.get_columns("tasks")}
+    if "version" not in columns:
+        with op.batch_alter_table("tasks") as batch_op:
+            batch_op.add_column(
+                sa.Column(
+                    "version",
+                    sa.Integer(),
+                    nullable=False,
+                    server_default="1",
+                )
+            )
+
+
+def downgrade() -> None:
+    """Drop the ``version`` column."""
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    columns = {col["name"] for col in inspector.get_columns("tasks")}
+    if "version" in columns:
+        with op.batch_alter_table("tasks") as batch_op:
+            batch_op.drop_column("version")

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/models/task_model.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/models/task_model.py
@@ -46,6 +46,12 @@ class TaskModel(Base):
     created_at: Mapped[datetime] = mapped_column(nullable=False)
     updated_at: Mapped[datetime] = mapped_column(nullable=False)
 
+    # Optimistic-lock version. Bumped on every update; a stale version at save
+    # time means another writer modified the row first (see #961).
+    version: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1, server_default="1"
+    )
+
     # Schedule fields (nullable)
     planned_start: Mapped[datetime | None] = mapped_column(nullable=True)
     planned_end: Mapped[datetime | None] = mapped_column(nullable=True)

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/mutation_builders/task_update_builder.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/mutation_builders/task_update_builder.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from sqlalchemy.orm import Session
 
 from taskdog_core.domain.entities.task import Task
+from taskdog_core.domain.exceptions.task_exceptions import ConcurrencyConflictError
 from taskdog_core.infrastructure.persistence.database.models import TaskModel
 from taskdog_core.infrastructure.persistence.mappers.task_db_mapper import TaskDbMapper
 
@@ -47,8 +48,28 @@ class TaskUpdateBuilder:
         Note:
             - Updates the model in-place
             - Automatically sets updated_at timestamp
+            - Bumps the optimistic-lock version, rejecting stale writes
             - Changes are tracked by SQLAlchemy session but not committed
             - Call session.commit() to persist the change
+
+        Raises:
+            ConcurrencyConflictError: If ``model`` (freshly loaded from the
+                database) is at a newer version than the entity being saved,
+                i.e. another writer modified the task in between.
         """
+        # Optimistic lock: the model is loaded fresh from the DB, so its version
+        # reflects the current row; task.version is what the caller read. A
+        # mismatch means someone else wrote first -> reject instead of clobber.
+        if model.version != task.version:
+            raise ConcurrencyConflictError(
+                task_id=model.id,
+                expected_version=task.version,
+                actual_version=model.version,
+            )
         self._mapper.update_model(model, task)
         model.updated_at = datetime.now()
+        new_version = task.version + 1
+        model.version = new_version
+        # Advance the in-memory entity too, so saving the same entity again in
+        # the same flow does not conflict against the row it just wrote.
+        task.version = new_version

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/mappers/task_db_mapper.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/mappers/task_db_mapper.py
@@ -151,6 +151,7 @@ class TaskDbMapper:
             depends_on=depends_on,
             tags=tags,
             is_archived=model.is_archived,
+            version=model.version,
         )
 
     def update_model(self, model: TaskModel, task: Task) -> None:

--- a/packages/taskdog-core/tests/infrastructure/persistence/database/mutation_builders/test_task_update_builder.py
+++ b/packages/taskdog-core/tests/infrastructure/persistence/database/mutation_builders/test_task_update_builder.py
@@ -7,6 +7,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from taskdog_core.domain.entities.task import Task, TaskStatus
+from taskdog_core.domain.exceptions.task_exceptions import ConcurrencyConflictError
 from taskdog_core.infrastructure.persistence.database.models import TaskModel
 from taskdog_core.infrastructure.persistence.database.models.task_model import Base
 from taskdog_core.infrastructure.persistence.database.mutation_builders import (
@@ -161,3 +162,68 @@ class TestTaskUpdateBuilder:
             assert initial_model.status == "IN_PROGRESS"
             assert initial_model.estimated_duration == 15.0
             assert initial_model.is_fixed is True
+
+    def test_update_task_bumps_version(self):
+        """A successful update increments the optimistic-lock version."""
+        initial_model = TaskModel(
+            id=1,
+            name="Task",
+            priority=5,
+            status="PENDING",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+        updated_task = Task(
+            id=1, name="Task v2", priority=5, status=TaskStatus.PENDING, tags=[]
+        )
+
+        with self.Session() as session:
+            session.add(initial_model)
+            session.flush()
+            assert initial_model.version == 1
+
+            builder = TaskUpdateBuilder(session, self.mapper)
+            builder.update_task(initial_model, updated_task)
+
+            assert initial_model.version == 2
+
+    def test_update_task_rejects_stale_version(self):
+        """A save whose read-time version is behind the row raises a conflict.
+
+        Reproduces the lost-update scenario in #961: the row in the database is
+        already at version 2 (another writer committed first), but the entity
+        being saved was read at version 1. The stale write must be rejected, not
+        silently applied.
+        """
+        current_model = TaskModel(
+            id=1,
+            name="Original",
+            priority=5,
+            status="PENDING",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            version=2,
+        )
+        stale_task = Task(
+            id=1,
+            name="Stale overwrite",
+            priority=9,
+            status=TaskStatus.PENDING,
+            tags=[],
+            version=1,
+        )
+
+        with self.Session() as session:
+            session.add(current_model)
+            session.flush()
+
+            builder = TaskUpdateBuilder(session, self.mapper)
+            with pytest.raises(ConcurrencyConflictError) as exc_info:
+                builder.update_task(current_model, stale_task)
+
+            assert exc_info.value.expected_version == 1
+            assert exc_info.value.actual_version == 2
+            # The stale write must not have touched the row.
+            assert current_model.name == "Original"
+            assert current_model.priority == 5
+            assert current_model.version == 2

--- a/packages/taskdog-core/tests/infrastructure/persistence/database/test_migration_runner.py
+++ b/packages/taskdog-core/tests/infrastructure/persistence/database/test_migration_runner.py
@@ -86,7 +86,7 @@ class TestRunMigrations:
             # Should now have alembic_version stamped
             inspector = inspect(engine)
             assert "alembic_version" in inspector.get_table_names()
-            assert get_current_revision(engine) == "006_remove_daily_allocations_json"
+            assert get_current_revision(engine) == "007_add_task_version"
         finally:
             engine.dispose()
 
@@ -100,7 +100,7 @@ class TestRunMigrations:
             run_migrations(engine)
 
             # Should still work and have correct revision
-            assert get_current_revision(engine) == "006_remove_daily_allocations_json"
+            assert get_current_revision(engine) == "007_add_task_version"
         finally:
             engine.dispose()
 
@@ -130,6 +130,7 @@ class TestRunMigrations:
                 "is_fixed",
                 "depends_on",
                 "is_archived",
+                "version",
             }
             assert columns == expected_columns
         finally:
@@ -294,7 +295,7 @@ class TestGetCurrentRevision:
         try:
             run_migrations(engine)
 
-            assert get_current_revision(engine) == "006_remove_daily_allocations_json"
+            assert get_current_revision(engine) == "007_add_task_version"
         finally:
             engine.dispose()
 

--- a/packages/taskdog-core/tests/infrastructure/persistence/database/test_sqlite_task_repository.py
+++ b/packages/taskdog-core/tests/infrastructure/persistence/database/test_sqlite_task_repository.py
@@ -7,6 +7,7 @@ import pytest
 
 from taskdog_core.domain.constants import MAX_TAGS_PER_TASK
 from taskdog_core.domain.entities.task import Task, TaskStatus
+from taskdog_core.domain.exceptions.task_exceptions import ConcurrencyConflictError
 from taskdog_core.infrastructure.persistence.database.sqlite_task_repository import (
     SqliteTaskRepository,
 )
@@ -66,6 +67,35 @@ class TestSqliteTaskRepository:
         retrieved = self.repository.get_by_id(1)
         assert retrieved.name == "Updated"
         assert retrieved.priority == 5
+
+    def test_save_rejects_concurrent_stale_update(self):
+        """Two readers of the same task: the second save must not clobber the first.
+
+        Regression for #961. Both flows read the task, then each saves its own
+        change. Without optimistic locking the later save silently overwrites
+        the earlier one (lost update); now the stale save raises a conflict.
+        """
+        self.repository.save(Task(id=1, name="Original", priority=1))
+
+        # Two independent reads of the same task (both at version 1).
+        reader_a = self.repository.get_by_id(1)
+        reader_b = self.repository.get_by_id(1)
+        assert reader_a.version == reader_b.version == 1
+
+        # Reader A commits its change first.
+        reader_a.priority = 5
+        self.repository.save(reader_a)
+
+        # Reader B, still holding the stale version, must be rejected.
+        reader_b.name = "Clobbered"
+        with pytest.raises(ConcurrencyConflictError):
+            self.repository.save(reader_b)
+
+        # A's change survived; B's did not.
+        persisted = self.repository.get_by_id(1)
+        assert persisted.name == "Original"
+        assert persisted.priority == 5
+        assert persisted.version == 2
 
     def test_get_all_returns_all_tasks(self):
         """Test get_all() retrieves all tasks from database."""

--- a/packages/taskdog-server/src/taskdog_server/api/error_handlers.py
+++ b/packages/taskdog-server/src/taskdog_server/api/error_handlers.py
@@ -14,6 +14,7 @@ from taskdog_core.domain.exceptions.backup_exceptions import (
 )
 from taskdog_core.domain.exceptions.tag_exceptions import TagNotFoundException
 from taskdog_core.domain.exceptions.task_exceptions import (
+    ConcurrencyConflictError,
     TaskNotFoundException,
     TaskValidationError,
 )
@@ -40,11 +41,19 @@ async def _not_implemented_handler(_request: Request, exc: Exception) -> JSONRes
     )
 
 
+async def _conflict_handler(_request: Request, exc: Exception) -> JSONResponse:
+    """Map concurrent-modification domain exceptions to 409 CONFLICT."""
+    return JSONResponse(
+        status_code=status.HTTP_409_CONFLICT, content={"detail": str(exc)}
+    )
+
+
 def register_exception_handlers(app: FastAPI) -> None:
     """Register domain exception handlers on the FastAPI app.
 
     - TaskNotFoundException, TagNotFoundException -> 404 NOT_FOUND
     - TaskValidationError (and subclasses), BackupValidationError -> 400 BAD_REQUEST
+    - ConcurrencyConflictError -> 409 CONFLICT
     - BackupNotSupportedError -> 501 NOT_IMPLEMENTED
 
     Starlette resolves handlers by walking the exception's MRO, so registering
@@ -57,5 +66,6 @@ def register_exception_handlers(app: FastAPI) -> None:
     app.add_exception_handler(TaskNotFoundException, _not_found_handler)
     app.add_exception_handler(TagNotFoundException, _not_found_handler)
     app.add_exception_handler(TaskValidationError, _bad_request_handler)
+    app.add_exception_handler(ConcurrencyConflictError, _conflict_handler)
     app.add_exception_handler(BackupValidationError, _bad_request_handler)
     app.add_exception_handler(BackupNotSupportedError, _not_implemented_handler)

--- a/tests/e2e/test_concurrency.py
+++ b/tests/e2e/test_concurrency.py
@@ -1,10 +1,11 @@
 """E2E: concurrent writes stay consistent through the real server + SQLite.
 
 Taskdog is used de-facto multi-writer (one person driving several AI agents at
-once), so these lock in the contract that concurrent HTTP writes neither error
-nor lose/corrupt data. It holds today because the engine runs SQLite in WAL mode
-with a 30s busy_timeout (see engine_factory.py); these tests would fail if that
-serialization guarantee regressed.
+once), so these lock in the contract that concurrent HTTP writes never corrupt
+data. Since #961, an update whose read-time version is stale is cleanly rejected
+with a 409 conflict rather than silently overwriting a newer write, so a
+contended update either commits or raises ``ConcurrencyConflictError`` - never a
+500 or a torn/garbage value. Concurrent creates still all persist.
 
 Each thread uses its own TaskdogApiClient because a client wraps a single
 httpx.Client that must not be shared across threads.
@@ -16,6 +17,8 @@ from concurrent.futures import ThreadPoolExecutor
 
 from taskdog_client.taskdog_api_client import TaskdogApiClient
 
+from taskdog_core.domain.exceptions.task_exceptions import ConcurrencyConflictError
+
 _WRITERS = 20
 
 
@@ -25,19 +28,28 @@ def test_concurrent_updates_to_same_task_stay_consistent(
     task = client.create_task(name="contended", priority=1)
     priorities = list(range(2, 2 + _WRITERS))
 
-    def update_priority(priority: int) -> None:
+    def update_priority(priority: int) -> str:
         api = TaskdogApiClient(base_url=live_server)
         try:
             api.update_task(task.id, priority=priority)
+            return "ok"
+        except ConcurrencyConflictError:
+            # Optimistic locking (#961): a writer that read a stale version is
+            # rejected with 409 instead of silently clobbering a newer write.
+            return "conflict"
         finally:
             api.close()
 
     with ThreadPoolExecutor(max_workers=_WRITERS) as pool:
-        list(pool.map(update_priority, priorities))
+        outcomes = list(pool.map(update_priority, priorities))
 
+    # Every writer either committed or was cleanly rejected with a conflict -
+    # never a 500 or a torn/garbage value - and at least one write landed.
+    assert set(outcomes) <= {"ok", "conflict"}
+    assert "ok" in outcomes
     fetched = client.get_task_by_id(task.id)
-    # Last-writer-wins: the final value is exactly one of the submitted ones,
-    # never a torn/garbage value, and unrelated fields are untouched.
+    # Final value is exactly one of the submitted ones, and unrelated fields are
+    # untouched.
     assert fetched.task.priority in priorities
     assert fetched.task.status == task.status
 


### PR DESCRIPTION
Fixes #961.

## Problem

All mutating operations read a task in one transaction, mutate it in memory, then `repository.save()` it in another, writing every column. There is no row lock and no version check, so two concurrent updates to the same task silently lose one of the changes (last-writer-wins). This is reachable now that the TUI, CLI, and MCP server can all hit the local server concurrently (e.g. an agent via MCP while the user edits in the TUI).

## Fix

Optimistic locking via a `version` column, per the approach in the issue:

- **`TaskModel`** gains a `version` column (`Integer`, default 1). Alembic migration `007_add_task_version` adds it and backfills existing rows via `server_default="1"`.
- **`Task`** entity carries `version`, populated by the mapper on read and advanced on save.
- **`TaskUpdateBuilder.update_task`** compares the freshly-loaded row's version against the entity's read-time version. On mismatch it raises `ConcurrencyConflictError` instead of overwriting; otherwise it bumps the version. The in-memory entity is advanced too, so saving the same entity again in one flow doesn't self-conflict.
- **Server** maps `ConcurrencyConflictError` to **HTTP 409 CONFLICT**.

## Tests

- `test_task_update_builder.py`: version bumps on a successful update; a stale-version save raises `ConcurrencyConflictError` and leaves the row untouched.
- `test_sqlite_task_repository.py`: end-to-end lost-update scenario - two readers, first save wins, the stale second save raises (this also exercises migration 007).
- Updated the migration-runner schema/revision assertions for the new head.

Full `taskdog-core` suite passes locally (the only failures are pre-existing `holidays`-library issues unrelated to this change).