### PR TITLE
chore(deps): migrate taskdog-mcp to mcp 2.0.0

### DIFF
--- a/packages/taskdog-mcp/pyproject.toml
+++ b/packages/taskdog-mcp/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dependencies = [
     "taskdog-client==0.26.0",
     "taskdog-core==0.26.0",
-    "mcp>=1.28.1",
+    "mcp>=2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/taskdog-mcp/src/taskdog_mcp/server.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/server.py
@@ -1,11 +1,11 @@
 """MCP server for Taskdog.
 
-This module creates and configures the FastMCP server with all task management tools.
+This module creates and configures the MCP server with all task management tools.
 """
 
 import logging
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 from taskdog_client import TaskdogApiClient
 
 from taskdog_mcp.config.mcp_config_manager import McpConfig, load_mcp_config
@@ -13,14 +13,14 @@ from taskdog_mcp.config.mcp_config_manager import McpConfig, load_mcp_config
 logger = logging.getLogger(__name__)
 
 
-def create_mcp_server(config: McpConfig | None = None) -> FastMCP:
+def create_mcp_server(config: McpConfig | None = None) -> MCPServer:
     """Create and configure the MCP server.
 
     Args:
         config: MCP configuration. If None, loads from mcp.toml.
 
     Returns:
-        Configured FastMCP server instance
+        Configured MCPServer instance
     """
     if config is None:
         config = load_mcp_config()
@@ -36,7 +36,7 @@ def create_mcp_server(config: McpConfig | None = None) -> FastMCP:
     client = TaskdogApiClient(base_url, api_key=config.api.api_key)
 
     # Create MCP server
-    mcp = FastMCP(config.server.name)
+    mcp = MCPServer(config.server.name)
 
     # Register all tools
     from taskdog_mcp.tools import (

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_audit.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_audit.py
@@ -10,15 +10,15 @@ from typing import TYPE_CHECKING, Any
 from taskdog_mcp.tools.serializers import parse_iso_datetime
 
 if TYPE_CHECKING:
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server import MCPServer
     from taskdog_client import TaskdogApiClient
 
 
-def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
+def register_tools(mcp: MCPServer, client: TaskdogApiClient) -> None:
     """Register audit log tools with the MCP server.
 
     Args:
-        mcp: FastMCP server instance
+        mcp: MCPServer instance
         client: Taskdog API client
     """
 

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_crud.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_crud.py
@@ -15,15 +15,15 @@ from taskdog_mcp.tools.serializers import (
 )
 
 if TYPE_CHECKING:
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server import MCPServer
     from taskdog_client import TaskdogApiClient
 
 
-def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
+def register_tools(mcp: MCPServer, client: TaskdogApiClient) -> None:
     """Register task CRUD tools with the MCP server.
 
     Args:
-        mcp: FastMCP server instance
+        mcp: MCPServer instance
         client: Taskdog API client
     """
 

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_decomposition.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_decomposition.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 from taskdog_mcp.tools.serializers import str_list
 
 if TYPE_CHECKING:
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server import MCPServer
     from taskdog_client import TaskdogApiClient
 
 
@@ -74,7 +74,7 @@ def _update_decomposition_notes(
         pass  # Notes update is optional
 
 
-def register_decomposition_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
+def register_decomposition_tools(mcp: MCPServer, client: TaskdogApiClient) -> None:
     """Register decompose_task tool with the MCP server."""
 
     @mcp.tool()
@@ -183,7 +183,7 @@ def register_decomposition_tools(mcp: FastMCP, client: TaskdogApiClient) -> None
         }
 
 
-def register_relationship_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
+def register_relationship_tools(mcp: MCPServer, client: TaskdogApiClient) -> None:
     """Register relationship management tools with the MCP server."""
 
     @mcp.tool()
@@ -247,7 +247,7 @@ def register_relationship_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
         }
 
 
-def register_notes_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
+def register_notes_tools(mcp: MCPServer, client: TaskdogApiClient) -> None:
     """Register notes management tools with the MCP server."""
 
     @mcp.tool()
@@ -285,11 +285,11 @@ def register_notes_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
         }
 
 
-def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
+def register_tools(mcp: MCPServer, client: TaskdogApiClient) -> None:
     """Register all task decomposition and relationship tools.
 
     Args:
-        mcp: FastMCP server instance
+        mcp: MCPServer instance
         client: Taskdog API client
     """
     register_decomposition_tools(mcp, client)

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_lifecycle.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_lifecycle.py
@@ -10,15 +10,15 @@ from typing import TYPE_CHECKING, Any
 from taskdog_mcp.tools.serializers import iso, parse_iso_datetime, task_result
 
 if TYPE_CHECKING:
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server import MCPServer
     from taskdog_client import TaskdogApiClient
 
 
