### PR TITLE
perf(core): avoid sorting all tasks in get_executable_tasks

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
@@ -99,7 +99,7 @@ class TaskQueryService(QueryService):
         """
         # Load the full task universe (incl. archived/completed) so a dependency's
         # status can be resolved even after it was archived post-completion.
-        all_tasks = self.get_filtered_tasks()
+        all_tasks = self.repository.get_all()
         status_by_id = {t.id: t.status for t in all_tasks}
 
         def deps_met(task: Task) -> bool:


### PR DESCRIPTION
## Description
This PR resolves issue #1156 by skipping the throwaway sort operation when retrieving the task universe in `get_executable_tasks`.

## Details
- Previously, `get_executable_tasks` called `self.get_filtered_tasks()` with no filters, which fetches all tasks and sorts them (by default, by ID). This initial sort is entirely discarded because `get_executable_tasks` re-sorts candidate tasks later using `_executable_sort_key`.
- This PR replaces the call to `self.get_filtered_tasks()` with direct invocation of `self.repository.get_all()`, avoiding the unnecessary sort and improving retrieval performance.