### PR TITLE
refactor(core): unify status-transition cascade and drop dead reopen path

### DIFF
--- a/packages/taskdog-core/src/taskdog_core/application/services/task_status_service.py
+++ b/packages/taskdog-core/src/taskdog_core/application/services/task_status_service.py
@@ -17,13 +17,38 @@ class TaskStatusService:
     and reduces code duplication in use cases.
     """
 
+    def apply_status_change(self, task: Task, new_status: TaskStatus) -> Task:
+        """Apply a status change with time tracking, without persisting.
+
+        Use this when the caller owns persistence (e.g. UpdateTaskUseCase,
+        which saves once after all fields are updated).
+
+        Args:
+            task: Task to update
+            new_status: New status to set
+
+        Returns:
+            The same task instance, with status and timestamps updated
+        """
+        # Update status via Task entity methods (encapsulation)
+        timestamp = datetime.now()
+
+        if new_status == TaskStatus.IN_PROGRESS:
+            task.start(timestamp)
+        elif new_status == TaskStatus.COMPLETED:
+            task.complete(timestamp)
+        elif new_status == TaskStatus.CANCELED:
+            task.cancel(timestamp)
+        elif new_status == TaskStatus.PENDING:
+            task.pause()
+
+        return task
+
     def change_status_with_tracking(
         self,
         task: Task,
         new_status: TaskStatus,
         repository: TaskRepository,
-        *,
-        clear_timestamps: bool = True,
     ) -> Task:
         """Change task status with automatic time tracking and persistence.
 
@@ -35,8 +60,6 @@ class TaskStatusService:
             task: Task to update
             new_status: New status to set
             repository: Repository for persisting changes
-            clear_timestamps: Whether to clear timestamps when moving to PENDING
-                              (True for pause, False for direct status change)
 
         Returns:
             Updated task with new status
@@ -50,23 +73,7 @@ class TaskStatusService:
             >>> assert updated.status == TaskStatus.IN_PROGRESS
             >>> assert updated.actual_start is not None
         """
-        # Update status via Task entity methods (encapsulation)
-        timestamp = datetime.now()
-
-        if new_status == TaskStatus.IN_PROGRESS:
-            task.start(timestamp)
-        elif new_status == TaskStatus.COMPLETED:
-            task.complete(timestamp)
-        elif new_status == TaskStatus.CANCELED:
-            task.cancel(timestamp)
-        elif new_status == TaskStatus.PENDING:
-            # For PENDING, use pause (clears timestamps) or reopen based on context
-            if clear_timestamps:
-                task.pause()
-            else:
-                task.reopen()
-
-        # Persist changes
+        self.apply_status_change(task, new_status)
         repository.save(task)
 
         return task

--- a/packages/taskdog-core/src/taskdog_core/application/use_cases/update_task.py
+++ b/packages/taskdog-core/src/taskdog_core/application/use_cases/update_task.py
@@ -1,17 +1,17 @@
 """Use case for updating a task."""
 
 from dataclasses import replace
-from datetime import datetime
 from typing import TYPE_CHECKING
 
 from taskdog_core.application.dto.update_task_input import UpdateTaskInput
 from taskdog_core.application.dto.update_task_output import TaskUpdateOutput
 from taskdog_core.application.queries.workload._strategies import ActualScheduleStrategy
+from taskdog_core.application.services.task_status_service import TaskStatusService
 from taskdog_core.application.use_cases.base import UseCase
 from taskdog_core.application.validators.validator_registry import (
     TaskFieldValidatorRegistry,
 )
-from taskdog_core.domain.entities.task import Task, TaskStatus
+from taskdog_core.domain.entities.task import Task
 from taskdog_core.domain.repositories.task_repository import TaskRepository
 
 if TYPE_CHECKING:
@@ -39,6 +39,7 @@ class UpdateTaskUseCase(UseCase[UpdateTaskInput, TaskUpdateOutput]):
         """
         self.repository = repository
         self.validator_registry = TaskFieldValidatorRegistry(repository)
