### PR TITLE
docs: fix default value for auth.enabled in configuration guide

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -55,7 +55,7 @@ The `[auth]` section configures API key authentication for the server.
 
 ```toml
 [auth]
-enabled = true  # Enable/disable authentication (default: true)
+enabled = true  # Enable/disable authentication (default: false)
 
 # Define API keys (can have multiple)
 [[auth.api_keys]]
@@ -69,7 +69,7 @@ name = "my-desktop"
 
 **Fields:**
 
-- `enabled` (boolean) - Enable or disable authentication. Default: `true`
+- `enabled` (boolean) - Enable or disable authentication. Default: `false`
 - `api_keys` (array) - List of valid API keys
   - `key` (string) - The secret API key value
   - `name` (string) - Friendly name for identifying the client


### PR DESCRIPTION
## Description
This PR updates  to state the correct default value for .

## Motivation
In ,  defaults to  ( and ). However,  stated the default was . Updating the guide ensures users have accurate information when configuring server authentication.