### PR TITLE
fix(ui,mcp): make audit --until cover the whole day for date-only input

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/shared/utils/datetime_parser.py
+++ b/packages/taskdog-core/src/taskdog_core/shared/utils/datetime_parser.py
@@ -11,7 +11,7 @@ Error Handling:
 """
 
 from collections.abc import Iterable
-from datetime import date, datetime
+from datetime import date, datetime, time
 
 
 def parse_iso_date(date_str: str | None) -> date | None:
@@ -33,11 +33,17 @@ def parse_iso_date(date_str: str | None) -> date | None:
     return datetime.fromisoformat(date_str).date()
 
 
-def parse_iso_datetime(datetime_str: str | None) -> datetime | None:
+def parse_iso_datetime(
+    datetime_str: str | None, end_of_day: bool = False
+) -> datetime | None:
     """Parse ISO 8601 datetime string to datetime object.
 
     Args:
         datetime_str: ISO format datetime string or None
+        end_of_day: If True and the input carries no time, return the last
+            microsecond of that day instead of midnight. Use it for inclusive
+            upper bounds, where a date-only midnight would drop every value
+            recorded later that day.
 
     Returns:
         Parsed datetime object, or None if input is None/empty
@@ -47,6 +53,13 @@ def parse_iso_datetime(datetime_str: str | None) -> datetime | None:
     """
     if not datetime_str:
         return None
+    if end_of_day:
+        try:
+            day = date.fromisoformat(datetime_str)
+        except ValueError:
+            pass
+        else:
+            return datetime.combine(day, time.max)
     return datetime.fromisoformat(datetime_str)
 
 

--- a/packages/taskdog-core/tests/shared/test_iso_datetime_parser.py
+++ b/packages/taskdog-core/tests/shared/test_iso_datetime_parser.py
@@ -77,6 +77,32 @@ class TestParseIsoDatetime:
         """Empty string should return None."""
         assert parse_iso_datetime("") is None
 
+    def test_date_only_defaults_to_midnight(self):
+        """Date-only input should parse to the start of that day."""
+        assert parse_iso_datetime("2025-01-15") == datetime(2025, 1, 15, 0, 0, 0)
+
+    def test_date_only_with_end_of_day_returns_last_microsecond(self):
+        """end_of_day should push a date-only input to the end of that day."""
+        assert parse_iso_datetime("2025-01-15", end_of_day=True) == datetime(
+            2025, 1, 15, 23, 59, 59, 999999
+        )
+
+    def test_end_of_day_keeps_explicit_time(self):
+        """end_of_day should not touch an input that already carries a time."""
+        assert parse_iso_datetime("2025-01-15T10:30:00", end_of_day=True) == datetime(
+            2025, 1, 15, 10, 30, 0
+        )
+
+    def test_end_of_day_keeps_explicit_midnight(self):
+        """An explicit midnight is a real time, not a date-only value."""
+        assert parse_iso_datetime("2025-01-15T00:00:00", end_of_day=True) == datetime(
+            2025, 1, 15, 0, 0, 0
+        )
+
+    def test_end_of_day_with_none_returns_none(self):
+        """None input should return None regardless of end_of_day."""
+        assert parse_iso_datetime(None, end_of_day=True) is None
+
     @pytest.mark.parametrize(
         "invalid_input",
         ["invalid-datetime"],

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/serializers.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/serializers.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+from taskdog_core.shared.utils.datetime_parser import (
+    parse_iso_datetime as core_parse_iso_datetime,
+)
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 def iso(dt: datetime | None) -> str | None:
@@ -17,9 +23,12 @@ def model_dump(model: Any | None) -> dict[str, Any] | None:
 
 
 def parse_iso_datetime(
-    value: str | None, field_name: str | None = None
+    value: str | None, field_name: str | None = None, end_of_day: bool = False
 ) -> datetime | None:
     """Parse an ISO datetime string, or None when the value is empty.
+
+    With ``end_of_day``, a date-only value becomes the last microsecond of that
+    day so it works as an inclusive upper bound.
 
     Raises ValueError with a unified message on malformed input, including the
     field name and offending value when ``field_name`` is given.
