### PR TITLE
chore(contrib): update PKGBUILD version and include in bump_version.py

### DIFF
--- a/contrib/aur/PKGBUILD
+++ b/contrib/aur/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Kohei Wada <program3152019@gmail.com>
 pkgname=taskdog
 _pkgname=taskdog
-pkgver=0.22.0
+pkgver=0.26.0
 pkgrel=1
 pkgdesc="Task management system with CLI/TUI and a REST API server (GTD, time tracking, schedule optimization)"
 arch=('x86_64')
@@ -10,7 +10,7 @@ license=('MIT')
 depends=('python')
 makedepends=('uv')
 source=("$_pkgname-$pkgver.tar.gz::https://github.com/Kohei-Wada/taskdog/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('ff66b405e2d855872b690a976c974d4677788f28debae30d170f2e6327420f6d')
+sha256sums=('SKIP')
 options=('!strip')
 
 _prefix=/usr/lib/taskdog

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -83,6 +83,26 @@ def update_pyproject_file(filepath: Path, new_version: str, dry_run: bool) -> li
     return changes
 
 
+def update_pkgbuild_file(new_version: str, dry_run: bool) -> list[str]:
+    """Update version in PKGBUILD file.
+
+    Returns list of changes made.
+    """
+    pkgbuild = ROOT_DIR / "contrib" / "aur" / "PKGBUILD"
+    if not pkgbuild.exists():
+        return []
+    changes = []
+    content = pkgbuild.read_text()
+    original_content = content
+    match = re.search(r"^pkgver=(\d+\.\d+\.\d+)", content, re.MULTILINE)
+    if match and match.group(1) != new_version:
+        changes.append(f"  pkgver: {match.group(1)} -> {new_version}")
+        content = re.sub(r"^pkgver=\d+\.\d+\.\d+", f"pkgver={new_version}", content, flags=re.MULTILINE)
+    if not dry_run and content != original_content:
+        pkgbuild.write_text(content)
+    return changes
+
+
 def verify_no_old_versions(old_version: str) -> list[str]:
     """Verify no old version references remain after update.
 
@@ -103,6 +123,10 @@ def verify_no_old_versions(old_version: str) -> list[str]:
         problems.extend(
             f"{relative_path}: {match} still present" for match in old_dep_matches
         )
+
+    pkgbuild = ROOT_DIR / "contrib" / "aur" / "PKGBUILD"
+    if pkgbuild.exists() and f"pkgver={old_version}" in pkgbuild.read_text():
+        problems.append(f"contrib/aur/PKGBUILD: pkgver={old_version} still present")
 
     return problems
 
@@ -150,6 +174,7 @@ def git_commit_and_tag(new_version: str, pyproject_files: list[Path]) -> int:
     tag = f"v{new_version}"
     paths = [str(f.relative_to(ROOT_DIR)) for f in pyproject_files]
     paths.append("uv.lock")
+    paths.append("contrib/aur/PKGBUILD")
 
     def run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
         return subprocess.run(cmd, cwd=ROOT_DIR, capture_output=True, text=True)
@@ -217,6 +242,14 @@ def bump_version(new_version: str, dry_run: bool, no_git: bool) -> int:
                 print(change)
             print()
             total_changes += len(changes)
+
+    pkgbuild_changes = update_pkgbuild_file(new_version, dry_run)
+    if pkgbuild_changes:
+        print("contrib/aur/PKGBUILD:")
+        for change in pkgbuild_changes:
+            print(change)
+        print()
+        total_changes += len(pkgbuild_changes)
 
     if total_changes == 0:
         print("No changes needed - already at target version.")


### PR DESCRIPTION
## Description
This PR resolves issue #1159 by updating `contrib/aur/PKGBUILD` to the current repository version (`0.26.0`) and including it in `scripts/bump_version.py`.

## Details
- Previously, `contrib/aur/PKGBUILD` remained hardcoded to `0.22.0` with a stale sha256 checksum, causing local AUR builds (`makepkg`) from the repository to fail.
- Updates `pkgver` in `PKGBUILD` to `0.26.0` and sets `sha256sums` to `('SKIP')`.
- Updates `scripts/bump_version.py` to rewrite `pkgver` in `PKGBUILD`, verify it during release checks, and stage it when creating release tags.