### PR TITLE
feat(ui,mcp): add an explicit api base_url for HTTPS / reverse-proxy setups

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -198,6 +198,7 @@ These variables configure how CLI/TUI connect to the API server:
 | `TASKDOG_API_HOST` | string | `"127.0.0.1"` | API server host |
 | `TASKDOG_API_PORT` | int | `8000` | API server port |
 | `TASKDOG_API_KEY` | string | `None` | API key for authentication |
+| `TASKDOG_API_BASE_URL` | string | `None` | Full API base URL (overrides host/port) |
 | `TASKDOG_GANTT_MIN_DISPLAY_DAYS` | int | `56` | Minimum days in TUI Gantt chart |
 
 **Example:**
@@ -287,6 +288,39 @@ Or use environment variables:
 export TASKDOG_API_HOST=192.168.1.100
 export TASKDOG_API_PORT=8000
 ```
+
+### HTTPS / Reverse Proxy
+
+`host` and `port` always produce a plain `http://host:port` URL. To reach a
+server exposed over HTTPS, or served under a path prefix by a reverse proxy
+(Caddy, nginx, Traefik, ...), set `base_url` instead:
+
+```toml
+# ~/.config/taskdog/cli.toml
+[api]
+base_url = "https://tasks.example.com"
+```
+
+Or via environment variable / CLI option:
+
+```bash
+export TASKDOG_API_BASE_URL=https://tasks.example.com
+taskdog --base-url https://tasks.example.com table
+```
+
+The same setting is available in `mcp.toml` (`[api] base_url`). When `base_url`
+is set, `host`/`port` are ignored; the TUI derives its WebSocket URL from it, so
+an `https://` base URL connects over `wss://`.
+
+If the server uses a certificate that is not signed by a public CA, point
+`SSL_CERT_FILE` at the CA bundle that signed it:
+
+```bash
+export SSL_CERT_FILE=/path/to/ca.pem
+```
+
+**Priority order:** `--base-url` > `--host`/`--port` > `TASKDOG_API_BASE_URL` >
+`base_url` in the config file > `host`/`port`
 
 ### Server Authentication
 

--- a/packages/taskdog-mcp/README.md
+++ b/packages/taskdog-mcp/README.md
@@ -28,6 +28,7 @@ Create `~/.config/taskdog/mcp.toml`:
 host = "127.0.0.1"
 port = 8000
 api_key = ""  # Optional, for authenticated servers
+# base_url = "https://tasks.example.com"  # Overrides host/port (HTTPS, reverse proxy)
 
 [server]
 name = "taskdog"
@@ -39,6 +40,7 @@ Environment variables override config file:
 - `TASKDOG_API_HOST`
 - `TASKDOG_API_PORT`
 - `TASKDOG_API_KEY`
+- `TASKDOG_API_BASE_URL`
 - `TASKDOG_MCP_NAME`
 - `TASKDOG_MCP_LOG_LEVEL`
 

--- a/packages/taskdog-mcp/src/taskdog_mcp/config/mcp_config_manager.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/config/mcp_config_manager.py
@@ -19,11 +19,15 @@ class McpApiConfig:
         host: API server hostname
         port: API server port
         api_key: API key for authentication