-def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
+def register_tools(mcp: MCPServer, client: TaskdogApiClient) -> None:
     """Register task lifecycle tools with the MCP server.
 
     Args:
-        mcp: FastMCP server instance
+        mcp: MCPServer instance
         client: Taskdog API client
     """
 

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_optimization.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_optimization.py
@@ -11,15 +11,15 @@ from typing import TYPE_CHECKING, Any
 from taskdog_mcp.tools.serializers import parse_iso_datetime
 
 if TYPE_CHECKING:
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server import MCPServer
     from taskdog_client import TaskdogApiClient
 
 
-def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
+def register_tools(mcp: MCPServer, client: TaskdogApiClient) -> None:
     """Register task optimization tools with the MCP server.
 
     Args:
-        mcp: FastMCP server instance
+        mcp: MCPServer instance
         client: Taskdog API client
     """
 

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_query.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_query.py
@@ -10,15 +10,15 @@ from typing import TYPE_CHECKING, Any
 from taskdog_mcp.tools.serializers import iso, model_dump, str_list
 
 if TYPE_CHECKING:
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server import MCPServer
     from taskdog_client import TaskdogApiClient
 
 
-def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
+def register_tools(mcp: MCPServer, client: TaskdogApiClient) -> None:
     """Register task query tools with the MCP server.
 
     Args:
-        mcp: FastMCP server instance
+        mcp: MCPServer instance
         client: Taskdog API client
     """
 

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_tags.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_tags.py
@@ -8,15 +8,15 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server import MCPServer
     from taskdog_client import TaskdogApiClient
 
 
-def register_tools(mcp: FastMCP, client: TaskdogApiClient) -> None:
+def register_tools(mcp: MCPServer, client: TaskdogApiClient) -> None:
     """Register tag management tools with the MCP server.
 
     Args:
-        mcp: FastMCP server instance
+        mcp: MCPServer instance
         client: Taskdog API client
     """
 

--- a/packages/taskdog-mcp/tests/test_server.py
+++ b/packages/taskdog-mcp/tests/test_server.py
@@ -40,5 +40,5 @@ class TestCreateMcpServer:
         mcp = create_mcp_server()
 
         # Check that tools are registered by verifying the server exists
-        # The actual tools are registered via FastMCP decorators
+        # The actual tools are registered via MCPServer decorators
         assert mcp is not None

--- a/packages/taskdog-mcp/tests/test_tools.py
+++ b/packages/taskdog-mcp/tests/test_tools.py
@@ -172,7 +172,7 @@ class TestTaskCrudTools:
 
     def test_list_tasks_returns_formatted_response(self) -> None:
         """Test list_tasks tool formats the response with default args."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_crud
 
         client = create_mock_client()
@@ -182,7 +182,7 @@ class TestTaskCrudTools:
             filtered_count=1,
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_crud.register_tools(mcp, client)
 
         list_tasks_fn = mcp._tool_manager._tools["list_tasks"].fn
@@ -209,7 +209,7 @@ class TestTaskCrudTools:
 
     def test_create_task_formats_response(self) -> None:
         """Test create_task tool formats the created-task response."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_crud
 
         client = create_mock_client()
@@ -217,7 +217,7 @@ class TestTaskCrudTools:
             name="New Task"
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_crud.register_tools(mcp, client)
 
         create_task_fn = mcp._tool_manager._tools["create_task"].fn
@@ -264,13 +264,13 @@ class TestTaskCrudTools:
         expected_kwargs: dict[str, Any],
     ) -> None:
         """Test create_task tool converts datetime strings correctly."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_crud
 
         client = create_mock_client()
         client.create_task.return_value = create_mock_task_operation_output()
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_crud.register_tools(mcp, client)
 
         create_task_fn = mcp._tool_manager._tools["create_task"].fn
@@ -315,7 +315,7 @@ class TestTaskCrudTools:
         expected_kwargs: dict[str, Any],
     ) -> None:
         """Test update_task tool converts datetime strings correctly."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_crud
 
         from taskdog_core.application.dto.update_task_output import TaskUpdateOutput
@@ -326,7 +326,7 @@ class TestTaskCrudTools:
             updated_fields=list(expected_kwargs.keys()),
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_crud.register_tools(mcp, client)
 
         update_task_fn = mcp._tool_manager._tools["update_task"].fn
@@ -351,11 +351,11 @@ class TestTaskCrudTools:
         self, invalid_datetime: str
     ) -> None:
         """Test create_task raises ValueError for invalid datetime strings."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_crud
 
         client = create_mock_client()
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_crud.register_tools(mcp, client)
 
         create_task_fn = mcp._tool_manager._tools["create_task"].fn
@@ -375,11 +375,11 @@ class TestTaskCrudTools:
         self, invalid_datetime: str
     ) -> None:
         """Test update_task raises ValueError for invalid datetime strings."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_crud
 
         client = create_mock_client()
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_crud.register_tools(mcp, client)
 
         update_task_fn = mcp._tool_manager._tools["update_task"].fn
