### PR TITLE
fix(core): enforce TaskFieldValidatorRegistry validation in CreateTaskUseCase

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/create_task.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/create_task.py
@@ -7,6 +7,9 @@ from taskdog_core.application.dto.create_task_input import CreateTaskInput
 from taskdog_core.application.dto.task_operation_output import TaskOperationOutput
 from taskdog_core.application.queries.workload._strategies import ActualScheduleStrategy
 from taskdog_core.application.use_cases.base import UseCase
+from taskdog_core.application.validators.validator_registry import (
+    TaskFieldValidatorRegistry,
+)
 from taskdog_core.domain.repositories.task_repository import TaskRepository
 
 if TYPE_CHECKING:
@@ -29,6 +32,7 @@ class CreateTaskUseCase(UseCase[CreateTaskInput, TaskOperationOutput]):
                            from daily allocation calculations
         """
         self.repository = repository
+        self.validator_registry = TaskFieldValidatorRegistry(repository)
         self._strategy = ActualScheduleStrategy(holiday_checker=holiday_checker)
 
     def execute(self, input_dto: CreateTaskInput) -> TaskOperationOutput:
@@ -45,6 +49,19 @@ class CreateTaskUseCase(UseCase[CreateTaskInput, TaskOperationOutput]):
             daily_allocations is automatically calculated using ActualScheduleStrategy.
             This enables SQL aggregation for workload calculations.
         """
+        # Validate fields using field validator registry
+        field_mapping = {
+            "name": input_dto.name,
+            "priority": input_dto.priority,
+            "planned_start": input_dto.planned_start,
+            "planned_end": input_dto.planned_end,
+            "deadline": input_dto.deadline,
+            "estimated_duration": input_dto.estimated_duration,
+        }
+        for field_name, value in field_mapping.items():
+            if value is not None:
+                self.validator_registry.validate_field(field_name, value)
+
         # Calculate daily_allocations if all required fields are present
         daily_allocations = self._calculate_daily_allocations(input_dto)
 

--- a/packages/taskdog-core/src/taskdog_core/application/validators/datetime_validator.py
+++ b/packages/taskdog-core/src/taskdog_core/application/validators/datetime_validator.py
@@ -27,12 +27,12 @@ class DateTimeValidator(FieldValidator):
         """
         self.field_name = field_name
 
-    def validate(self, value: Any, task: Task, repository: TaskRepository) -> None:
+    def validate(self, value: Any, task: Task | None, repository: TaskRepository) -> None:
         """Validate datetime field value.
 
         Args:
             value: The datetime object to validate
-            task: The task being updated
+            task: The task being updated (or None if creating a new task)
             repository: Repository for data access (unused)
 
         Raises:
@@ -53,7 +53,7 @@ class DateTimeValidator(FieldValidator):
         now = datetime.now()
 
         # Allow past dates if task has already started
-        if task.actual_start is not None:
+        if task is not None and task.actual_start is not None:
             return
 
         # Reject past dates for tasks that haven't started

--- a/packages/taskdog-core/src/taskdog_core/application/validators/field_validator.py
+++ b/packages/taskdog-core/src/taskdog_core/application/validators/field_validator.py
@@ -15,12 +15,12 @@ class FieldValidator(ABC):
     """
 
     @abstractmethod
-    def validate(self, value: Any, task: Task, repository: TaskRepository) -> None:
+    def validate(self, value: Any, task: Task | None, repository: TaskRepository) -> None:
         """Validate a field value for the given task.
 
         Args:
             value: The new value to validate
-            task: The task being updated
+            task: The task being updated (or None if creating a new task)
             repository: Repository for data access (if needed)
 
         Raises:

--- a/packages/taskdog-core/src/taskdog_core/application/validators/validator_registry.py
+++ b/packages/taskdog-core/src/taskdog_core/application/validators/validator_registry.py
@@ -44,13 +44,13 @@ class TaskFieldValidatorRegistry:
         )
         self._validators["priority"] = NumericFieldValidator("priority")
 
-    def validate_field(self, field_name: str, value: Any, task: Task) -> None:
+    def validate_field(self, field_name: str, value: Any, task: Task | None = None) -> None:
         """Validate a field value if a validator exists for that field.
 
         Args:
             field_name: Name of the field being updated
             value: New value for the field
-            task: Task being updated
+            task: Task being updated (or None if creating a task)
 
         Raises:
             TaskValidationError: If validation fails


### PR DESCRIPTION
## Description
This PR resolves issue #1134 by enforcing field validation via `TaskFieldValidatorRegistry` in `CreateTaskUseCase`.

## Details
- Previously, `CreateTaskUseCase` bypassed the validator registry entirely when creating new tasks, allowing invalid inputs (e.g., past deadlines, non-positive durations, invalid priorities) to enter the system upon creation even though `UpdateTaskUseCase` rejected them.
- This PR updates `CreateTaskUseCase` to instantiate `TaskFieldValidatorRegistry` and validate input fields (`priority`, `deadline`, `planned_start`, `planned_end`, `estimated_duration`) before repository creation.
- Updates `FieldValidator`, `DateTimeValidator`, and `TaskFieldValidatorRegistry` type annotations and logic to support optional `task` parameter when validating new task creation.