### PR TITLE
fix(core): apply filter arguments in default TaskRepository.get_filtered

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/domain/repositories/task_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/repositories/task_repository.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from datetime import date
+from datetime import date, datetime
 from typing import Any
 
 from taskdog_core.domain.entities.task import Task, TaskStatus
@@ -70,13 +70,64 @@ class TaskRepository(ABC):
             List of tasks matching the filter criteria
 
         Notes:
-            - Default implementation falls back to get_all() (no optimization)
+            - Default implementation filters get_all() in Python (no optimization)
             - Repositories should override this for SQL-level filtering
             - Date filtering typically checks multiple date fields (deadline, planned dates, etc.)
         """
-        # Default implementation: fallback to get_all() without optimization
-        # Subclasses should override this method to provide SQL-level filtering
-        return self.get_all()
+        # Default implementation: filter get_all() in Python (no optimization).
+        # Subclasses should override this method to provide SQL-level filtering.
+        result: list[Task] = []
+        for task in self.get_all():
+            if not include_archived and task.is_archived:
+                continue
+            if status is not None and task.status != status:
+                continue
+            if tags:
+                if match_all_tags:
+                    if not all(tag in task.tags for tag in tags):
+                        continue
+                elif not any(tag in task.tags for tag in tags):
+                    continue
+            if (
+                start_date is not None or end_date is not None
+            ) and not self._matches_date_filter(task, start_date, end_date):
+                continue
+            result.append(task)
+        return result
+
+    @staticmethod
+    def _matches_date_filter(
+        task: Task, start_date: date | None, end_date: date | None
+    ) -> bool:
+        """Check whether any of the task's date fields fall within the range.
+
+        Mirrors the SQL date filtering logic: deadline, planned_start,
+        planned_end, actual_start and actual_end are combined with OR logic.
+
+        Args:
+            task: Task whose date fields are inspected
+            start_date: Minimum date (inclusive), or None
+            end_date: Maximum date (inclusive), or None
+
+        Returns:
+            True if any date field falls within the requested range
+        """
+        for value in (
+            task.deadline,
+            task.planned_start,
+            task.planned_end,
+            task.actual_start,
+            task.actual_end,
+        ):
+            if value is None:
+                continue
+            value_date = value.date() if isinstance(value, datetime) else value
+            if start_date is not None and value_date < start_date:
+                continue
+            if end_date is not None and value_date > end_date:
+                continue
+            return True
+        return False
 
     def count_tasks(
         self,

--- a/packages/taskdog-core/tests/domain/repositories/__init__.py
+++ b/packages/taskdog-core/tests/domain/repositories/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for domain repository interfaces."""

