### PR TITLE
fix(core): enforce Task tag invariants in set_task_tags

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/set_task_tags.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/set_task_tags.py
@@ -1,9 +1,10 @@
 """Use case for setting task tags."""
 
+from dataclasses import replace
+
 from taskdog_core.application.dto.set_task_tags_input import SetTaskTagsInput
 from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 from taskdog_core.application.use_cases.base import UseCase
-from taskdog_core.domain.exceptions.task_exceptions import TaskValidationError
 from taskdog_core.domain.repositories.task_repository import TaskRepository
 
 
@@ -32,19 +33,15 @@ class SetTaskTagsUseCase(UseCase[SetTaskTagsInput, TaskOperationOutput]):
 
         Raises:
             TaskNotFoundException: If task doesn't exist
-            TaskValidationError: If tags are invalid (empty strings or duplicates)
+            TaskValidationError: If tags violate the Task entity's tag invariants
+                (empty strings, duplicates, too many tags, or a tag that is too long)
         """
         task = self._get_task_or_raise(self.repository, input_dto.task_id)
 
-        # Validate tags before setting
-        for tag in input_dto.tags:
-            if not tag or not tag.strip():
-                raise TaskValidationError("Tag cannot be empty")
-        if len(input_dto.tags) != len(set(input_dto.tags)):
-            raise TaskValidationError("Tags must be unique")
-
-        # Replace tags
-        task.tags = input_dto.tags
+        # Rebuild task to trigger __post_init__ validation (Always-Valid Entity).
+        # Direct attribute assignment would skip Task._validate_tags, which also
+        # enforces the maximum tag count and tag length.
+        task = replace(task, tags=input_dto.tags)
 
         # Save changes
         self.repository.save(task)

--- a/packages/taskdog-core/tests/application/use_cases/test_set_task_tags_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_set_task_tags_use_case.py
@@ -6,6 +6,7 @@ from taskdog_core.application.dto.create_task_input import CreateTaskInput
 from taskdog_core.application.dto.set_task_tags_input import SetTaskTagsInput
 from taskdog_core.application.use_cases.create_task import CreateTaskUseCase
 from taskdog_core.application.use_cases.set_task_tags import SetTaskTagsUseCase
+from taskdog_core.domain.entities.task import MAX_TAG_LENGTH, MAX_TAGS_PER_TASK
 from taskdog_core.domain.exceptions.task_exceptions import (
     TaskNotFoundException,
     TaskValidationError,
@@ -107,3 +108,26 @@ class TestSetTaskTagsUseCase:
         result = self.use_case.execute(input_dto)
 
         assert result.tags == ["project-2024", "client_a", "v1.0"]
+
+    def test_execute_with_too_many_tags_raises_error(self):
+        """Test execute enforces the Task entity's maximum tag count."""
+        input_dto = SetTaskTagsInput(
+            task_id=self.task.id,
+            tags=[f"tag{i}" for i in range(MAX_TAGS_PER_TASK + 1)],
+        )
+
+        with pytest.raises(TaskValidationError) as exc_info:
+            self.use_case.execute(input_dto)
+
+        assert f"more than {MAX_TAGS_PER_TASK} tags" in str(exc_info.value)
+
+    def test_execute_with_too_long_tag_raises_error(self):
+        """Test execute enforces the Task entity's maximum tag length."""
+        input_dto = SetTaskTagsInput(
+            task_id=self.task.id, tags=["x" * (MAX_TAG_LENGTH + 1)]
+        )
+
+        with pytest.raises(TaskValidationError) as exc_info:
+            self.use_case.execute(input_dto)
+
+        assert f"exceed {MAX_TAG_LENGTH} characters" in str(exc_info.value)


### PR DESCRIPTION
## Description

`SetTaskTagsUseCase` re-implemented a subset of tag validation locally (non-empty, unique) and then assigned `task.tags = input_dto.tags` directly. Direct attribute assignment never re-runs `__post_init__`, so `Task._validate_tags` — which additionally enforces `MAX_TAGS_PER_TASK` (20) and `MAX_TAG_LENGTH` (50) — was bypassed. `set_task_tags` would happily persist 1000 tags or a 5000-character tag that `create`/`update` reject.

The fix uses `dataclasses.replace(task, tags=...)` so the entity re-validates, mirroring the existing convention in `update_task.py:167-169`. The duplicated local checks are dropped so a single code path owns the invariant.

## Related Issue

Closes #1132

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `set_task_tags.py`: replaced direct `task.tags` assignment + duplicated local validation with `replace(task, tags=input_dto.tags)`, so `Task.__post_init__` validation runs.
- Updated the `Raises:` docstring to reflect the full set of tag invariants now enforced.
- Added two regression tests covering the tag-count and tag-length limits.

## Testing

### Test Environment

- OS: macOS
- Python version: 3.14

### Tests Performed

- [x] Unit tests pass
- [x] Added new tests for new features
- [x] All affected commands work as expected

Both new tests fail on the previous implementation (`DID NOT RAISE TaskValidationError`) and pass with this change (stash-verified). `tests/application` + `tests/domain` are baseline-identical apart from the two added tests (734 -> 736 passed; the same 4 pre-existing `test_date_helper` failures occur with and without this change on my machine).

## Code Quality Checklist

- [x] Linter passes (`ruff check` on changed files)
- [x] Code is formatted (`ruff format --check` on changed files)
- [x] No new warnings introduced
- [x] Code follows project conventions

## Documentation

- [x] Added/updated docstrings

## Package Affected

- [x] taskdog-core

## Breaking Changes

None. The previously-accepted inputs that now raise were already invalid per the `Task` entity contract and are rejected identically by `create`/`update`.

## Checklist

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
