### PR TITLE
fix(ci): audit project dependencies in security scan job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,10 +150,10 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --all-extras --dev
+        run: uv sync --all-packages --all-extras --dev
 
       - name: Run security audit
-        run: uv tool run pip-audit --skip-editable --progress-spinner off
+        run: uv run --no-sync pip-audit --skip-editable --progress-spinner off
 
   build:
     name: Build (${{ matrix.package }})


### PR DESCRIPTION
## Description
This PR resolves issue #1150 by updating the Security Scan job in `.github/workflows/ci.yml` to audit project workspace dependencies instead of pip-audit's isolated tool environment.

## Details
- Replaces `uv sync --all-extras --dev` with `uv sync --all-packages --all-extras --dev` so all workspace packages and dependencies are installed.
- Replaces `uv tool run pip-audit` with `uv run --no-sync pip-audit` so pip-audit scans the project environment rather than its own ephemeral tool environment.