--- a/packages/taskdog-core/tests/domain/repositories/test_task_repository_defaults.py
+++ b/packages/taskdog-core/tests/domain/repositories/test_task_repository_defaults.py
@@ -1,0 +1,107 @@
+"""Tests for TaskRepository's default (non-overridden) filtering methods."""
+
+from datetime import date, datetime
+from typing import Any
+
+import pytest
+
+from taskdog_core.domain.entities.task import Task, TaskStatus
+from taskdog_core.domain.repositories.task_repository import TaskRepository
+
+
+class MinimalTaskRepository(TaskRepository):
+    """Repository that only implements the abstract methods.
+
+    It deliberately does not override get_filtered()/count_tasks(), so it
+    exercises the default implementations provided by the base class.
+    """
+
+    def __init__(self, tasks: list[Task]) -> None:
+        self._tasks = tasks
+
+    def get_all(self) -> list[Task]:
+        return list(self._tasks)
+
+    def get_by_id(self, task_id: int) -> Task | None:
+        return next((t for t in self._tasks if t.id == task_id), None)
+
+    def get_by_ids(self, task_ids: list[int]) -> dict[int, Task]:
+        return {t.id: t for t in self._tasks if t.id in task_ids}
+
+    def save(self, task: Task) -> None:
+        self._tasks.append(task)
+
+    def save_all(self, tasks: list[Task]) -> None:
+        self._tasks.extend(tasks)
+
+    def delete(self, task_id: int) -> None:
+        self._tasks = [t for t in self._tasks if t.id != task_id]
+
+    def create(self, name: str, priority: int | None = None, **kwargs: Any) -> Task:
+        raise NotImplementedError
+
+
+@pytest.fixture
+def repository() -> MinimalTaskRepository:
+    now = datetime(2026, 1, 1)
+    return MinimalTaskRepository(
+        [
+            Task(
+                id=1,
+                name="active",
+                created_at=now,
+                updated_at=now,
+                tags=["work"],
+                deadline=datetime(2026, 3, 10),
+            ),
+            Task(
+                id=2,
+                name="archived",
+                created_at=now,
+                updated_at=now,
+                is_archived=True,
+            ),
+            Task(
+                id=3,
+                name="completed",
+                created_at=now,
+                updated_at=now,
+                status=TaskStatus.COMPLETED,
+                tags=["home"],
+                deadline=datetime(2026, 6, 20),
+            ),
+        ]
+    )
+
+
+class TestTaskRepositoryDefaultGetFiltered:
+    """The default get_filtered() must honour its filter arguments."""
+
+    def test_excludes_archived_tasks(self, repository: MinimalTaskRepository) -> None:
+        names = [t.name for t in repository.get_filtered(include_archived=False)]
+        assert names == ["active", "completed"]
+
+    def test_filters_by_status(self, repository: MinimalTaskRepository) -> None:
+        names = [t.name for t in repository.get_filtered(status=TaskStatus.COMPLETED)]
+        assert names == ["completed"]
+
+    def test_filters_by_tags(self, repository: MinimalTaskRepository) -> None:
+        names = [t.name for t in repository.get_filtered(tags=["work"])]
+        assert names == ["active"]
+
+    def test_filters_by_date_range(self, repository: MinimalTaskRepository) -> None:
+        names = [
+            t.name
+            for t in repository.get_filtered(
+                start_date=date(2026, 1, 1), end_date=date(2026, 4, 1)
+            )
+        ]
+        assert names == ["active"]
+
+    def test_no_filters_returns_all_tasks(
+        self, repository: MinimalTaskRepository
+    ) -> None:
+        assert len(repository.get_filtered()) == 3
+
+    def test_count_tasks_uses_filters(self, repository: MinimalTaskRepository) -> None:
+        assert repository.count_tasks(include_archived=False) == 2


### PR DESCRIPTION
## Description

The default `TaskRepository.get_filtered()` returned `self.get_all()` and silently ignored every argument, so any repository that does not override it returned unfiltered data with no error. `count_tasks()` delegates to it, so counts were wrong too. The base implementation now applies the predicates in Python, mirroring the SQL semantics in `SqliteTaskRepository`/`TaskQueryBuilder`; subclasses can still override for SQL-level filtering.

## Related Issue

Closes #1141

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `TaskRepository.get_filtered()` now filters `get_all()` by `include_archived`, `status`, `tags` (AND/OR) and the date range instead of returning everything.
- Added `TaskRepository._matches_date_filter()`, matching the SQL OR logic across `deadline`, `planned_start`, `planned_end`, `actual_start`, `actual_end`.
- Added `tests/domain/repositories/test_task_repository_defaults.py` covering the default `get_filtered()`/`count_tasks()` via a repository that implements only the abstract members.

## Testing

### Test Environment

- OS: macOS
- Python version: 3.14
- UV version: N/A (ran pytest directly)

### Tests Performed

- [x] Unit tests pass (`make test`)
- [x] Added new tests for new features
- [ ] Manual testing completed
- [ ] All affected commands work as expected

The new tests fail 5/6 on `main` (filters ignored) and pass 6/6 with the fix. The rest of `packages/taskdog-core` is unchanged: 1149 passed before, 1155 after, with the same 5 failures / 12 errors on both sides (pre-existing, from optional deps missing in my environment).

## Code Quality Checklist

- [x] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] Code is formatted (`make format`)
- [x] No new warnings introduced
- [x] Code follows project conventions

Ruff check and format are clean on both changed files.

## Documentation

- [ ] Updated README.md (if needed)
- [ ] Updated CLAUDE.md (if architecture changed)
- [ ] Updated CHANGELOG.md
- [x] Added/updated docstrings
- [x] Updated type hints

## Package Affected

- [x] taskdog-core

## Breaking Changes

- [ ] This PR includes breaking changes
- [ ] Migration guide provided (if breaking changes)

Behavior only changes for repositories that did not override `get_filtered()`, which previously ignored their arguments. `SqliteTaskRepository` and the in-memory test fixture both override it and are unaffected.

## Screenshots/Output

```text
Before:
include_archived=False -> ['active', 'archived', 'done']
status=COMPLETED       -> ['active', 'archived', 'done']
```

```text
After:
include_archived=False -> ['active', 'done']
status=COMPLETED       -> ['done']
```

## Checklist

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