@@ -389,7 +389,7 @@ class TestTaskCrudTools:
 
     def test_list_tasks_with_filters(self) -> None:
         """Test list_tasks tool with various filters."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_crud
 
         client = create_mock_client()
@@ -401,7 +401,7 @@ class TestTaskCrudTools:
             filtered_count=2,
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_crud.register_tools(mcp, client)
 
         list_tasks_fn = mcp._tool_manager._tools["list_tasks"].fn
@@ -429,7 +429,7 @@ class TestTaskCrudTools:
 
     def test_get_task_returns_full_details(self) -> None:
         """Test get_task tool returns full task details including notes."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_crud
 
         client = create_mock_client()
@@ -439,7 +439,7 @@ class TestTaskCrudTools:
             notes_content="# Notes\nSome notes here",
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_crud.register_tools(mcp, client)
 
         get_task_fn = mcp._tool_manager._tools["get_task"].fn
@@ -455,7 +455,7 @@ class TestTaskCrudTools:
 
     def test_delete_task_soft(self) -> None:
         """Test delete_task tool with soft delete (archive)."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_crud
 
         client = create_mock_client()
@@ -463,7 +463,7 @@ class TestTaskCrudTools:
             task_id=1, name="Archived Task"
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_crud.register_tools(mcp, client)
 
         delete_task_fn = mcp._tool_manager._tools["delete_task"].fn
@@ -476,12 +476,12 @@ class TestTaskCrudTools:
 
     def test_delete_task_hard(self) -> None:
         """Test delete_task tool with hard delete (permanent)."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_crud
 
         client = create_mock_client()
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_crud.register_tools(mcp, client)
 
         delete_task_fn = mcp._tool_manager._tools["delete_task"].fn
@@ -493,7 +493,7 @@ class TestTaskCrudTools:
 
     def test_restore_task_returns_restored_data(self) -> None:
         """Test restore_task tool returns restored task data."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_crud
 
         client = create_mock_client()
@@ -501,7 +501,7 @@ class TestTaskCrudTools:
             task_id=1, name="Restored Task"
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_crud.register_tools(mcp, client)
 
         restore_task_fn = mcp._tool_manager._tools["restore_task"].fn
@@ -519,7 +519,7 @@ class TestTaskLifecycleTools:
 
     def test_start_task_formats_response(self) -> None:
         """Test start_task tool formats response correctly."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_lifecycle
 
         client = create_mock_client()
@@ -527,14 +527,14 @@ class TestTaskLifecycleTools:
         started_task.actual_start = datetime.now()
         client.start_task.return_value = started_task
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_lifecycle.register_tools(mcp, client)
 
         assert mcp is not None
 
     def test_start_task_returns_actual_start(self) -> None:
         """Test start_task returns actual_start in ISO format."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_lifecycle
 
         client = create_mock_client()
@@ -545,7 +545,7 @@ class TestTaskLifecycleTools:
         started_task.actual_start = start_time
         client.start_task.return_value = started_task
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_lifecycle.register_tools(mcp, client)
 
         start_task_fn = mcp._tool_manager._tools["start_task"].fn
@@ -560,7 +560,7 @@ class TestTaskLifecycleTools:
 
     def test_complete_task_returns_duration(self) -> None:
         """Test complete_task returns actual_end and actual_duration_hours."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_lifecycle
 
         client = create_mock_client()
@@ -572,7 +572,7 @@ class TestTaskLifecycleTools:
         completed_task.actual_duration_hours = 8.0
         client.complete_task.return_value = completed_task
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_lifecycle.register_tools(mcp, client)
 
         complete_task_fn = mcp._tool_manager._tools["complete_task"].fn
@@ -605,7 +605,7 @@ class TestTaskLifecycleTools:
         message_keyword: str,
     ) -> None:
         """Test lifecycle tools that change task status."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_lifecycle
 
         client = create_mock_client()
@@ -615,7 +615,7 @@ class TestTaskLifecycleTools:
         )
         getattr(client, client_method).return_value = task
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_lifecycle.register_tools(mcp, client)
 
         tool_fn = mcp._tool_manager._tools[tool_name].fn
@@ -628,7 +628,7 @@ class TestTaskLifecycleTools:
 
     def test_fix_actual_times_valid_datetime(self) -> None:
         """Test fix_actual_times with valid ISO format datetimes."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_lifecycle
 
         client = create_mock_client()
@@ -642,7 +642,7 @@ class TestTaskLifecycleTools:
         fixed_task.actual_duration_hours = 8.0
         client.fix_actual_times.return_value = fixed_task
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_lifecycle.register_tools(mcp, client)
 
         fix_fn = mcp._tool_manager._tools["fix_actual_times"].fn
