### PR TITLE
docs: fix fork clone URL placeholder in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ This guide will help you get started with contributing to the project.
 1. **Clone the repository:**
 
 ```bash
-git clone https://github.com/Kohei-Wada/taskdog.git
+git clone https://github.com/<your-username>/taskdog.git
 cd taskdog
 ```
 


### PR DESCRIPTION
## Description
This PR fixes the git clone URL placeholder in `CONTRIBUTING.md`.

## Details
Replaced upstream repository URL with user fork placeholder (`Kohei-Wada` $\to$ `<your-username>`).