+        base_url: Full API base URL (e.g. "https://tasks.example.com").
+            Takes precedence over host/port; required for HTTPS endpoints or
+            reverse proxies serving the API under a path prefix.
     """
 
     host: str = "127.0.0.1"
     port: int = 8000
     api_key: str | None = None
+    base_url: str | None = None
 
 
 @dataclass(frozen=True)
@@ -59,6 +63,7 @@ def load_mcp_config() -> McpConfig:
         TASKDOG_API_HOST: API server hostname
         TASKDOG_API_PORT: API server port
         TASKDOG_API_KEY: API key for authentication
+        TASKDOG_API_BASE_URL: Full API base URL (overrides host/port)
         TASKDOG_MCP_NAME: MCP server name
         TASKDOG_MCP_LOG_LEVEL: Logging level
 
@@ -94,6 +99,11 @@ def load_mcp_config() -> McpConfig:
             api_key=ConfigLoader.get_env(
                 "API_KEY",
                 api_data.get("api_key"),
+                str,
+            ),
+            base_url=ConfigLoader.get_env(
+                "API_BASE_URL",
+                api_data.get("base_url"),
                 str,
             ),
         ),

--- a/packages/taskdog-mcp/src/taskdog_mcp/server.py
+++ b/packages/taskdog-mcp/src/taskdog_mcp/server.py
@@ -32,7 +32,7 @@ def create_mcp_server(config: McpConfig | None = None) -> MCPServer:
     )
 
     # Create API client
-    base_url = f"http://{config.api.host}:{config.api.port}"
+    base_url = config.api.base_url or f"http://{config.api.host}:{config.api.port}"
     client = TaskdogApiClient(base_url, api_key=config.api.api_key)
 
     # Create MCP server

--- a/packages/taskdog-mcp/tests/test_config.py
+++ b/packages/taskdog-mcp/tests/test_config.py
@@ -22,6 +22,7 @@ class TestMcpConfig:
         assert config.api.host == "127.0.0.1"
         assert config.api.port == 8000
         assert config.api.api_key is None
+        assert config.api.base_url is None
         assert config.server.name == "taskdog"
         assert config.server.log_level == "INFO"
 
@@ -130,6 +131,52 @@ port = 5000
                 assert config.api.host == "127.0.0.1"  # default
                 assert config.api.port == 5000  # from file
                 assert config.server.name == "taskdog"  # default
+
+
+class TestMcpConfigBaseUrl:
+    """Test the optional base_url setting."""
+
+    def test_load_base_url_from_file(self) -> None:
+        """Test loading base_url from the [api] section."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "mcp.toml"
+            config_path.write_text("""
+[api]
+base_url = "https://tasks.example.com"
+""")
+
+            with patch(
+                "taskdog_mcp.config.mcp_config_manager.XDGDirectories.get_config_home"
+            ) as mock_config_home:
+                mock_config_home.return_value = Path(tmpdir)
+
+                config = load_mcp_config()
+
+                assert config.api.base_url == "https://tasks.example.com"
+
+    def test_env_var_overrides_base_url(self) -> None:
+        """Test TASKDOG_API_BASE_URL overrides the file setting."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "mcp.toml"
+            config_path.write_text("""
+[api]
+base_url = "https://file.example.com"
+""")
+
+            with (
+                patch(
+                    "taskdog_mcp.config.mcp_config_manager.XDGDirectories.get_config_home"
+                ) as mock_config_home,
+                patch.dict(
+                    "os.environ",
+                    {"TASKDOG_API_BASE_URL": "https://env.example.com"},
+                ),
+            ):
+                mock_config_home.return_value = Path(tmpdir)
+
+                config = load_mcp_config()
+
+                assert config.api.base_url == "https://env.example.com"
 
 
 class TestMcpConfigEnvVars:

--- a/packages/taskdog-mcp/tests/test_server.py
+++ b/packages/taskdog-mcp/tests/test_server.py
@@ -1,5 +1,7 @@
 """Tests for MCP server creation."""
 
+from unittest.mock import patch
+
 from taskdog_mcp.config.mcp_config_manager import (
     McpApiConfig,
     McpConfig,
@@ -32,6 +34,34 @@ class TestCreateMcpServer:
 
         assert mcp is not None
         assert mcp.name == "custom-server"
+
+    def test_client_uses_host_and_port_when_base_url_unset(self) -> None:
+        """Test the API URL falls back to http://host:port."""
+        from taskdog_mcp.server import create_mcp_server
+
+        config = McpConfig(api=McpApiConfig(host="custom-host", port=9999))
+
+        with patch("taskdog_mcp.server.TaskdogApiClient") as mock_client:
+            create_mcp_server(config)
+
+        mock_client.assert_called_once_with("http://custom-host:9999", api_key=None)
+
+    def test_client_uses_base_url_when_set(self) -> None:
+        """Test base_url takes precedence over host/port."""
+        from taskdog_mcp.server import create_mcp_server
+
+        config = McpConfig(
+            api=McpApiConfig(
+                host="custom-host",
+                port=9999,
+                base_url="https://tasks.example.com",
+            )
+        )
+
+        with patch("taskdog_mcp.server.TaskdogApiClient") as mock_client:
+            create_mcp_server(config)
+
+        mock_client.assert_called_once_with("https://tasks.example.com", api_key=None)
 
     def test_server_has_registered_tools(self) -> None:
         """Test server has tools registered."""