@@ -669,7 +669,7 @@ class TestTaskLifecycleTools:
 
     def test_fix_actual_times_with_clear_flags(self) -> None:
         """Test fix_actual_times with clear_start and clear_end flags."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_lifecycle
 
         client = create_mock_client()
@@ -681,7 +681,7 @@ class TestTaskLifecycleTools:
         cleared_task.actual_duration_hours = None
         client.fix_actual_times.return_value = cleared_task
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_lifecycle.register_tools(mcp, client)
 
         fix_fn = mcp._tool_manager._tools["fix_actual_times"].fn
@@ -702,11 +702,11 @@ class TestTaskLifecycleTools:
 
     def test_fix_actual_times_invalid_datetime(self) -> None:
         """Test fix_actual_times raises ValueError for invalid datetime."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_lifecycle
 
         client = create_mock_client()
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_lifecycle.register_tools(mcp, client)
 
         fix_fn = mcp._tool_manager._tools["fix_actual_times"].fn
@@ -716,7 +716,7 @@ class TestTaskLifecycleTools:
 
     def test_fix_actual_times_with_duration(self) -> None:
         """Test fix_actual_times with actual_duration parameter."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_lifecycle
 
         client = create_mock_client()
@@ -728,7 +728,7 @@ class TestTaskLifecycleTools:
         fixed_task.actual_duration_hours = 2.5
         client.fix_actual_times.return_value = fixed_task
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_lifecycle.register_tools(mcp, client)
 
         fix_fn = mcp._tool_manager._tools["fix_actual_times"].fn
@@ -747,7 +747,7 @@ class TestTaskLifecycleTools:
 
     def test_fix_actual_times_with_clear_duration(self) -> None:
         """Test fix_actual_times with clear_duration flag."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_lifecycle
 
         client = create_mock_client()
@@ -759,7 +759,7 @@ class TestTaskLifecycleTools:
         fixed_task.actual_duration_hours = None
         client.fix_actual_times.return_value = fixed_task
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_lifecycle.register_tools(mcp, client)
 
         fix_fn = mcp._tool_manager._tools["fix_actual_times"].fn
@@ -786,11 +786,11 @@ class TestTaskLifecycleTools:
     )
     def test_fix_actual_times_invalid_duration(self, invalid_duration: float) -> None:
         """Test fix_actual_times raises ValueError for invalid duration."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_lifecycle
 
         client = create_mock_client()
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_lifecycle.register_tools(mcp, client)
 
         fix_fn = mcp._tool_manager._tools["fix_actual_times"].fn
@@ -804,7 +804,7 @@ class TestTaskQueryTools:
 
     def test_get_statistics_formats_response(self) -> None:
         """Test get_statistics tool formats response correctly."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_query
 
         client = create_mock_client()
@@ -837,14 +837,14 @@ class TestTaskQueryTools:
             trend_stats=None,
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_query.register_tools(mcp, client)
 
         assert mcp is not None
 
     def test_get_tag_statistics_formats_response(self) -> None:
         """Test get_tag_statistics tool formats response correctly."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_query
 
         client = create_mock_client()
@@ -854,14 +854,14 @@ class TestTaskQueryTools:
             total_tagged_tasks=8,
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_query.register_tools(mcp, client)
 
         assert mcp is not None
 
     def test_get_statistics_returns_formatted_data(self) -> None:
         """Test get_statistics returns properly formatted statistics."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_query
 
         client = create_mock_client()
@@ -894,7 +894,7 @@ class TestTaskQueryTools:
             trend_stats=None,
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_query.register_tools(mcp, client)
 
         get_statistics_fn = mcp._tool_manager._tools["get_statistics"].fn
@@ -912,7 +912,7 @@ class TestTaskQueryTools:
 
     def test_get_statistics_without_time_stats(self) -> None:
         """Test get_statistics when time_stats is None."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_query
 
         client = create_mock_client()
@@ -938,7 +938,7 @@ class TestTaskQueryTools:
             trend_stats=None,
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_query.register_tools(mcp, client)
 
         get_statistics_fn = mcp._tool_manager._tools["get_statistics"].fn
@@ -948,7 +948,7 @@ class TestTaskQueryTools:
 
     def test_get_statistics_reports_all_sections(self) -> None:
         """Test get_statistics exposes every StatisticsOutput section."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_query
 
         client = create_mock_client()
@@ -980,7 +980,7 @@ class TestTaskQueryTools:
             trend_stats=None,
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_query.register_tools(mcp, client)
 
         get_statistics_fn = mcp._tool_manager._tools["get_statistics"].fn
