### PR TITLE
fix(server): include daily_allocations in TaskFieldsBase server response model

### DIFF
--- a/packages/taskdog-server/src/taskdog_server/api/models/responses.py
+++ b/packages/taskdog-server/src/taskdog_server/api/models/responses.py
@@ -38,6 +38,7 @@ class TaskFieldsBase(BaseModel):
     tags: list[str] = Field(default_factory=list)
     is_fixed: bool = False
     is_archived: bool = False
+    daily_allocations: dict[str, float] = Field(default_factory=dict)
 
 
 class TaskOperationResponse(TaskFieldsBase):


### PR DESCRIPTION
## Description
This PR resolves issue #1135 by adding `daily_allocations: dict[str, float]` to `TaskFieldsBase` in `packages/taskdog-server/src/taskdog_server/api/models/responses.py`.

## Details
- Previously, `TaskFieldsBase` omitted `daily_allocations`, causing FastAPI response serialization of write operations (`TaskOperationResponse`, `UpdateTaskResponse`) to drop `daily_allocations`.
- As a result, the client always validated and deserialized `daily_allocations` to an empty dictionary `{}` after create, update, or lifecycle calls.
- Adding `daily_allocations` ensures full feature parity and complete data round-tripping between the server response models and client DTOs.