### PR TITLE
chore: require pre-commit 4.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ docs = [
   "mkdocs-click>=0.8",
 ]
 dev = [
-  "pre-commit>=4.6.0",
+  "pre-commit>=4.6.1",
   "ruff>=0.15.22",
   "mypy>=2.3.0",
   "types-python-dateutil>=2.9.0.20260716",

--- a/uv.lock
+++ b/uv.lock
@@ -1096,7 +1096,7 @@ wheels = [
 
 [[package]]
 name = "pre-commit"
-version = "4.6.0"
+version = "4.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cfgv" },
@@ -1105,9 +1105,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/3a/ddb78f32a0814e66b18a099377a106a2dcdce92d86a034d69d65df9b256e/pre_commit-4.6.1.tar.gz", hash = "sha256:03e809865c7d178b9979d06c761fcbfe6808fdaded8581a745bb110e52050421", size = 198646, upload-time = "2026-07-21T20:56:58.225Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/49/bc925106abcdac498074f2cbe6137e94e09f418dd2b7775df5b577dc0313/pre_commit-4.6.1-py2.py3-none-any.whl", hash = "sha256:0e3b2942510d1fb34eec167a3ec57331bf8442122f1153a9fb8b58f5c49b2717", size = 226186, upload-time = "2026-07-21T20:56:57.064Z" },
 ]
 
 [[package]]
@@ -1834,7 +1834,7 @@ requires-dist = [
     { name = "mkdocs-click", marker = "extra == 'docs'", specifier = ">=0.8" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=2.3.0" },
-    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.6.0" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.6.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.1.1" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.22" },


### PR DESCRIPTION
## Description

I updated the root development dependency to require `pre-commit>=4.6.1` and regenerated `uv.lock`. This picks up the node hook installation change that restores compatibility with npm 12.

## Related Issue

Fixes #1158

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- I raised the minimum pre-commit version from 4.6.0 to 4.6.1.
- I relocked the workspace so pre-commit resolves to 4.6.1.

## Testing

### Test Environment

- OS: Debian Linux
- Python version: 3.13.5
- UV version: 0.11.28

### Tests Performed

- [x] `uv lock --check`
- [x] `pre-commit run markdownlint-cli2 --files README.md`
- [x] Parsed `pyproject.toml` and verified the dev requirement is exactly `pre-commit>=4.6.1`
- [x] `git diff --check`

I deferred the full workspace test suite to CI because this change only updates the development-tool requirement and lockfile.

## Checklist

- [x] My changes follow the project's coding standards.
- [x] I performed a self-review of the complete diff.
- [x] My changes generate no new warnings in the checks listed above.