@@ -1004,7 +1004,7 @@ class TestTaskQueryTools:
 
     def test_get_tag_statistics_returns_formatted_data(self) -> None:
         """Test get_tag_statistics returns properly formatted tag stats."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_query
 
         client = create_mock_client()
@@ -1014,7 +1014,7 @@ class TestTaskQueryTools:
             total_tagged_tasks=10,
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_query.register_tools(mcp, client)
 
         get_tag_stats_fn = mcp._tool_manager._tools["get_tag_statistics"].fn
@@ -1030,7 +1030,7 @@ class TestTaskQueryTools:
 
     def test_get_executable_tasks(self) -> None:
         """Test get_executable_tasks delegates to the client and shapes the result."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_query
 
         from taskdog_core.application.dto.next_tasks_output import NextTasksOutput
@@ -1047,7 +1047,7 @@ class TestTaskQueryTools:
             tasks=[in_progress_task, pending_task]
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_query.register_tools(mcp, client)
 
         get_executable_fn = mcp._tool_manager._tools["get_executable_tasks"].fn
@@ -1065,7 +1065,7 @@ class TestTaskQueryTools:
 
     def test_get_executable_tasks_with_default_args(self) -> None:
         """Test get_executable_tasks passes through default tags/limit."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_query
 
         from taskdog_core.application.dto.next_tasks_output import NextTasksOutput
@@ -1075,7 +1075,7 @@ class TestTaskQueryTools:
         tasks = [create_mock_task_row(task_id=i, name=f"Task {i}") for i in range(1, 4)]
         client.get_executable_tasks.return_value = NextTasksOutput(tasks=tasks)
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_query.register_tools(mcp, client)
 
         get_executable_fn = mcp._tool_manager._tools["get_executable_tasks"].fn
@@ -1087,7 +1087,7 @@ class TestTaskQueryTools:
 
     def test_get_executable_tasks_empty_result(self) -> None:
         """Test get_executable_tasks handles an empty ranked list."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_query
 
         from taskdog_core.application.dto.next_tasks_output import NextTasksOutput
@@ -1096,7 +1096,7 @@ class TestTaskQueryTools:
         client.get_executable_tasks = MagicMock()
         client.get_executable_tasks.return_value = NextTasksOutput(tasks=[])
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_query.register_tools(mcp, client)
 
         get_executable_fn = mcp._tool_manager._tools["get_executable_tasks"].fn
@@ -1111,12 +1111,12 @@ class TestTaskDecompositionTools:
 
     def test_decompose_task_registers_without_error(self) -> None:
         """Test decompose_task tool registration."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_decomposition
 
         client = create_mock_client()
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_decomposition.register_tools(mcp, client)
 
         assert mcp is not None
@@ -1147,7 +1147,7 @@ class TestTaskDecompositionTools:
 
     def test_decompose_task_single_subtask(self) -> None:
         """Test decompose_task with a single subtask."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_decomposition
 
         client = create_mock_client()
@@ -1158,7 +1158,7 @@ class TestTaskDecompositionTools:
         client.create_task.return_value = created_subtask
         client.get_task_notes.return_value = ("", False)
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_decomposition.register_tools(mcp, client)
 
         decompose_fn = mcp._tool_manager._tools["decompose_task"].fn
@@ -1176,7 +1176,7 @@ class TestTaskDecompositionTools:
 
     def test_decompose_task_with_dependencies(self) -> None:
         """Test decompose_task creates dependencies between subtasks."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_decomposition
 
         client = create_mock_client()
@@ -1189,7 +1189,7 @@ class TestTaskDecompositionTools:
         ]
         client.get_task_notes.return_value = ("", False)
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_decomposition.register_tools(mcp, client)
 
         decompose_fn = mcp._tool_manager._tools["decompose_task"].fn
@@ -1210,7 +1210,7 @@ class TestTaskDecompositionTools:
 
     def test_decompose_task_with_group_tag(self) -> None:
         """Test decompose_task adds group_tag to all subtasks."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_decomposition
 
         client = create_mock_client()
@@ -1222,7 +1222,7 @@ class TestTaskDecompositionTools:
         )
         client.get_task_notes.return_value = ("", False)
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_decomposition.register_tools(mcp, client)
 
         decompose_fn = mcp._tool_manager._tools["decompose_task"].fn
@@ -1239,7 +1239,7 @@ class TestTaskDecompositionTools:
 
     def test_decompose_task_archive_original(self) -> None:
         """Test decompose_task archives original task when requested."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_decomposition
 
         client = create_mock_client()
@@ -1251,7 +1251,7 @@ class TestTaskDecompositionTools:
         )
         client.get_task_notes.return_value = ("", False)
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_decomposition.register_tools(mcp, client)
 
         decompose_fn = mcp._tool_manager._tools["decompose_task"].fn
@@ -1266,7 +1266,7 @@ class TestTaskDecompositionTools:
 
     def test_add_dependency_returns_formatted_response(self) -> None:
         """Test add_dependency returns properly formatted response."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_decomposition
 
         client = create_mock_client()
@@ -1276,7 +1276,7 @@ class TestTaskDecompositionTools:
         result_task.depends_on = [2]
         client.add_dependency.return_value = result_task
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_decomposition.register_tools(mcp, client)
 
         add_dep_fn = mcp._tool_manager._tools["add_dependency"].fn
