### PR TITLE
ci: audit the project's locked dependencies in Security Scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,11 +149,13 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Install dependencies
-        run: uv sync --all-extras --dev
+      - name: Export locked dependencies
+        run: >-
+          uv export --all-packages --all-extras --frozen --no-emit-workspace
+          --no-hashes --format requirements-txt -o requirements-audit.txt
 
       - name: Run security audit
-        run: uv tool run pip-audit --skip-editable --progress-spinner off
+        run: uv tool run pip-audit -r requirements-audit.txt --no-deps --progress-spinner off
 
   build:
     name: Build (${{ matrix.package }})


### PR DESCRIPTION
Closes #1150

## Problem

The Security Scan job ran `uv tool run pip-audit`, which runs pip-audit in its own ephemeral tool environment — so it audited **pip-audit's own ~28 dependencies**, never the project's. The job has been green-by-construction since it was introduced. The preceding `uv sync --all-extras --dev` was also missing `--all-packages`, so it removed the workspace packages and their deps from the environment.

## Fix

Export the resolved lockfile and audit that file directly:

```yaml
- run: uv export --all-packages --all-extras --frozen --no-emit-workspace --no-hashes --format requirements-txt -o requirements-audit.txt
- run: uv tool run pip-audit -r requirements-audit.txt --no-deps --progress-spinner off
```

- `--all-packages --all-extras` covers all five workspace packages; dev dependencies are included by default.
- `--no-emit-workspace` drops the workspace members themselves, replacing the old `--skip-editable`.
- `--frozen` fails rather than silently re-resolving if `uv.lock` is out of date.
- No install is needed, so the `uv sync` step is removed.

## Verification

Ran the exact new commands locally:

- Export produces 99 pinned packages including `fastapi`, `sqlalchemy`, `pydantic`, `uvicorn`, `mcp`, `textual`, plus dev deps (`pytest`, `ruff`, `mypy`, `coverage`) — previously **none** of these were audited.
- `pip-audit` on the current lockfile: `No known vulnerabilities found`, exit 0.
- Fail-closed check: downgrading `pyyaml` to `5.3.1` in the exported file makes the audit report `PYSEC-2021-142` and exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015p1DCxzR9iPoQs3LybHycj