### PR TITLE
perf(core): batch-fetch dependency subgraph in detect_cycle

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/services/dependency_graph_service.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/dependency_graph_service.py
@@ -33,6 +33,8 @@ class DependencyGraphService:
             List of task IDs forming the cycle if detected, None otherwise.
             Example: [1, 2, 3, 1] means task1→task2→task3→task1
         """
+        adjacency = self._load_reachable_adjacency(target_task_id)
+
         visited: set[int] = set()
         rec_stack: list[int] = []
 
@@ -57,12 +59,9 @@ class DependencyGraphService:
             visited.add(current_id)
             rec_stack.append(current_id)
 
-            # Get current task's dependencies
-            current_task = self.repository.get_by_id(current_id)
-            if current_task and current_task.depends_on:
-                for dep_id in current_task.depends_on:
-                    if dfs(dep_id):
-                        return True
+            for dep_id in adjacency.get(current_id, []):
+                if dfs(dep_id):
+                    return True
 
             rec_stack.pop()
             return False
@@ -73,3 +72,30 @@ class DependencyGraphService:
             return rec_stack.copy()
 
         return None
+
+    def _load_reachable_adjacency(self, root_id: int) -> dict[int, list[int]]:
+        """Load the depends_on adjacency of the subgraph reachable from root_id.
+
+        Fetches tasks level by level with get_by_ids, so repository round trips
+        scale with graph depth instead of node count (avoids N+1 reads).
+
+        Args:
+            root_id: Task ID to start traversal from
+
+        Returns:
+            Mapping of task ID to its depends_on list. Missing tasks map to [].
+        """
+        adjacency: dict[int, list[int]] = {}
+        frontier = [root_id]
+        while frontier:
+            tasks = self.repository.get_by_ids(frontier)
+            next_frontier: dict[int, None] = {}
+            for task_id in frontier:
+                task = tasks.get(task_id)
+                deps = list(task.depends_on) if task and task.depends_on else []
+                adjacency[task_id] = deps
+                for dep_id in deps:
+                    if dep_id not in adjacency:
+                        next_frontier[dep_id] = None
+            frontier = list(next_frontier)
+        return adjacency

--- a/packages/taskdog-core/tests/application/services/test_dependency_graph_service.py
+++ b/packages/taskdog-core/tests/application/services/test_dependency_graph_service.py
@@ -1,5 +1,8 @@
 """Tests for DependencyGraphService."""
 
+from itertools import pairwise
+from unittest.mock import patch
+
 import pytest
 
 from taskdog_core.application.services.dependency_graph_service import (
@@ -220,6 +223,36 @@ class TestDependencyGraphService:
         result = self.service.detect_cycle(task2.id, task1.id)
 
         assert result is None
+
+    def test_detect_cycle_does_not_call_get_by_id_per_node(self):
+        """detect_cycle must batch-fetch tasks, not issue get_by_id per node (N+1)."""
+        tasks = [self.repository.create(name=f"Task {i}", priority=1) for i in range(5)]
+        for upstream, downstream in pairwise(tasks):
+            upstream.depends_on = [downstream.id]
+            self.repository.save(upstream)
+
+        with patch.object(
+            self.repository, "get_by_id", wraps=self.repository.get_by_id
+        ) as get_by_id_spy:
+            result = self.service.detect_cycle(tasks[-1].id, tasks[0].id)
+
+        assert result is not None
+        assert get_by_id_spy.call_count == 0
+
+    def test_detect_cycle_batches_fetches_per_depth_level(self):
+        """A linear chain of depth N must use O(N) get_by_ids calls, not N get_by_id."""
+        tasks = [self.repository.create(name=f"Task {i}", priority=1) for i in range(4)]
+        for upstream, downstream in pairwise(tasks):
+            upstream.depends_on = [downstream.id]
+            self.repository.save(upstream)
+
+        with patch.object(
+            self.repository, "get_by_ids", wraps=self.repository.get_by_ids
+        ) as get_by_ids_spy:
+            result = self.service.detect_cycle(tasks[-1].id, tasks[0].id)
+
+        assert result is not None
+        assert get_by_ids_spy.call_count <= len(tasks)
 
     def test_detect_cycle_complex_graph_with_cycle(self):
         """Test detect_cycle in complex graph with multiple branches."""

--- a/packages/taskdog-core/tests/controllers/test_task_relationship_controller.py
+++ b/packages/taskdog-core/tests/controllers/test_task_relationship_controller.py
@@ -45,15 +45,11 @@ class TestTaskRelationshipController:
             status=TaskStatus.PENDING,
         )
 
-        # Return appropriate task based on ID (cycle detection calls get_by_id multiple times)
-        def get_by_id_side_effect(task_id_arg):
-            if task_id_arg == task_id:
-                return task
-            if task_id_arg == depends_on_id:
-                return dependency_task
-            return None
-
-        self.repository.get_by_id.side_effect = get_by_id_side_effect
+        tasks_by_id = {task_id: task, depends_on_id: dependency_task}
+        self.repository.get_by_id.side_effect = tasks_by_id.get
+        self.repository.get_by_ids.side_effect = lambda ids: {
+            tid: tasks_by_id[tid] for tid in ids if tid in tasks_by_id
+        }
         self.repository.save.return_value = None
 
         # Act


### PR DESCRIPTION
## Summary

Fixes the N+1 access pattern in `DependencyGraphService.detect_cycle` (#1114): the DFS previously called `repository.get_by_id` once per visited node, so a single cycle check on `add_dependency` issued O(V) individual reads against SQLite.

## Changes

- `detect_cycle` now prefetches the dependency subgraph reachable from the target task via a new `_load_reachable_adjacency` helper, fetching level by level with the existing `TaskRepository.get_by_ids` batch method. Repository round trips now scale with graph **depth** instead of node count.
- The DFS itself runs purely in memory over the prefetched adjacency map; the returned cycle path (`rec_stack` semantics) is unchanged, as pinned by the existing tests.
- Tests: added regression tests asserting `get_by_id` is never called per node and that fetch count is bounded by chain depth. Updated `test_task_relationship_controller` mock setup to stub `get_by_ids` alongside `get_by_id`.

## Verification

- `pytest packages/taskdog-core/tests`: 1165 passed
- `ruff check` / `ruff format --check` / `mypy`: clean
- Live server (SQLite backend): created A→B→C chain via `POST /api/v1/tasks/{id}/dependencies`, normal adds return 200; closing the cycle (C→A) correctly rejected with 400 and cycle path `3 → 1 → 2 → 3`.

Closes #1114