@@ -27,7 +36,7 @@ def parse_iso_datetime(
     if not value:
         return None
     try:
-        return datetime.fromisoformat(value)
+        return core_parse_iso_datetime(value, end_of_day=end_of_day)
     except ValueError as e:
         target = f" for '{field_name}'" if field_name else ""
         raise ValueError(

--- a/packages/taskdog-mcp/src/taskdog_mcp/tools/task_audit.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/tools/task_audit.py
@@ -39,7 +39,8 @@ def register_tools(mcp: MCPServer, client: TaskdogApiClient) -> None:
             operation: Filter by operation type (e.g., 'create_task', 'complete_task')
             client_name: Filter by client name
             since: Filter logs after this datetime (ISO format, e.g., '2025-12-11T09:00:00')
-            until: Filter logs before this datetime (ISO format, e.g., '2025-12-11T17:00:00')
+            until: Filter logs before this datetime (ISO format, e.g., '2025-12-11T17:00:00');
+                a date-only value covers the whole day
             failed: If True, only show failed operations
             limit: Maximum number of logs to return
 
@@ -47,7 +48,7 @@ def register_tools(mcp: MCPServer, client: TaskdogApiClient) -> None:
             Dictionary with logs list and metadata
         """
         start_date = parse_iso_datetime(since, "since")
-        end_date = parse_iso_datetime(until, "until")
+        end_date = parse_iso_datetime(until, "until", end_of_day=True)
         success = False if failed else None
 
         result = client.list_audit_logs(

--- a/packages/taskdog-mcp/tests/test_tools.py
+++ b/packages/taskdog-mcp/tests/test_tools.py
@@ -1627,6 +1627,31 @@ class TestTaskAuditTools:
         assert result["total_count"] == 0
         assert result["logs"] == []
 
+    def test_list_audit_logs_until_date_only_covers_whole_day(self) -> None:
+        """A bare `until` date must include logs recorded later that day."""
+        from mcp.server import MCPServer
+        from taskdog_mcp.tools import task_audit
+
+        from taskdog_core.application.dto.audit_log_dto import AuditLogListOutput
+
+        client = create_mock_client()
+        client.list_audit_logs.return_value = AuditLogListOutput(
+            logs=[],
+            total_count=0,
+            limit=50,
+            offset=0,
+        )
+
+        mcp = MCPServer("test")
+        task_audit.register_tools(mcp, client)
+
+        list_fn = mcp._tool_manager._tools["list_audit_logs"].fn
+        list_fn(since="2025-12-31", until="2025-12-31")
+
+        kwargs = client.list_audit_logs.call_args.kwargs
+        assert kwargs["start_date"] == datetime(2025, 12, 31, 0, 0, 0)
+        assert kwargs["end_date"] == datetime(2025, 12, 31, 23, 59, 59, 999999)
+
     def test_get_audit_log_returns_formatted_response(self) -> None:
         """Test get_audit_log tool returns all fields including old/new values."""
         from mcp.server import MCPServer

--- a/packages/taskdog-ui/src/taskdog/cli/commands/audit/list.py
+++ b/packages/taskdog-ui/src/taskdog/cli/commands/audit/list.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime
 from typing import TYPE_CHECKING
 
 import click
@@ -30,27 +29,11 @@ from taskdog.constants.common import HEADER_ID, HEADER_NAME, TABLE_HEADER_STYLE
 from taskdog.constants.formatting import format_table_title
 from taskdog.formatters.audit_log_formatter import compact_changes, truncate_error
 from taskdog.presenters.audit_log_presenter import AuditLogPresenter
+from taskdog_core.shared.utils.datetime_parser import parse_iso_datetime
 
 if TYPE_CHECKING:
     from taskdog.cli.context import CliContext
     from taskdog.view_models.audit_log_view_model import AuditLogRowViewModel
-
-
-def _parse_date_filter(date_str: str, end_of_day: bool = False) -> datetime:
-    """Parse a date filter string to datetime.
-
-    Args:
-        date_str: ISO format date or datetime string
-        end_of_day: If True and only date provided, use end of day
-
-    Returns:
-        Parsed datetime object
-    """
-    try:
-        return datetime.fromisoformat(date_str)
-    except ValueError:
-        suffix = "T23:59:59" if end_of_day else "T00:00:00"
-        return datetime.fromisoformat(f"{date_str}{suffix}")
 
 
 def _format_resource(row: AuditLogRowViewModel) -> str:
@@ -122,7 +105,10 @@ Examples:
     "--until",
     type=str,
     default=None,
-    help="Show logs until this date (ISO format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)",
+    help=(
+        "Show logs until this date, inclusive "
+        "(ISO format: YYYY-MM-DD covers the whole day, or YYYY-MM-DDTHH:MM:SS)"
+    ),
 )
 @click.option(
     "--limit",
@@ -155,8 +141,8 @@ def list_command(
     api_client = ctx_obj.api_client
 
     # Parse date filters
-    start_date = _parse_date_filter(since) if since else None
-    end_date = _parse_date_filter(until, end_of_day=True) if until else None
+    start_date = parse_iso_datetime(since)
+    end_date = parse_iso_datetime(until, end_of_day=True)
 
     # Fetch audit logs via API
     result = api_client.list_audit_logs(

--- a/packages/taskdog-ui/tests/cli/commands/test_audit_list_command.py
+++ b/packages/taskdog-ui/tests/cli/commands/test_audit_list_command.py
@@ -1,0 +1,43 @@
+"""Tests for audit list command date filters."""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from taskdog.cli.commands.audit.list import list_command
+
+
+class TestAuditListDateFilters:
+    """Test cases for --since / --until parsing."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Set up test fixtures."""
+        self.runner = CliRunner()
+        self.api_client = MagicMock()
+        self.api_client.list_audit_logs.return_value = MagicMock(logs=[], total_count=0)
+        self.cli_context = MagicMock()
+        self.cli_context.console_writer = MagicMock()
+        self.cli_context.api_client = self.api_client
+
+    def _invoke(self, args):
+        result = self.runner.invoke(list_command, args, obj=self.cli_context)
+        assert result.exit_code == 0, result.output
+        return self.api_client.list_audit_logs.call_args.kwargs
+
+    def test_until_date_only_covers_whole_day(self):
+        """A bare --until date must include logs recorded later that day."""
+        kwargs = self._invoke(["--until", "2025-12-31"])
+        assert kwargs["end_date"] == datetime(2025, 12, 31, 23, 59, 59, 999999)
+
+    def test_until_with_explicit_time_is_preserved(self):
+        """An explicit --until time must be passed through unchanged."""
+        kwargs = self._invoke(["--until", "2025-12-31T09:00:00"])
+        assert kwargs["end_date"] == datetime(2025, 12, 31, 9, 0, 0)
+
+    def test_since_date_only_starts_at_midnight(self):
+        """A bare --since date must start at the beginning of that day."""
+        kwargs = self._invoke(["--since", "2025-12-01"])
+        assert kwargs["start_date"] == datetime(2025, 12, 1, 0, 0, 0)


### PR DESCRIPTION
## Problem

`taskdog audit list --until <date>` dropped every log from the day requested.

`_parse_date_filter` only reached its end-of-day branch when `fromisoformat` raised, but `datetime.fromisoformat("2026-07-25")` has parsed bare dates since 3.7. So `end_of_day=True` was dead for the very format the `--until` help advertises, and `end_date` went to the API as `2026-07-25T00:00:00`; audit timestamps always carry a time, so `timestamp <= end_date` matched nothing.

`taskdog-mcp`'s `list_audit_logs` had the same gap from the other side: it called `parse_iso_datetime(until)` with no end-of-day handling at all.

Closes #1181.

## Change

- `taskdog_core.shared.utils.datetime_parser.parse_iso_datetime` gains `end_of_day`: a date-only value resolves to the last microsecond of that day; a value that already carries a time (including an explicit `T00:00:00`) is untouched.
- The CLI's local `_parse_date_filter` is deleted in favour of the shared helper — one helper for both call sites, as the issue suggested.
- `taskdog-mcp` `list_audit_logs` passes `end_of_day=True` for `until`.

`--since` semantics are unchanged (date-only still means midnight).

## Verification

- TDD: tests written first and watched fail with the reported symptom (`end_date == 2025-12-31T00:00:00`).
- `make lint` / `make typecheck` / `make test` all pass.
- Live server + CLI: created a task, then `taskdog audit list --since <today> --until <today>` returned the 21:28 `create_task` row (empty before the fix).