### PR TITLE
fix(core): align SQL end_date filter with whole-day semantics

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/domain/repositories/task_repository.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/repositories/task_repository.py
@@ -101,8 +101,11 @@ class TaskRepository(ABC):
     ) -> bool:
         """Check whether any of the task's date fields fall within the range.
 
-        Mirrors the SQL date filtering logic: deadline, planned_start,
-        planned_end, actual_start and actual_end are combined with OR logic.
+        Mirrors the SQL date filtering logic in
+        ``TaskQueryBuilder._build_date_filter_conditions``: deadline,
+        planned_start, planned_end, actual_start and actual_end are combined
+        with OR logic, and ``end_date`` is whole-day inclusive so a value that
+        carries a time on the boundary day still matches.
 
         Args:
             task: Task whose date fields are inspected

--- a/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/query_builders/task_query_builder.py
+++ b/packages/taskdog-core/src/taskdog_core/infrastructure/persistence/database/query_builders/task_query_builder.py
@@ -8,7 +8,7 @@ The builder supports the hybrid filtering architecture where simple filters
 (archived, status, tags, dates) are translated to SQL for optimal performance.
 """
 
-from datetime import date
+from datetime import date, timedelta
 
 from sqlalchemy import func, or_, select
 from sqlalchemy.sql.expression import ColumnElement
@@ -188,9 +188,14 @@ class TaskQueryBuilder:
         This helper method creates SQLAlchemy filter conditions for date range
         filtering across all date fields (deadline, planned_start, planned_end,
         actual_start, actual_end). It handles three cases for each field:
-        - Both start and end dates: field.between(start_date, end_date)
+        - Both start and end dates: field >= start_date AND field < end_date + 1 day
         - Only start date: field >= start_date
-        - Only end date: field <= end_date
+        - Only end date: field < end_date + 1 day
+
+        The columns store datetimes, so ``end_date`` is turned into an exclusive
+        next-day bound. Comparing against the bare date would coerce it to
+        midnight and drop same-day values that carry a time, which disagrees
+        with ``TaskRepository._matches_date_filter``.
 
         Args:
             start_date: Minimum date for filtering (inclusive), or None
@@ -216,11 +221,14 @@ class TaskQueryBuilder:
 
         # Build conditions for each date field
         for field in date_fields:
+            end_bound = end_date + timedelta(days=1) if end_date else None
             if start_date and end_date:
-                date_conditions.append(field.between(start_date, end_date))  # type: ignore[attr-defined]
+                date_conditions.append(
+                    (field >= start_date) & (field < end_bound)  # type: ignore[operator]
+                )
             elif start_date:
                 date_conditions.append(field >= start_date)  # type: ignore[arg-type,operator]
             elif end_date:
-                date_conditions.append(field <= end_date)  # type: ignore[arg-type,operator]
+                date_conditions.append(field < end_bound)  # type: ignore[arg-type,operator]
 
         return date_conditions

--- a/packages/taskdog-core/tests/infrastructure/persistence/database/query_builders/test_task_query_builder.py
+++ b/packages/taskdog-core/tests/infrastructure/persistence/database/query_builders/test_task_query_builder.py
@@ -172,7 +172,7 @@ class TestTaskQueryBuilder:
         assert "deadline" in result_str
 
     def test_with_date_filter_both_dates(self):
-        """Test that with_date_filter adds BETWEEN clause for date range."""
+        """Test that with_date_filter adds a half-open range for a date range."""
         base_stmt = select(TaskModel)
         builder = TaskQueryBuilder(base_stmt)
 
@@ -180,10 +180,11 @@ class TestTaskQueryBuilder:
             start_date=date(2025, 1, 1), end_date=date(2025, 12, 31)
         ).build()
 
-        # Should add WHERE clause with BETWEEN for date range
+        # Should add WHERE clause with an inclusive lower and exclusive upper bound
         result_str = str(result).lower()
         assert "where" in result_str
-        assert "between" in result_str
+        assert "deadline >=" in result_str
+        assert "deadline <" in result_str
         assert "deadline" in result_str
 
     def test_method_chaining_fluent_interface(self):