@@ -1290,7 +1290,7 @@ class TestTaskDecompositionTools:
 
     def test_remove_dependency_returns_formatted_response(self) -> None:
         """Test remove_dependency returns properly formatted response."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_decomposition
 
         client = create_mock_client()
@@ -1300,7 +1300,7 @@ class TestTaskDecompositionTools:
         result_task.depends_on = []
         client.remove_dependency.return_value = result_task
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_decomposition.register_tools(mcp, client)
 
         remove_dep_fn = mcp._tool_manager._tools["remove_dependency"].fn
@@ -1313,7 +1313,7 @@ class TestTaskDecompositionTools:
 
     def test_set_task_tags_returns_formatted_response(self) -> None:
         """Test set_task_tags returns properly formatted response."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_decomposition
 
         client = create_mock_client()
@@ -1321,7 +1321,7 @@ class TestTaskDecompositionTools:
         result_task.tags = ["new-tag", "another-tag"]
         client.set_task_tags.return_value = result_task
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_decomposition.register_tools(mcp, client)
 
         set_tags_fn = mcp._tool_manager._tools["set_task_tags"].fn
@@ -1334,12 +1334,12 @@ class TestTaskDecompositionTools:
 
     def test_update_task_notes_returns_confirmation(self) -> None:
         """Test update_task_notes returns confirmation message."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_decomposition
 
         client = create_mock_client()
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_decomposition.register_tools(mcp, client)
 
         update_notes_fn = mcp._tool_manager._tools["update_task_notes"].fn
@@ -1351,13 +1351,13 @@ class TestTaskDecompositionTools:
 
     def test_get_task_notes_returns_content(self) -> None:
         """Test get_task_notes returns notes content."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_decomposition
 
         client = create_mock_client()
         client.get_task_notes.return_value = ("# Notes\nSome content", True)
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_decomposition.register_tools(mcp, client)
 
         get_notes_fn = mcp._tool_manager._tools["get_task_notes"].fn
@@ -1370,13 +1370,13 @@ class TestTaskDecompositionTools:
 
     def test_get_task_notes_no_notes(self) -> None:
         """Test get_task_notes when task has no notes."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_decomposition
 
         client = create_mock_client()
         client.get_task_notes.return_value = (None, False)
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_decomposition.register_tools(mcp, client)
 
         get_notes_fn = mcp._tool_manager._tools["get_task_notes"].fn
@@ -1387,7 +1387,7 @@ class TestTaskDecompositionTools:
 
     def test_decompose_task_handles_subtask_creation_error(self) -> None:
         """Test decompose_task handles subtask creation errors gracefully."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_decomposition
 
         client = create_mock_client()
@@ -1401,7 +1401,7 @@ class TestTaskDecompositionTools:
         ]
         client.get_task_notes.return_value = ("", False)
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_decomposition.register_tools(mcp, client)
 
         decompose_fn = mcp._tool_manager._tools["decompose_task"].fn
@@ -1421,7 +1421,7 @@ class TestTaskDecompositionTools:
 
     def test_decompose_task_handles_dependency_error(self) -> None:
         """Test decompose_task handles dependency creation errors."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_decomposition
 
         client = create_mock_client()
@@ -1435,7 +1435,7 @@ class TestTaskDecompositionTools:
         client.add_dependency.side_effect = Exception("Dependency error")
         client.get_task_notes.return_value = ("", False)
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_decomposition.register_tools(mcp, client)
 
         decompose_fn = mcp._tool_manager._tools["decompose_task"].fn
@@ -1455,7 +1455,7 @@ class TestTaskDecompositionTools:
 
     def test_decompose_task_handles_archive_error(self) -> None:
         """Test decompose_task handles archive error gracefully."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_decomposition
 
         client = create_mock_client()
@@ -1468,7 +1468,7 @@ class TestTaskDecompositionTools:
         client.archive_task.side_effect = Exception("Archive failed")
         client.get_task_notes.return_value = ("", False)
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_decomposition.register_tools(mcp, client)
 
         decompose_fn = mcp._tool_manager._tools["decompose_task"].fn
