### PR TITLE
fix(mcp): validate actual_end is not before actual_start in fix_actual_times tool

### DIFF
--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_lifecycle.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_lifecycle.py
@@ -135,6 +135,9 @@ def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
         start_dt = parse_iso_datetime(actual_start, "actual_start")
         end_dt = parse_iso_datetime(actual_end, "actual_end")
 
+        if start_dt and end_dt and end_dt < start_dt:
+            raise ValueError("actual_end cannot be before actual_start")
+
         if actual_duration is not None and actual_duration <= 0:
             raise ValueError("actual_duration must be greater than 0")
 


### PR DESCRIPTION
## Description
This PR resolves part of issue #1143 by adding validation to the MCP `fix_actual_times` tool in `packages/taskdog-mcp/src/taskdog_mcp/tools/task_lifecycle.py` to reject inputs where `actual_end < actual_start`.

## Details
- Previously, MCP `fix_actual_times` validated only `actual_duration > 0`, permitting invalid timestamp configurations where `actual_end` was earlier than `actual_start`.
- This PR checks `start_dt` and `end_dt` to raise `ValueError("actual_end cannot be before actual_start")` if `end_dt < start_dt`.