### PR TITLE
perf(core): call repository.get_all directly in get_executable_tasks to skip redundant initial sort

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
@@ -99,7 +99,7 @@ class TaskQueryService(QueryService):
         """
         # Load the full task universe (incl. archived/completed) so a dependency's
         # status can be resolved even after it was archived post-completion.
-        all_tasks = self.get_filtered_tasks()
+        all_tasks = self.repository.get_all()
         status_by_id = {t.id: t.status for t in all_tasks}
 
         def deps_met(task: Task) -> bool:


### PR DESCRIPTION
## Description
This PR resolves issue #1156 by calling `repository.get_all()` directly in `get_executable_tasks` (`packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py`).

## Details
- Avoids executing an expensive, un-filtered table sort prior to candidate filtering and re-sorting by `_executable_sort_key`.