@@ -1486,7 +1486,7 @@ class TestTaskDecompositionTools:
 
     def test_update_decomposition_notes_handles_error(self) -> None:
         """Test _update_decomposition_notes silently handles errors."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_decomposition
 
         client = create_mock_client()
@@ -1499,7 +1499,7 @@ class TestTaskDecompositionTools:
         # Notes operations fail
         client.get_task_notes.side_effect = Exception("Notes read failed")
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_decomposition.register_tools(mcp, client)
 
         decompose_fn = mcp._tool_manager._tools["decompose_task"].fn
@@ -1519,7 +1519,7 @@ class TestTaskAuditTools:
 
     def test_list_audit_logs_returns_formatted_response(self) -> None:
         """Test list_audit_logs tool formats response correctly."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_audit
 
         from taskdog_core.application.dto.audit_log_dto import (
@@ -1562,7 +1562,7 @@ class TestTaskAuditTools:
             offset=0,
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_audit.register_tools(mcp, client)
 
         list_fn = mcp._tool_manager._tools["list_audit_logs"].fn
@@ -1588,7 +1588,7 @@ class TestTaskAuditTools:
 
     def test_list_audit_logs_with_filters(self) -> None:
         """Test list_audit_logs passes filters correctly."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_audit
 
         from taskdog_core.application.dto.audit_log_dto import AuditLogListOutput
@@ -1601,7 +1601,7 @@ class TestTaskAuditTools:
             offset=0,
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_audit.register_tools(mcp, client)
 
         list_fn = mcp._tool_manager._tools["list_audit_logs"].fn
@@ -1629,7 +1629,7 @@ class TestTaskAuditTools:
 
     def test_get_audit_log_returns_formatted_response(self) -> None:
         """Test get_audit_log tool returns all fields including old/new values."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_audit
 
         from taskdog_core.application.dto.audit_log_dto import AuditLogOutput
@@ -1649,7 +1649,7 @@ class TestTaskAuditTools:
             error_message=None,
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_audit.register_tools(mcp, client)
 
         get_fn = mcp._tool_manager._tools["get_audit_log"].fn
@@ -1679,11 +1679,11 @@ class TestTaskAuditTools:
     )
     def test_list_audit_logs_invalid_datetime(self, field: str, value: str) -> None:
         """Test list_audit_logs raises ValueError for invalid since/until."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_audit
 
         client = create_mock_client()
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_audit.register_tools(mcp, client)
 
         list_fn = mcp._tool_manager._tools["list_audit_logs"].fn
@@ -1697,7 +1697,7 @@ class TestTaskTagTools:
 
     def test_delete_tag_returns_formatted_response(self) -> None:
         """Test delete_tag tool formats response correctly."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_tags
 
         from taskdog_core.application.dto.delete_tag_output import DeleteTagOutput
@@ -1707,7 +1707,7 @@ class TestTaskTagTools:
             tag_name="bug", affected_task_count=3
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_tags.register_tools(mcp, client)
 
         delete_tag_fn = mcp._tool_manager._tools["delete_tag"].fn
@@ -1720,7 +1720,7 @@ class TestTaskTagTools:
 
     def test_delete_tag_with_zero_affected_tasks(self) -> None:
         """Test delete_tag when tag exists but no tasks have it."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_tags
 
         from taskdog_core.application.dto.delete_tag_output import DeleteTagOutput
@@ -1730,7 +1730,7 @@ class TestTaskTagTools:
             tag_name="unused", affected_task_count=0
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_tags.register_tools(mcp, client)
 
         delete_tag_fn = mcp._tool_manager._tools["delete_tag"].fn
@@ -1741,7 +1741,7 @@ class TestTaskTagTools:
 
     def test_delete_tag_calls_client_with_correct_name(self) -> None:
         """Test delete_tag passes tag name to client correctly."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_tags
 
         from taskdog_core.application.dto.delete_tag_output import DeleteTagOutput
@@ -1751,7 +1751,7 @@ class TestTaskTagTools:
             tag_name="bug", affected_task_count=1
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_tags.register_tools(mcp, client)
 
         delete_tag_fn = mcp._tool_manager._tools["delete_tag"].fn
@@ -1806,7 +1806,7 @@ class TestTaskOptimizationTools:
 
     def test_optimize_schedule_returns_formatted_response(self) -> None:
         """Test optimize_schedule returns successful_tasks, daily_allocations, summary."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_optimization
 
         client = create_mock_client()
@@ -1814,7 +1814,7 @@ class TestTaskOptimizationTools:
             successful=[(1, "Task A"), (2, "Task B")],
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_optimization.register_tools(mcp, client)
 
         optimize_fn = mcp._tool_manager._tools["optimize_schedule"].fn
@@ -1840,7 +1840,7 @@ class TestTaskOptimizationTools:
 
     def test_optimize_schedule_with_failures(self) -> None:
         """Test optimize_schedule reports partial failures."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_optimization
 
         client = create_mock_client()
@@ -1849,7 +1849,7 @@ class TestTaskOptimizationTools:
             failed=[(2, "Task B", "deadline too tight")],
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_optimization.register_tools(mcp, client)
 
         optimize_fn = mcp._tool_manager._tools["optimize_schedule"].fn
