### PR TITLE
fix(server): include daily_allocations in task write responses

### DIFF
--- a/packages/taskdog-server/src/taskdog_server/api/models/responses.py
+++ b/packages/taskdog-server/src/taskdog_server/api/models/responses.py
@@ -38,6 +38,18 @@ class TaskFieldsBase(BaseModel):
     tags: list[str] = Field(default_factory=list)
     is_fixed: bool = False
     is_archived: bool = False
+    daily_allocations: dict[str, float] = Field(default_factory=dict)
+
+    @field_validator("daily_allocations", mode="before")
+    @classmethod
+    def _isoformat_allocation_keys(cls, value: Any) -> Any:
+        """Convert date keys (from the DTO) to ISO format strings."""
+        if isinstance(value, dict):
+            return {
+                key.isoformat() if isinstance(key, date) else key: hours
+                for key, hours in value.items()
+            }
+        return value
 
 
 class TaskOperationResponse(TaskFieldsBase):
@@ -83,22 +95,10 @@ class TaskReadResponseBase(TaskFieldsBase):
 
     model_config = ConfigDict(frozen=True)
 
-    daily_allocations: dict[str, float] = Field(default_factory=dict)
     is_finished: bool = False
     has_notes: bool = False
     created_at: datetime
     updated_at: datetime
-
-    @field_validator("daily_allocations", mode="before")
-    @classmethod
-    def _isoformat_allocation_keys(cls, value: Any) -> Any:
-        """Convert date keys (from the DTO) to ISO format strings."""
-        if isinstance(value, dict):
-            return {
-                key.isoformat() if isinstance(key, date) else key: hours
-                for key, hours in value.items()
-            }
-        return value
 
 
 class TaskResponse(TaskReadResponseBase):

--- a/packages/taskdog-server/tests/api/models/test_responses.py
+++ b/packages/taskdog-server/tests/api/models/test_responses.py
@@ -126,6 +126,45 @@ class TestTaskOperationResponse:
         assert response.tags == dto.tags
         assert response.actual_duration_hours == dto.actual_duration_hours
 
+    def test_from_dto_preserves_daily_allocations(self):
+        """Test from_dto keeps daily_allocations instead of dropping them."""
+        # Arrange
+        dto = TaskOperationOutput(
+            id=1,
+            name="Test Task",
+            status=TaskStatus.PENDING,
+            priority=2,
+            daily_allocations={"2026-01-15": 4.0, "2026-01-16": 2.5},
+        )
+
+        # Act
+        response = TaskOperationResponse.from_dto(dto)
+
+        # Assert
+        assert response.daily_allocations == {"2026-01-15": 4.0, "2026-01-16": 2.5}
+
+    def test_from_dto_converts_date_keys_in_daily_allocations(self):
+        """Test date keys are normalized to ISO strings like read responses."""
+        # Act
+        response = TaskOperationResponse.model_validate(
+            {
+                "id": 1,
+                "name": "Test Task",
+                "status": TaskStatus.PENDING,
+                "priority": 2,
+                "daily_allocations": {date(2026, 1, 15): 4.0},
+            }
+        )
+
+        # Assert
+        assert response.daily_allocations == {"2026-01-15": 4.0}
+
+    def test_fields_match_task_operation_output_dto(self):
+        """Test the response model does not drift from the DTO it mirrors."""
+        assert set(TaskOperationResponse.model_fields) == set(
+            TaskOperationOutput.model_fields
+        )
+
 
 class TestUpdateTaskResponse:
     """Test cases for UpdateTaskResponse model."""


### PR DESCRIPTION
## Summary

`TaskOperationResponse` listed every task field except `daily_allocations`, while the core DTO the client deserializes into (`TaskOperationOutput`) declares it. Every create/update/lifecycle response therefore validated the field to `{}` on the client — a wrong value, not an error.

## Changes

- Move `daily_allocations` and its date-key → ISO-string normalizer from `TaskReadResponseBase` up to `TaskFieldsBase`, so read *and* write responses carry it. The validator accepts both `date` keys (`TaskRowDto`) and `str` keys (`TaskOperationOutput`).
- Add a drift test: `set(TaskOperationResponse.model_fields) == set(TaskOperationOutput.model_fields)`, so the two hand-maintained parallel shapes can't silently diverge again.

## Acceptance

- `make check` / `make test` pass.
- Verified against a live server (fresh DB): create task → `POST /api/v1/optimize` → `PATCH /api/v1/tasks/2` now returns
  `"daily_allocations":{"2026-08-13":4.0,"2026-08-14":4.0,"2026-08-17":4.0}` where it previously returned nothing for that key.

Fixes #1135