### PR TITLE
docs: point stale doc links at the new documentation site

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ Controllers instantiate use cases, build request DTOs, and apply config defaults
 
 ## Design Philosophy
 
-Taskdog is for **individual** task management following GTD. See [DESIGN_PHILOSOPHY.md](docs/DESIGN_PHILOSOPHY.md).
+Taskdog is for **individual** task management following GTD. See [DESIGN_PHILOSOPHY.md](docs/design-philosophy.md).
 
 Key decisions:
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ taskdog gantt
 taskdog tui
 ```
 
-For complete setup including API key configuration, see **[Quick Start Guide](docs/QUICKSTART.md)**.
+For complete setup including API key configuration, see **[Quick Start Guide](https://kohei-wada.github.io/taskdog/getting-started/)**.
 
 ## Features
 
@@ -125,11 +125,11 @@ https://github.com/user-attachments/assets/dcb44390-7b10-49a0-bdfc-01a03d7751f9
 
 ## Documentation
 
-- **[Quick Start Guide](docs/QUICKSTART.md)** - Step-by-step setup
-- **[CLI Commands Reference](docs/COMMANDS.md)** - Complete command documentation
-- **[API Reference](docs/API.md)** - REST API endpoints and examples
-- **[Configuration Guide](docs/CONFIGURATION.md)** - All configuration options
-- **[Design Philosophy](docs/DESIGN_PHILOSOPHY.md)** - Why Taskdog works this way
+- **[Quick Start Guide](https://kohei-wada.github.io/taskdog/getting-started/)** - Step-by-step setup
+- **[CLI Commands Reference](https://kohei-wada.github.io/taskdog/reference/cli-guide/)** - Complete command documentation
+- **[API Reference](https://kohei-wada.github.io/taskdog/reference/api-guide/)** - REST API endpoints and examples
+- **[Configuration Guide](https://kohei-wada.github.io/taskdog/configuration/)** - All configuration options
+- **[Design Philosophy](https://kohei-wada.github.io/taskdog/design-philosophy/)** - Why Taskdog works this way
 - **[Deployment Guide](contrib/README.md)** - Docker, systemd, launchd
 
 ## Architecture

--- a/packages/taskdog-server/README.md
+++ b/packages/taskdog-server/README.md
@@ -54,7 +54,7 @@ Once the server is running, visit:
 - Alternative docs: http://localhost:8000/redoc
 - Health check: http://localhost:8000/health
 
-For complete API reference, see [docs/API.md](../../docs/API.md).
+For complete API reference, see [API Guide](https://kohei-wada.github.io/taskdog/reference/api-guide/).
 
 ## Authentication
 
@@ -75,7 +75,7 @@ Clients authenticate via `X-Api-Key` header:
 curl -H "X-Api-Key: your-secret-key" http://localhost:8000/api/v1/tasks/
 ```
 
-See [Authentication Documentation](../../docs/API.md#authentication) for details.
+See [Authentication Documentation](https://kohei-wada.github.io/taskdog/reference/api-guide/#authentication) for details.
 
 ## WebSocket Real-time Updates
 
@@ -123,7 +123,7 @@ Core configuration: `~/.config/taskdog/core.toml`
 country = "JP"
 ```
 
-See [Configuration Guide](../../docs/CONFIGURATION.md) for all options.
+See [Configuration Guide](https://kohei-wada.github.io/taskdog/configuration/) for all options.
 
 ## Architecture
 


### PR DESCRIPTION
Follow-up to #1129: README, CLAUDE.md, and packages/taskdog-server/README.md still linked the pre-MkDocs doc paths (docs/QUICKSTART.md etc.), which are now 404 on GitHub. Links now point to https://kohei-wada.github.io/taskdog/ pages (site URLs also render correctly on PyPI for the server README) and the renamed docs/design-philosophy.md for CLAUDE.md.