### PR TITLE
chore(ci): bump GitHub Pages actions to v5

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site/
 
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Description

Supersedes #1183 and #1184 by combining them into one change.

## Why combined

`actions/upload-pages-artifact@v5` updates its internal `upload-artifact` to v7, so the artifact producer and `actions/deploy-pages` consumer should move together. Because `.github/workflows/docs.yml` is itself listed in that workflow's trigger `paths`, merging the two bumps separately would fire a real Pages deployment in the intermediate v5-upload / v4-deploy state.

## Details

- `actions/upload-pages-artifact` v4 → v5 (internal upload-artifact → v7, adds `include-hidden-files` input)
- `actions/deploy-pages` v4 → v5 (Node.js runtime → 24.x)

No workflow logic changes. Verified after merge by watching the docs deployment run.