+        self.status_service = TaskStatusService()
         self._strategy = ActualScheduleStrategy(holiday_checker=holiday_checker)
 
     def _update_status(
@@ -58,17 +59,9 @@ class UpdateTaskUseCase(UseCase[UpdateTaskInput, TaskUpdateOutput]):
             # Validate status transition
             self.validator_registry.validate_field("status", input_dto.status, task)
 
-            # Use Task entity methods for status changes (encapsulation)
-            timestamp = datetime.now()
-            if input_dto.status == TaskStatus.IN_PROGRESS:
-                task.start(timestamp)
-            elif input_dto.status == TaskStatus.COMPLETED:
-                task.complete(timestamp)
-            elif input_dto.status == TaskStatus.CANCELED:
-                task.cancel(timestamp)
-            elif input_dto.status == TaskStatus.PENDING:
-                # For update command, preserve timestamps by default (don't clear)
-                task.status = TaskStatus.PENDING
+            # Shared cascade with the lifecycle use cases; persistence is done
+            # once by execute() after all fields are updated.
+            self.status_service.apply_status_change(task, input_dto.status)
 
             updated_fields.append("status")
 

--- a/packages/taskdog-core/src/taskdog_core/domain/entities/task.py
+++ b/packages/taskdog-core/src/taskdog_core/domain/entities/task.py
@@ -338,18 +338,6 @@ class Task:
         self.actual_end = None
         self.actual_duration = None
 
-    def reopen(self) -> None:
-        """Reopen a finished task back to PENDING.
-
-        Side effects:
-            - Changes status to PENDING
-            - Clears actual_start, actual_end, and actual_duration
-        """
-        self.status = TaskStatus.PENDING
-        self.actual_start = None
-        self.actual_end = None
-        self.actual_duration = None
-
     def fix_actual_times(
         self,
         actual_start: datetime | EllipsisType | None = ...,

--- a/packages/taskdog-core/tests/application/services/test_task_status_service.py
+++ b/packages/taskdog-core/tests/application/services/test_task_status_service.py
@@ -64,6 +64,32 @@ class TestTaskStatusService:
         assert from_db.status == TaskStatus.COMPLETED
         assert from_db.actual_end is not None
 
+    def test_change_status_to_pending_clears_time_tracking(self):
+        """Test changing status to PENDING clears time tracking."""
+        task = self.repository.create(name="Test Task", priority=1)
+        task = self.service.change_status_with_tracking(
+            task, TaskStatus.IN_PROGRESS, self.repository
+        )
+
+        updated = self.service.change_status_with_tracking(
+            task, TaskStatus.PENDING, self.repository
+        )
+
+        assert updated.status == TaskStatus.PENDING
+        assert updated.actual_start is None
+        assert updated.actual_end is None
+        assert updated.actual_duration is None
+
+    def test_apply_status_change_does_not_persist(self):
+        """Test apply_status_change mutates the task without saving it."""
+        task = self.repository.create(name="Test Task", priority=1)
+
+        self.service.apply_status_change(task, TaskStatus.IN_PROGRESS)
+
+        assert task.status == TaskStatus.IN_PROGRESS
+        assert task.actual_start is not None
+        assert self.repository.get_by_id(task.id).status == TaskStatus.PENDING
+
     def test_change_status_to_canceled(self):
         """Test changing status to CANCELED records actual_end."""
         # Create a task and start it

--- a/packages/taskdog-core/tests/application/use_cases/test_update_task_use_case.py
+++ b/packages/taskdog-core/tests/application/use_cases/test_update_task_use_case.py
@@ -98,6 +98,24 @@ class TestUpdateTaskUseCase:
         # Verify time tracking was triggered
         assert result.task.actual_start is not None
 
+    def test_execute_update_status_to_pending_clears_time_tracking(self):
+        """Test updating status to PENDING clears time tracking like pause does."""
+        task = self.repository.create(
+            name="Test Task", priority=1, status=TaskStatus.PENDING
+        )
+        self.use_case.execute(
+            UpdateTaskInput(task_id=task.id, status=TaskStatus.IN_PROGRESS)
+        )
+
+        result = self.use_case.execute(
+            UpdateTaskInput(task_id=task.id, status=TaskStatus.PENDING)
+        )
+
+        assert result.task.status == TaskStatus.PENDING
+        assert result.task.actual_start is None
+        assert result.task.actual_end is None
+        assert result.task.actual_duration is None
+
     def test_execute_update_multiple_fields(self):
         """Test updating multiple fields at once."""
         task = self.repository.create(name="Test Task", priority=1)


### PR DESCRIPTION
## Summary

The status-transition cascade existed in two places with already-divergent behavior:

- `TaskStatusService.change_status_with_tracking` — PENDING → `task.pause()` (clears time tracking)
- `UpdateTaskUseCase._update_status` — PENDING → `task.status = PENDING` directly (preserved it)

So `update --status PENDING` and `pause` reached the same status with different `actual_start/end/duration`.

## Decision

Unify on the **clearing** behavior: reaching PENDING clears time tracking regardless of the route. This is a behavior change for `update --status PENDING` (previously preserved timestamps).

## Changes

- Extract `TaskStatusService.apply_status_change()` — the cascade without persistence — and route `UpdateTaskUseCase` through it. `UpdateTaskUseCase` keeps saving once after all fields are applied, so no double write.
- Delete the `clear_timestamps` parameter: no caller ever passed it, making the `False` branch unreachable.
- Delete `Task.reopen()`: byte-identical to `Task.pause()`, and its name misleadingly suggested that reopening preserves timestamps.

## Acceptance

- `make check` / `make test` pass (1184 core + 223 client + 333 server + 1191 ui + 100 mcp).
- Verified against a live server — all three routes now agree:

```
after start:             {'status': 'IN_PROGRESS', 'actual_start': '2026-08-13T21:28:23', ...}
update --status PENDING: {'status': 'PENDING', 'actual_start': None, 'actual_end': None, 'actual_duration': None}
pause:                   {'status': 'PENDING', 'actual_start': None, 'actual_end': None, 'actual_duration': None}
reopen:                  {'status': 'PENDING', 'actual_start': None, 'actual_end': None, 'actual_duration': None}
```

Fixes #1139