--- a/packages/taskdog-ui/README.md
+++ b/packages/taskdog-ui/README.md
@@ -73,6 +73,7 @@ Edit `~/.config/taskdog/cli.toml`:
 enabled = true
 host = "127.0.0.1"
 port = 8000
+# base_url = "https://tasks.example.com"  # Overrides host/port (HTTPS, reverse proxy)
 ```
 
 Or set environment variables:
@@ -80,6 +81,7 @@ Or set environment variables:
 ```bash
 export TASKDOG_API_HOST=127.0.0.1
 export TASKDOG_API_PORT=8000
+# export TASKDOG_API_BASE_URL=https://tasks.example.com
 ```
 
 ### 4. Verify Connection

--- a/packages/taskdog-ui/src/taskdog/cli_main.py
+++ b/packages/taskdog-ui/src/taskdog/cli_main.py
@@ -7,7 +7,7 @@ from taskdog import __version__
 from taskdog.cli.context import CliContext
 from taskdog.cli.lazy_group import LazyGroup
 from taskdog.console.rich_console_writer import RichConsoleWriter
-from taskdog.infrastructure.cli_config_manager import load_cli_config
+from taskdog.infrastructure.cli_config_manager import CliApiConfig, load_cli_config
 
 # Registry of every subcommand: name -> (import path "module.attr", summary).
 #
@@ -107,6 +107,25 @@ LAZY_SUBCOMMANDS: dict[str, tuple[str, str]] = {
 COMMAND_ALIASES: dict[str, str] = {"ls": "list"}
 
 
+def _resolve_base_url(
+    api_config: CliApiConfig,
+    host: str | None,
+    port: int | None,
+    base_url: str | None,
+) -> str:
+    """Resolve the API base URL.
+
+    Precedence: --base-url > --host/--port > configured base_url > host/port.
+    """
+    if base_url is not None:
+        return base_url
+    if host is None and port is None and api_config.base_url:
+        return api_config.base_url
+    api_host = host if host is not None else api_config.host
+    api_port = port if port is not None else api_config.port
+    return f"http://{api_host}:{api_port}"
+
+
 class TaskdogGroup(LazyGroup):
     """Root group: lazy loading (via LazyGroup) plus ASCII art in --help."""
 
@@ -143,6 +162,12 @@ class TaskdogGroup(LazyGroup):
     help="API server port (overrides config/env)",
 )
 @click.option(
+    "--base-url",
+    type=str,
+    default=None,
+    help="Full API base URL, e.g. https://tasks.example.com (overrides host/port)",
+)
+@click.option(
     "-k",
     "--api-key",
     type=str,
@@ -151,7 +176,11 @@ class TaskdogGroup(LazyGroup):
 )
 @click.pass_context
 def cli(
-    ctx: click.Context, host: str | None, port: int | None, api_key: str | None
+    ctx: click.Context,
+    host: str | None,
+    port: int | None,
+    base_url: str | None,
+    api_key: str | None,
 ) -> None:
     """Taskdog: Task management CLI tool with time tracking and optimization."""
     # Display help when no subcommand is provided
@@ -165,16 +194,15 @@ def cli(
     config = load_cli_config()
 
     # CLI options override config/env settings
-    api_host = host if host is not None else config.api.host
-    api_port = port if port is not None else config.api.port
     effective_api_key = api_key if api_key is not None else config.api.api_key
+    api_base_url = _resolve_base_url(config.api, host, port, base_url)
 
     # Initialize API client (required for all CLI commands)
     # Health check is deferred to actual API calls for better performance
     from taskdog_client import TaskdogApiClient
 
     api_client = TaskdogApiClient(
-        base_url=f"http://{api_host}:{api_port}",
+        base_url=api_base_url,
         api_key=effective_api_key,
     )
 

--- a/packages/taskdog-ui/src/taskdog/infrastructure/cli_config_manager.py
+++ b/packages/taskdog-ui/src/taskdog/infrastructure/cli_config_manager.py
@@ -51,11 +51,15 @@ class CliApiConfig:
         host: API server hostname
         port: API server port
         api_key: API key for authentication (used with reverse proxies like Kong)
+        base_url: Full API base URL (e.g. "https://tasks.example.com").
+            Takes precedence over host/port; required for HTTPS endpoints or
+            reverse proxies serving the API under a path prefix.
     """
 
     host: str = "127.0.0.1"
     port: int = 8000
     api_key: str | None = None
+    base_url: str | None = None
 
 
 @dataclass(frozen=True)
@@ -133,6 +137,7 @@ def load_cli_config() -> CliConfig:
         TASKDOG_API_HOST: API server hostname
         TASKDOG_API_PORT: API server port
         TASKDOG_API_KEY: API key for authentication
+        TASKDOG_API_BASE_URL: Full API base URL (overrides host/port)
         TASKDOG_INPUT_DEADLINE_TIME: Default time for deadline input
         TASKDOG_INPUT_PLANNED_START_TIME: Default time for planned_start input
         TASKDOG_INPUT_PLANNED_END_TIME: Default time for planned_end input
@@ -195,6 +200,11 @@ def load_cli_config() -> CliConfig:
             api_key=ConfigLoader.get_env(
                 "API_KEY",
                 api_data.get("api_key"),
+                str,
+            ),
+            base_url=ConfigLoader.get_env(
+                "API_BASE_URL",
+                api_data.get("base_url"),
                 str,
             ),
         ),

--- a/packages/taskdog-ui/tests/cli/commands/test_tui_command.py
+++ b/packages/taskdog-ui/tests/cli/commands/test_tui_command.py
@@ -1,0 +1,22 @@
+"""Tests for the tui command helpers."""
+
+from taskdog.cli.commands.tui import _get_websocket_url
+
+
+class TestGetWebsocketUrl:
+    """Test WebSocket URL derivation from the API base URL."""
+
+    def test_http_base_url_uses_ws(self):
+        assert _get_websocket_url("http://127.0.0.1:8000") == "ws://127.0.0.1:8000/ws"
+
+    def test_https_base_url_uses_wss(self):
+        assert (
+            _get_websocket_url("https://tasks.example.com")
+            == "wss://tasks.example.com/ws"
+        )
+
+    def test_path_prefix_is_preserved(self):
+        assert (
+            _get_websocket_url("https://example.com/taskdog")
+            == "wss://example.com/taskdog/ws"
+        )

--- a/packages/taskdog-ui/tests/cli/test_cli_main.py
+++ b/packages/taskdog-ui/tests/cli/test_cli_main.py
@@ -27,6 +27,7 @@ class TestCliGlobalOptions:
         mock_config.api.host = "127.0.0.1"
         mock_config.api.port = 8000
         mock_config.api.api_key = None
+        mock_config.api.base_url = None
         mock_load_config.return_value = mock_config
 
         mock_client_instance = MagicMock()
@@ -50,6 +51,7 @@ class TestCliGlobalOptions:
         mock_config.api.host = "127.0.0.1"
         mock_config.api.port = 8000
         mock_config.api.api_key = None
+        mock_config.api.base_url = None
         mock_load_config.return_value = mock_config
 
         mock_client_instance = MagicMock()
@@ -72,6 +74,7 @@ class TestCliGlobalOptions:
         mock_config.api.host = "127.0.0.1"
         mock_config.api.port = 8000
         mock_config.api.api_key = None
+        mock_config.api.base_url = None
         mock_load_config.return_value = mock_config
 
         mock_client_instance = MagicMock()
@@ -94,6 +97,7 @@ class TestCliGlobalOptions:
         mock_config.api.host = "127.0.0.1"
         mock_config.api.port = 8000
         mock_config.api.api_key = None
+        mock_config.api.base_url = None
         mock_load_config.return_value = mock_config
 
         mock_client_instance = MagicMock()
@@ -148,6 +152,7 @@ class TestCliGlobalOptions:
         mock_config.api.host = "127.0.0.1"
         mock_config.api.port = 8000
         mock_config.api.api_key = None
+        mock_config.api.base_url = None
         mock_load_config.return_value = mock_config
 
         mock_client_instance = MagicMock()
@@ -175,6 +180,7 @@ class TestCliGlobalOptions:
         mock_config.api.host = "127.0.0.1"
         mock_config.api.port = 8000
         mock_config.api.api_key = "config-key"
+        mock_config.api.base_url = None
         mock_load_config.return_value = mock_config
 
         mock_client_instance = MagicMock()
@@ -197,6 +203,7 @@ class TestCliGlobalOptions:
         mock_config.api.host = "127.0.0.1"
         mock_config.api.port = 8000
         mock_config.api.api_key = "config-key"
+        mock_config.api.base_url = None
         mock_load_config.return_value = mock_config
 
         mock_client_instance = MagicMock()
@@ -209,6 +216,68 @@ class TestCliGlobalOptions:
         mock_api_client.assert_called_once_with(
             base_url="http://127.0.0.1:8000", api_key="config-key"
         )
+
+    @patch("taskdog_client.TaskdogApiClient")
+    @patch("taskdog.cli_main.load_cli_config")
+    def test_base_url_from_config(self, mock_load_config, mock_api_client):
+        """Test base_url from config is used instead of host/port."""
+        mock_config = MagicMock()
+        mock_config.api.host = "127.0.0.1"
+        mock_config.api.port = 8000
+        mock_config.api.api_key = None
+        mock_config.api.base_url = "https://tasks.example.com"
+        mock_load_config.return_value = mock_config
+
+        self.runner.invoke(cli, ["list", "--help"])
+
+        mock_api_client.assert_called_once_with(
+            base_url="https://tasks.example.com", api_key=None
+        )
+
+    @patch("taskdog_client.TaskdogApiClient")
+    @patch("taskdog.cli_main.load_cli_config")
+    def test_base_url_option_override(self, mock_load_config, mock_api_client):
+        """Test --base-url overrides the configured base_url."""
+        mock_config = MagicMock()
+        mock_config.api.host = "127.0.0.1"
+        mock_config.api.port = 8000
+        mock_config.api.api_key = None
+        mock_config.api.base_url = "https://config.example.com"
+        mock_load_config.return_value = mock_config
+
+        self.runner.invoke(
+            cli, ["--base-url", "https://cli.example.com", "list", "--help"]
+        )
+
+        mock_api_client.assert_called_once_with(
+            base_url="https://cli.example.com", api_key=None
+        )
+
+    @patch("taskdog_client.TaskdogApiClient")
+    @patch("taskdog.cli_main.load_cli_config")
+    def test_host_option_wins_over_configured_base_url(
+        self, mock_load_config, mock_api_client
+    ):
+        """Test an explicit --host/--port beats a configured base_url."""
+        mock_config = MagicMock()
+        mock_config.api.host = "127.0.0.1"
+        mock_config.api.port = 8000
+        mock_config.api.api_key = None
+        mock_config.api.base_url = "https://config.example.com"
+        mock_load_config.return_value = mock_config
+
+        self.runner.invoke(cli, ["--host", "192.168.1.100", "list", "--help"])
+
+        mock_api_client.assert_called_once_with(
+            base_url="http://192.168.1.100:8000", api_key=None
+        )
+
+    def test_help_shows_base_url_option(self):
+        """Test that --help displays --base-url option."""
+        result = self.runner.invoke(cli, ["--help"])
+
+        assert result.exit_code == 0
+        assert "--base-url" in result.output
 
     def test_help_shows_api_key_option(self):
         """Test that --help displays --api-key option."""

--- a/packages/taskdog-ui/tests/infrastructure/test_cli_config_manager.py
+++ b/packages/taskdog-ui/tests/infrastructure/test_cli_config_manager.py
@@ -25,6 +25,7 @@ class TestCliConfig:
         original_env = {
             "TASKDOG_API_HOST": os.environ.get("TASKDOG_API_HOST"),
             "TASKDOG_API_PORT": os.environ.get("TASKDOG_API_PORT"),
+            "TASKDOG_API_BASE_URL": os.environ.get("TASKDOG_API_BASE_URL"),
             "TASKDOG_GANTT_WORKLOAD_COMFORTABLE_HOURS": os.environ.get(
                 "TASKDOG_GANTT_WORKLOAD_COMFORTABLE_HOURS"
             ),
@@ -36,6 +37,7 @@ class TestCliConfig:
         for key in [
             "TASKDOG_API_HOST",
             "TASKDOG_API_PORT",
+            "TASKDOG_API_BASE_URL",
             "TASKDOG_GANTT_WORKLOAD_COMFORTABLE_HOURS",
             "TASKDOG_GANTT_WORKLOAD_MODERATE_HOURS",
         ]:
@@ -180,6 +182,48 @@ theme = "nord"
                 assert config.api.port == 4000
                 # UI settings should come from file (no env var override)
                 assert config.ui.theme == "nord"
+
+    def test_base_url_defaults_to_none(self):
+        """Test base_url is unset by default."""
+        assert CliConfig().api.base_url is None
+
+    def test_load_config_with_base_url(self):
+        """Test loading base_url from the [api] section."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir)
+            (config_dir / "cli.toml").write_text(
+                """
+[api]
+base_url = "https://tasks.example.com"
+"""
+            )
+
+            with patch(
+                "taskdog.infrastructure.cli_config_manager.XDGDirectories.get_config_home",
+                return_value=config_dir,
+            ):
+                config = load_cli_config()
+                assert config.api.base_url == "https://tasks.example.com"
+
+    def test_env_var_overrides_base_url(self):
+        """Test TASKDOG_API_BASE_URL overrides the file setting."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir)
+            (config_dir / "cli.toml").write_text(
+                """
+[api]
+base_url = "https://file.example.com"
+"""
+            )
+
+            os.environ["TASKDOG_API_BASE_URL"] = "https://env.example.com"
+
+            with patch(
+                "taskdog.infrastructure.cli_config_manager.XDGDirectories.get_config_home",
+                return_value=config_dir,
+            ):
+                config = load_cli_config()
+                assert config.api.base_url == "https://env.example.com"
 
     def test_gantt_config_defaults(self):
         """Test GanttConfig default values."""


### PR DESCRIPTION
## Summary

The CLI/TUI and MCP clients always built their API URL as `http://{host}:{port}`, so a server exposed over HTTPS behind a reverse proxy was unreachable, and a URL with a path prefix could not be expressed at all. Reported in #1209.

This adds an optional `base_url` to the `[api]` section of `cli.toml` / `mcp.toml`.

Fixes #1210

## Changes

- `CliApiConfig.base_url` / `McpApiConfig.base_url` (default `None`), with `TASKDOG_API_BASE_URL` env override
- `--base-url` global CLI option
- `_resolve_base_url()` in `cli_main.py` — precedence: `--base-url` > `--host`/`--port` > configured `base_url` > `host`/`port`
- `taskdog_mcp/server.py` uses `config.api.base_url` when set
- docs: `docs/configuration.md` HTTPS / reverse-proxy section, `TASKDOG_API_BASE_URL` in the env var table, package READMEs

No behaviour change when `base_url` is unset. The TUI's WebSocket URL derivation already mapped `https` → `wss`, so it needed no change.

## Acceptance

- `make check` and `make test` pass
- New unit tests: config loading (file + env), CLI option precedence, MCP client construction, `_get_websocket_url` for `http`/`https`/path-prefix
- Live check against a local TLS-terminating proxy in front of the running server:
  - `taskdog --base-url https://localhost:8443 list` returns real task data
  - `wss://localhost:8443/ws` reaches `CONNECTED` and receives a client id