### PR TITLE
fix(core): treat empty notes content as no notes in task detail

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/get_task_detail.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/get_task_detail.py
@@ -41,7 +41,9 @@ class GetTaskDetailUseCase(UseCase[SingleTaskInput, TaskDetailOutput]):
 
         # Read notes in a single query (read_notes returns None if no notes exist)
         notes_content = self.notes_repository.read_notes(input_dto.task_id)
-        has_notes = notes_content is not None
+        # Deleting notes leaves an empty row behind, so an empty string means
+        # "no notes" here too - matching NotesRepository.has_notes().
+        has_notes = bool(notes_content)
 
         # Convert Task entity to DTO
         task_dto = TaskDetailDto.from_entity(task)

--- a/packages/taskdog-core/tests/application/use_cases/test_get_task_detail_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_get_task_detail_use_case.py
@@ -46,6 +46,20 @@ class TestGetTaskDetailUseCase:
         assert result.has_notes is True
         assert result.notes_content == notes_content
 
+    def test_execute_after_notes_deleted(self):
+        """Test has_notes is False once notes are deleted (empty content)."""
+        task = self.repository.create(name="Test Task", priority=1)
+
+        self.notes_repository.write_notes(task.id, "# Test Notes")
+        # delete_notes writes an empty string, leaving an empty row behind
+        self.notes_repository.write_notes(task.id, "")
+
+        input_dto = SingleTaskInput(task.id)
+        result = self.use_case.execute(input_dto)
+
+        assert self.notes_repository.has_notes(task.id) is False
+        assert result.has_notes is False
+
     def test_execute_without_notes(self):
         """Test execute handles missing notes gracefully."""
         task = self.repository.create(name="Test Task", priority=1)


### PR DESCRIPTION
## Description

`GetTaskDetailUseCase` computed `has_notes` from `notes_content is not None`, but `NotesController.delete_notes` implements deletion as `write_notes(task_id, "")`, leaving an empty row behind. `SqliteNotesRepository.has_notes` and `get_task_ids_with_notes` both require `content != ""`, so after deleting a note the two sources of truth disagreed: the task list showed no note indicator while `show`/detail reported `has_notes=True` with empty content. Fixed by using `bool(notes_content)`.

## Related Issue

Closes #1157

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `get_task_detail.py`: `has_notes = bool(notes_content)` so an empty (deleted) note counts as no notes, matching `NotesRepository.has_notes()`.
- Added `test_execute_after_notes_deleted` regression test.

## Testing

### Test Environment

- OS: macOS
- Python version: 3.14
- UV version: N/A (pytest run directly against the source tree)

### Tests Performed

- [x] Unit tests pass (`make test`)
- [x] Added new tests for new features
- [ ] Manual testing completed
- [x] All affected commands work as expected

The new test fails without the source change (`has_notes=True` with `notes_content=''`) and passes with it, verified by stashing the source file. Full `taskdog-core` suite: 1166 passed.

## Code Quality Checklist

- [x] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] Code is formatted (`make format`)
- [x] No new warnings introduced
- [x] Code follows project conventions

Ruff check and format are clean on both changed files.

## Documentation

- [ ] Updated README.md (if needed)
- [ ] Updated CLAUDE.md (if architecture changed)
- [ ] Updated CHANGELOG.md
- [x] Added/updated docstrings
- [ ] Updated type hints

N/A — no user-facing API or architecture change.

## Package Affected

- [x] taskdog-core

## Breaking Changes

- [ ] This PR includes breaking changes
- [ ] Migration guide provided (if breaking changes)

## Checklist

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

The issue offered two directions; this takes the smaller one (`bool(notes_content)` in the use case) rather than changing `delete_notes` to drop the row, since the repository layer already treats empty content as "no notes".
