### PR TITLE
ci(docs): queue Pages deployments instead of racing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,6 +45,10 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs: build
     runs-on: ubuntu-latest
+    # Pages allows one deployment at a time; queue instead of failing with 400.
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
## Description

Merging #1165 / #1168 / #1169 within the same second started three `Docs` runs
concurrently. `actions/deploy-pages` allows only one deployment at a time, so
the run for #1165 failed with:

```
HttpError: Deployment request failed for 740d50de... due to in progress
deployment. Please cancel 909d556d... first or wait for it to complete.
```

The build itself was fine — this was purely a race between deploy jobs. Adding a
`pages` concurrency group to the `deploy` job makes the runs queue instead.

`cancel-in-progress` is left `false` deliberately: cancelling a deployment that
is already being applied is worse than waiting for it.

## Type of Change

- [x] CI / infrastructure

## Testing

Workflow-only change; `actionlint` (pre-commit) passes.