--- a/packages/taskdog-core/tests/infrastructure/persistence/database/test_sqlite_task_repository.py
+++ b/packages/taskdog-core/tests/infrastructure/persistence/database/test_sqlite_task_repository.py
@@ -4,6 +4,7 @@ from datetime import date, datetime
 from pathlib import Path
 
 import pytest
+from fixtures.repositories import InMemoryTaskRepository
 
 from taskdog_core.domain.constants import MAX_TAGS_PER_TASK
 from taskdog_core.domain.entities.task import Task, TaskStatus
@@ -536,6 +537,38 @@ class TestSqliteTaskRepository:
         # Count tasks before Feb 28
         before_feb_count = self.repository.count_tasks(end_date=date(2025, 2, 28))
         assert before_feb_count == 3  # task1, task2, task4
+
+    def test_date_filter_end_date_includes_same_day_time(self):
+        """Test end_date is whole-day inclusive for time-bearing values.
+
+        The columns store datetimes, so a bare ``end_date`` bound is coerced to
+        midnight and used to drop same-day values that carry a time. That
+        disagrees with the default ``TaskRepository.get_filtered()``, which
+        compares dates only.
+        """
+        task = Task(
+            id=1, name="Boundary", priority=1, deadline=datetime(2025, 2, 28, 10, 0)
+        )
+        self.repository.save(task)
+
+        end_date = date(2025, 2, 28)
+        in_memory = InMemoryTaskRepository()
+        in_memory.save(task)
+
+        assert len(self.repository.get_filtered(end_date=end_date)) == 1
+        assert (
+            len(
+                self.repository.get_filtered(
+                    start_date=date(2025, 2, 1), end_date=end_date
+                )
+            )
+            == 1
+        )
+        assert self.repository.count_tasks(end_date=end_date) == 1
+        # Both repository implementations must agree on the boundary.
+        assert len(in_memory.get_filtered(end_date=end_date)) == 1
+        # The day after the deadline is still excluded.
+        assert len(self.repository.get_filtered(end_date=date(2025, 2, 27))) == 0
 
     def test_count_tasks_with_combined_filters(self):
         """Test count_tasks() with multiple filters combined."""


### PR DESCRIPTION
## Description

`TaskQueryBuilder._build_date_filter_conditions` compared the datetime columns against the bare `end_date`, which SQLite coerces to midnight, so a same-day value carrying a time was excluded. The default `TaskRepository.get_filtered()` truncates to a date and includes it, so both repository implementations returned different results for the same query. `end_date` is now turned into an exclusive next-day bound, making both paths whole-day inclusive.

## Related Issue

Closes #1164

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `_build_date_filter_conditions`: `end_date` becomes an exclusive `end_date + 1 day` bound (`field >= start` / `field < end + 1d`) instead of `between`/`<= end_date`.
- `TaskRepository._matches_date_filter`: docstring now names the SQL helper it mirrors and states the whole-day-inclusive `end_date` semantics.
- New regression test with a time-bearing boundary value asserting both implementations agree; updated the query-builder SQL-shape assertion that checked for `between`.

## Testing

### Test Environment

- OS: macOS
- Python version: 3.14
- UV version: N/A (plain venv + pytest)

### Tests Performed

- [x] Unit tests pass (`packages/taskdog-core/tests`, 1175 passed)
- [x] Added new tests for new features
- [x] Manual testing completed

`test_date_filter_end_date_includes_same_day_time` fails on `main` (`assert 0 == 1` — the task is dropped by the SQL path) and passes with the fix; verified by stashing only the source change.

## Code Quality Checklist

- [x] Linter passes (Ruff check on changed files)
- [ ] Type checker passes (`make typecheck`)
- [x] Code is formatted (`make format`)
- [x] No new warnings introduced
- [x] Code follows project conventions

## Documentation

- [x] Added/updated docstrings

## Package Affected

- [x] taskdog-core

## Breaking Changes

Behavioural change to the SQL filter only, bringing it in line with the documented inclusive `end_date` and with the default repository implementation.

## Checklist

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