@@ -1864,7 +1864,7 @@ class TestTaskOptimizationTools:
 
     def test_optimize_schedule_all_failed(self) -> None:
         """Test optimize_schedule when no tasks could be scheduled."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_optimization
 
         client = create_mock_client()
@@ -1876,7 +1876,7 @@ class TestTaskOptimizationTools:
             ],
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_optimization.register_tools(mcp, client)
 
         optimize_fn = mcp._tool_manager._tools["optimize_schedule"].fn
@@ -1888,13 +1888,13 @@ class TestTaskOptimizationTools:
 
     def test_optimize_schedule_no_tasks(self) -> None:
         """Test optimize_schedule when there's nothing to optimize."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_optimization
 
         client = create_mock_client()
         client.optimize_schedule.return_value = _make_optimization_output()
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_optimization.register_tools(mcp, client)
 
         optimize_fn = mcp._tool_manager._tools["optimize_schedule"].fn
@@ -1906,7 +1906,7 @@ class TestTaskOptimizationTools:
 
     def test_optimize_schedule_passes_all_arguments(self) -> None:
         """Test optimize_schedule forwards all arguments to the client."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_optimization
 
         client = create_mock_client()
@@ -1914,7 +1914,7 @@ class TestTaskOptimizationTools:
             successful=[(1, "Task A")],
         )
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_optimization.register_tools(mcp, client)
 
         optimize_fn = mcp._tool_manager._tools["optimize_schedule"].fn
@@ -1945,11 +1945,11 @@ class TestTaskOptimizationTools:
     )
     def test_optimize_schedule_invalid_datetime(self, invalid_date: str) -> None:
         """Test optimize_schedule raises ValueError for invalid datetime."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_optimization
 
         client = create_mock_client()
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_optimization.register_tools(mcp, client)
 
         optimize_fn = mcp._tool_manager._tools["optimize_schedule"].fn
@@ -1970,11 +1970,11 @@ class TestTaskOptimizationTools:
     )
     def test_optimize_schedule_invalid_max_hours(self, invalid_hours: float) -> None:
         """Test optimize_schedule rejects non-positive max_hours_per_day."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_optimization
 
         client = create_mock_client()
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_optimization.register_tools(mcp, client)
 
         optimize_fn = mcp._tool_manager._tools["optimize_schedule"].fn
@@ -1986,7 +1986,7 @@ class TestTaskOptimizationTools:
 
     def test_list_algorithms_returns_metadata(self) -> None:
         """Test list_algorithms returns formatted algorithm list."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
         from taskdog_mcp.tools import task_optimization
 
         client = create_mock_client()
@@ -1995,7 +1995,7 @@ class TestTaskOptimizationTools:
             ("balanced", "Balanced", "Distribute hours evenly across days"),
         ]
 
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         task_optimization.register_tools(mcp, client)
 
         list_fn = mcp._tool_manager._tools["list_algorithms"].fn

--- a/uv.lock
+++ b/uv.lock
@@ -540,6 +540,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -591,12 +604,19 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
@@ -610,11 +630,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -842,15 +862,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -860,9 +880,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -1041,6 +1074,18 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1207,20 +1252,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
     { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
     { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
-]
-
-[[package]]
-name = "pydantic-settings"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]
@@ -1715,7 +1746,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mcp", specifier = ">=1.28.1" },
+    { name = "mcp", specifier = ">=2.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
@@ -1870,6 +1901,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9a/b0/e4e0f38df057db778252db0dd2c08522d7222b8537b6a0181d797b9044bd/textual_plotext-1.0.1.tar.gz", hash = "sha256:836f53a3316756609e194129a35c2875638e7958c261f541e0a794f7c98011be", size = 16489, upload-time = "2024-11-30T19:25:56.625Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/35/53/fba7da208f9d3f59254413660fa0aa6599f2aca806f3ae356670455fd4ea/textual_plotext-1.0.1-py3-none-any.whl", hash = "sha256:6b6bfd00b29f121ddf216eaaf9bdac9d688ed72f40028484d279a10cbbb169ed", size = 16558, upload-time = "2024-11-30T19:25:32.208Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

mcp 2.0.0 removed the `mcp.server.fastmcp` module, which broke Dependabot PR #1195 (81 test failures with `ModuleNotFoundError: No module named 'mcp.server.fastmcp'`).

`FastMCP` is now `mcp.server.MCPServer`. The decorator (`@mcp.tool()`) and `run()` APIs are unchanged, so this is a rename plus a constraint bump.

- `from mcp.server.fastmcp import FastMCP` → `from mcp.server import MCPServer`
- `FastMCP` type annotations → `MCPServer`
- `mcp>=1.28.1` → `mcp>=2.0.0`

Supersedes #1195.

## Verification

- `taskdog-mcp`: 95 passed
- `taskdog-core` 1175 / `taskdog-client` 223 / `taskdog-server` 330 / `taskdog-ui` 1178 passed
- `ruff check` / `ruff format --check` / `mypy` clean
- Live stdio handshake against a running taskdog server: `initialize` OK, 26 tools listed, `create_task` and `list_tasks` round-tripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3VXthBcCZBTwbuAQ7BZ3J