### PR TITLE
perf(core): fetch the task universe unsorted in get_executable_tasks

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
+++ b/packages/taskdog-core/src/taskdog_core/application/queries/task_query_service.py
@@ -99,7 +99,8 @@ class TaskQueryService(QueryService):
         """
         # Load the full task universe (incl. archived/completed) so a dependency's
         # status can be resolved even after it was archived post-completion.
-        all_tasks = self.get_filtered_tasks()
+        # Fetched unsorted: the candidates are re-sorted by _executable_sort_key below.
+        all_tasks = self.repository.get_all()
         status_by_id = {t.id: t.status for t in all_tasks}
 
         def deps_met(task: Task) -> bool:

--- a/packages/taskdog-core/tests/application/queries/test_executable_tasks.py
+++ b/packages/taskdog-core/tests/application/queries/test_executable_tasks.py
@@ -5,12 +5,19 @@ from taskdog_core.domain.entities.task import Task, TaskStatus
 
 
 class _StubRepo:
-    """Minimal repository: get_filtered returns all tasks (filters applied in Python)."""
+    """Minimal repository: returns all tasks (filters applied in Python)."""
 
     def __init__(self, tasks):
         self._tasks = tasks
+        self.get_all_calls = 0
+        self.get_filtered_calls = 0
+
+    def get_all(self):
+        self.get_all_calls += 1
+        return list(self._tasks)
 
     def get_filtered(self, **kwargs):
+        self.get_filtered_calls += 1
         return list(self._tasks)
 
 
@@ -148,3 +155,19 @@ def test_id_tie_break():
     ]
     ids = [t.id for t in _svc(tasks).get_executable_tasks()]
     assert ids == [1, 2, 3]
+
+
+def test_fetches_the_task_universe_without_a_throwaway_sort():
+    tasks = [_task(2, TaskStatus.PENDING), _task(1, TaskStatus.PENDING)]
+    repo = _StubRepo(tasks)
+    service = TaskQueryService(repo, _FixedTime())
+    sort_calls = []
+    service.sorter.sort = lambda *args, **kwargs: (
+        sort_calls.append(args) or list(args[0])
+    )
+
+    service.get_executable_tasks()
+
+    assert repo.get_all_calls == 1
+    assert repo.get_filtered_calls == 0
+    assert sort_calls == []

--- a/packages/taskdog-core/tests/controllers/test_query_controller_executable.py
+++ b/packages/taskdog-core/tests/controllers/test_query_controller_executable.py
@@ -7,6 +7,9 @@ class _Repo:
     def __init__(self, tasks):
         self._tasks = tasks
 
+    def get_all(self):
+        return list(self._tasks)
+
     def get_filtered(self, **kwargs):
         return list(self._tasks)
 


### PR DESCRIPTION
## Summary

`TaskQueryService.get_executable_tasks` loaded the full task universe via `get_filtered_tasks()` with no filter. That path is `repository.get_filtered()` **plus** a full `TaskSorter.sort` by id — a sort whose result is discarded immediately, since the candidates are re-sorted by `_executable_sort_key` before the limit is applied.

## Changes

- `get_executable_tasks` now calls `repository.get_all()` directly.
- New test asserting the universe is fetched via `get_all()` and that no sorter pass happens.
- Stub repositories in the two affected test modules gained `get_all()`.

### Not done

The issue also suggests a repository-level `get_status_map()` so dependency resolution avoids hydrating full entities. Left out: it would add a method to the `TaskRepository` interface and every implementation, while the candidate set still needs fully hydrated entities from the same fetch — so the extra interface surface buys little here.

## Acceptance

- `make check` and `make test` pass.
- Behaviour verified against real data: a server on this branch and the running server on `main` return byte-identical JSON for `GET /api/v1/tasks/executable?limit=10`.

Fixes #1156