### PR TITLE
fix(mcp): report real statistics sections in get_statistics

### DIFF
--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/serializers.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/serializers.py
@@ -11,6 +11,11 @@ def iso(dt: datetime | None) -> str | None:
     return dt.isoformat() if dt else None
 
 
+def model_dump(model: Any | None) -> dict[str, Any] | None:
+    """Serialize a pydantic statistics section, or None when absent."""
+    return model.model_dump(mode="json") if model is not None else None
+
+
 def parse_iso_datetime(
     value: str | None, field_name: str | None = None
 ) -> datetime | None:

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_query.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_query.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from taskdog_mcp.tools.serializers import iso, str_list
+from taskdog_mcp.tools.serializers import iso, model_dump, str_list
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
@@ -33,7 +33,6 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
             Statistics including counts by status, completion rates, etc.
         """
         result = client.calculate_statistics(period)
-        # StatisticsOutput has .task_stats, .time_stats, etc.
         task_stats = result.task_stats
         time_stats = result.time_stats
         return {
@@ -44,10 +43,17 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
             "completed": task_stats.completed_count,
             "canceled": task_stats.canceled_count,
             "completion_rate": task_stats.completion_rate,
-            "overdue_count": 0,  # Not directly available
             "average_completion_time_hours": time_stats.average_work_hours
             if time_stats
             else None,
+            # Every remaining StatisticsOutput section, serialized as-is.
+            "time_stats": model_dump(time_stats),
+            "estimation_stats": model_dump(result.estimation_stats),
+            "deadline_stats": model_dump(result.deadline_stats),
+            "priority_stats": model_dump(result.priority_stats),
+            "trend_stats": model_dump(result.trend_stats),
+            "activity_stats": model_dump(result.activity_stats),
+            "reschedule_stats": model_dump(result.reschedule_stats),
         }
 
     @mcp.tool()

--- a/packages/taskdog-mcp/tests/test_tools.py
+++ b/packages/taskdog-mcp/tests/test_tools.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from taskdog_core.application.dto.statistics_output import (
+    DeadlineComplianceStatistics,
     PriorityDistributionStatistics,
     StatisticsOutput,
     TaskStatistics,
@@ -907,7 +908,6 @@ class TestTaskQueryTools:
         assert result["completed"] == 2
         assert result["canceled"] == 1
         assert result["completion_rate"] == 0.2
-        assert result["overdue_count"] == 0
         assert result["average_completion_time_hours"] == 2.0
 
     def test_get_statistics_without_time_stats(self) -> None:
@@ -945,6 +945,62 @@ class TestTaskQueryTools:
         result = get_statistics_fn(period="all")
 
         assert result["average_completion_time_hours"] is None
+
+    def test_get_statistics_reports_all_sections(self) -> None:
+        """Test get_statistics exposes every StatisticsOutput section."""
+        from mcp.server.fastmcp import FastMCP
+        from taskdog_mcp.tools import task_query
+
+        client = create_mock_client()
+        client.calculate_statistics.return_value = StatisticsOutput(
+            task_stats=TaskStatistics(
+                total_tasks=5,
+                pending_count=2,
+                in_progress_count=1,
+                completed_count=2,
+                canceled_count=0,
+                completion_rate=0.4,
+            ),
+            time_stats=None,
+            estimation_stats=None,
+            deadline_stats=DeadlineComplianceStatistics(
+                total_tasks_with_deadline=3,
+                met_deadline_count=1,
+                missed_deadline_count=2,
+                compliance_rate=1 / 3,
+                average_delay_days=1.5,
+            ),
+            priority_stats=PriorityDistributionStatistics(
+                high_priority_count=1,
+                medium_priority_count=2,
+                low_priority_count=2,
+                high_priority_completion_rate=0.5,
+                priority_completion_map={},
+            ),
+            trend_stats=None,
+        )
+
+        mcp = FastMCP("test")
+        task_query.register_tools(mcp, client)
+
+        get_statistics_fn = mcp._tool_manager._tools["get_statistics"].fn
+        result = get_statistics_fn()
+
+        # The hardcoded overdue_count must not be reported as ground truth.
+        assert "overdue_count" not in result
+        for section in (
+            "time_stats",
+            "estimation_stats",
+            "deadline_stats",
+            "priority_stats",
+            "trend_stats",
+            "activity_stats",
+            "reschedule_stats",
+        ):
+            assert section in result
+        assert result["deadline_stats"]["missed_deadline_count"] == 2
+        assert result["priority_stats"]["high_priority_count"] == 1
+        assert result["time_stats"] is None
 
     def test_get_tag_statistics_returns_formatted_data(self) -> None:
         """Test get_tag_statistics returns properly formatted tag stats."""


### PR DESCRIPTION
## Description

`get_statistics` returned a hardcoded `"overdue_count": 0` that an LLM consumer reads as ground truth, and exposed only `task_stats`/`time_stats` while dropping the other six `StatisticsOutput` sections. The fake key is removed and every remaining section is serialized via a small shared `model_dump` helper in `tools/serializers.py`.

## Related Issue

Closes #1153

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `tools/serializers.py`: added `model_dump()` (serialize a pydantic section, or `None` when absent).
- `tools/task_query.py`: dropped `"overdue_count": 0`; now emits `time_stats`, `estimation_stats`, `deadline_stats`, `priority_stats`, `trend_stats`, `activity_stats`, `reschedule_stats`.
- `tests/test_tools.py`: added `test_get_statistics_reports_all_sections`; dropped the assertion pinning the removed fake key.

## Testing

### Test Environment

- OS: macOS
- Python version: 3.14
- UV version: N/A (venv + pip)

### Tests Performed

- [x] Unit tests pass (`packages/taskdog-mcp/tests/test_tools.py`, 81 passed)
- [x] Added new tests for new features
- [ ] Manual testing completed
- [x] All affected commands work as expected

The new test fails on the unpatched source (`overdue_count` still present, sections missing) and passes with the fix; verified by stashing the two source files.

## Code Quality Checklist

- [x] Linter passes (`ruff check`, clean on changed files)
- [ ] Type checker passes (`make typecheck`)
- [x] Code is formatted (`ruff format --check`, clean)
- [x] No new warnings introduced
- [x] Code follows project conventions

## Documentation

- [ ] Updated README.md (if needed)
- [ ] Updated CLAUDE.md (if architecture changed)
- [ ] Updated CHANGELOG.md
- [x] Added/updated docstrings
- [x] Updated type hints

## Package Affected

- [x] Multiple packages — `taskdog-mcp` only

## Breaking Changes

- [x] This PR includes breaking changes

The `overdue_count` key is removed from the `get_statistics` response. It only ever reported a constant `0`, so no correct consumer depended on its value.

## Screenshots/Output

```text
Before:
keys: average_completion_time_hours, canceled, completed, completion_rate,
      in_progress, overdue_count, pending, period, total_tasks
overdue_count = 0   (actual missed_deadline_count = 2)
```

```text
After:
overdue_count key absent; deadline_stats.missed_deadline_count = 2,
plus estimation/priority/trend/activity/reschedule sections.
```

## Checklist

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Follows the "serialize the full `StatisticsOutput` DTO and remove the fake `overdue_count` key" direction stated in the issue. I did not add a `sections` argument mirroring the CLI's `--focus`; happy to add it if you'd prefer that shape.
