### PR TITLE
fix(tui): pass active status and tag filters to list_tasks during TUI export

### DIFF
--- a/packages/taskdog-ui/src/taskdog/tui/commands/export.py
+++ b/packages/taskdog-ui/src/taskdog/tui/commands/export.py
@@ -50,8 +50,13 @@ class ExportCommand(TUICommandBase):
     def execute(self) -> None:
         """Execute the export command."""
         try:
+            status = getattr(self.context.state, "status_filter", None)
+            raw_tag = getattr(self.context.state, "tag_filter", None)
+            tags = [raw_tag] if raw_tag else None
             result = self.context.api_client.list_tasks(
                 include_archived=self.context.state.show_archived,
+                status=status,
+                tags=tags,
             )
             tasks = result.tasks
 


### PR DESCRIPTION
## Description
This PR resolves part of issue #1144 by ensuring the TUI export command in `packages/taskdog-ui/src/taskdog/tui/commands/export.py` passes active status and tag filters to `api_client.list_tasks`.

## Details
- Previously, `ExportCommand` retrieved all tasks with only `include_archived=self.context.state.show_archived`, ignoring active filters applied in the TUI.
- This PR retrieves active `status_filter` and `tag_filter` from state to filter exported tasks accordingly.