### PR TITLE
docs: fix markdownlint violations

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,6 @@
 
 Complete guide to configuring Taskdog.
 
-
 ## Configuration File Location
 
 Taskdog looks for configuration in the following locations (in order):

--- a/docs/optimization/architecture.md
+++ b/docs/optimization/architecture.md
@@ -2,7 +2,6 @@
 
 This document describes the architecture of taskdog's task scheduling optimization system.
 
-
 ## Overview
 
 The optimization system schedules tasks by allocating work hours across calendar days while respecting constraints like deadlines, work hour limits, and dependencies.
@@ -156,7 +155,7 @@ def _sort_tasks(self, tasks: list[Task], start_date: datetime) -> list[Task]:
 **Functions:**
 
 | Function | Purpose |
-|----------|---------|
+| ---------- | --------- |
 | `prepare_task_for_allocation()` | Validates task and creates deep copy |
 | `calculate_available_hours()` | Computes available hours for a date |
 | `set_planned_times()` | Sets planned_start, planned_end, daily_allocations |
@@ -211,7 +210,7 @@ Entry point that:
 ### Strategy Comparison
 
 | Strategy | Sort Key | Allocation | Use Case |
-|----------|----------|------------|----------|
+| ---------- | ---------- | ------------ | ---------- |
 | **Greedy** | Deadline, Priority | Front-loads | Fast completion, default |
 | **Balanced** | Deadline, Priority | Even distribution | Work-life balance |
 | **Backward** | Deadline (furthest first) | Backward from deadline | Just-in-time, flexibility |

--- a/docs/reference/api-guide.md
+++ b/docs/reference/api-guide.md
@@ -2,7 +2,6 @@
 
 Complete reference for the Taskdog REST API.
 
-
 ## Getting Started
 
 The Taskdog API server provides a comprehensive REST API built with FastAPI. All endpoints return JSON and follow REST conventions.

--- a/docs/reference/cli-guide.md
+++ b/docs/reference/cli-guide.md
@@ -2,7 +2,6 @@
 
 Complete reference for all Taskdog CLI commands.
 
-
 ## Task Creation & Updates
 
 ### add - Create a new task

--- a/packages/taskdog-client/README.md
+++ b/packages/taskdog-client/README.md
@@ -28,7 +28,7 @@ pip install -e ".[dev]"
 ## Client Classes
 
 | Client | Purpose |
-|--------|---------|
+| -------- | --------- |
 | `TaskClient` | Task CRUD operations (create, update, delete, archive) |
 | `LifecycleClient` | Status changes (start, complete, pause, cancel, reopen) |
 | `RelationshipClient` | Dependencies and tags |

--- a/packages/taskdog-ui/ARCHITECTURE.md
+++ b/packages/taskdog-ui/ARCHITECTURE.md
@@ -140,7 +140,7 @@ class MyWidget(Widget):
 ## Decision Matrix: Which Pattern to Use?
 
 | Question | Answer | Pattern |
-|----------|--------|---------|
+| ---------- | -------- | --------- |
 | Does multiple widgets need this state? | Yes | **TUIState** |
 | Is this an event notification? | Yes | **Messages** |
 | Is this widget-internal UI state? | Yes | **Reactive** |


### PR DESCRIPTION
Closes #1167. Ran markdownlint-cli2 --fix, resolving 26 violations across 6 docs files (verified 0 remaining).